### PR TITLE
Add kubernetes job 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This repository contains CLI tools for performing specific automations.
 
 ## Run
 
-To be written
+You can run the migration as a Kubernetes job in your cluster. The benefit is that you do not need to expose anything, and use the internal Kubernetes dns.
+
+kubectl apply -f kubernetes-job.yaml
 
 ## Installation and contributing
 
@@ -48,12 +50,14 @@ This tool migrates data from a Vault database to a Hub database.
 - `-mongodb-username`: The MongoDB username (optional).
 - `-mongodb-password`: The MongoDB password (optional).
 - `-username`: The username to filter data (required).
+- `-queue`: The integration used to transfer events to the hub pipeline.
 - `-start-timestamp`: The start timestamp for filtering data (required).
 - `-end-timestamp`: The end timestamp for filtering data (required).
 - `-timezone`: The timezone for converting timestamps (optional, default is `UTC`).
 - `-pipeline`: The pipeline to execute (optional, default is `monitor,sequence`).
 - `-batch-size`: The size of each batch (optional, default is `10`).
 - `-batch-delay`: The delay between batches in milliseconds (optional, default is `1000`).
+- `-mode`: You can choose to run a `dry-run` or `live`.
 
 #### Example
 
@@ -64,10 +68,15 @@ go run main.go -action vault-to-hub-migration \
                -mongodb-uri "mongodb+srv://<username>:<password>@<host>/<database>?retryWrites=true&w=majority&appName=<appName>" \
                -mongodb-source-database=<sourceDatabase> \
                -mongodb-destination-database=<destinationDatabase> \
+               -queue <rabbitmq-integration> \
                -username <username> \
                -start-timestamp <startTimestamp> \
                -end-timestamp <endTimestamp> \
-               -timezone <timezone>
+               -timezone <timezone> \
+               -pipeline 'monitor,sequence,analysis' \
+               -mode 'dry-run' \
+               -batch-size 100 \
+               -batch-delay 1000
 ```
 
 #### Output

--- a/kubernetes-job.yaml
+++ b/kubernetes-job.yaml
@@ -16,7 +16,7 @@ spec:
           #'-mongodb-password', '<password>',
           '-mongodb-source-database', 'KerberosStorage',
           '-mongodb-destination-database', 'Kerberos',
-          '-mongodb-destination-database', 'admin',
+          '-mongodb-database-credentials', 'admin',
           '-username', '<username>',
           '-queue', '<rabbitmq-integration>',
           '-start-timestamp', '1733425260',

--- a/kubernetes-job.yaml
+++ b/kubernetes-job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uugai-cli-vault-to-hub-migration
+spec:
+  template:
+    spec:
+      containers:
+      - name: init-container
+        image: uugai/cli:latest
+        command: ['/main', '-action', 'vault-to-hub-migration',
+          '-mongodb-uri', 'mongodb+srv://<username>:<password>@<host>/<database>?retryWrites=true&w=majority&appName=<appName>',
+          #'-mongodb-host', '<host>',
+          #'-mongodb-port', '27017',
+          #'-mongodb-username', '<username>',
+          #'-mongodb-password', '<password>',
+          '-mongodb-source-database', 'KerberosStorage',
+          '-mongodb-destination-database', 'Kerberos',
+          '-mongodb-destination-database', 'admin',
+          '-username', '<username>',
+          '-queue', '<rabbitmq-integration',
+          '-start-timestamp', '1733425260',
+          '-end-timestamp', '1753952373',
+          '-timezone', 'UTC',
+          '-pipeline', 'monitor,sequence,analysis',
+          '-mode', 'dry-run', # or live to execute for real.
+          '-batch-size', '100',
+          '-batch-delay', '1000',
+        ]
+            
+      restartPolicy: Never
+      volumes:
+      - name: hub-import
+        emptyDir: {}

--- a/kubernetes-job.yaml
+++ b/kubernetes-job.yaml
@@ -18,7 +18,7 @@ spec:
           '-mongodb-destination-database', 'Kerberos',
           '-mongodb-destination-database', 'admin',
           '-username', '<username>',
-          '-queue', '<rabbitmq-integration',
+          '-queue', '<rabbitmq-integration>',
           '-start-timestamp', '1733425260',
           '-end-timestamp', '1753952373',
           '-timezone', 'UTC',


### PR DESCRIPTION
## Description

## Pull Request Description

### Motivation

This pull request introduces the ability to run the migration as a Kubernetes job within a cluster. This enhancement leverages Kubernetes' internal DNS, eliminating the need to expose services externally and simplifying the deployment process. By running migrations as Kubernetes jobs, users can benefit from the robust orchestration and management capabilities provided by Kubernetes.

### Why It Improves the Project

1. **Simplified Deployment**: Users can now deploy migrations directly in their Kubernetes clusters using a straightforward `kubectl apply -f kubernetes-job.yaml` command, eliminating the need for complex setup and configuration.
   
2. **Enhanced Security**: By using internal Kubernetes DNS, there is no need to expose services externally, reducing the attack surface and enhancing the overall security posture of the deployment.

3. **Scalability and Reliability**: Kubernetes' built-in features such as automatic restarts, resource management, and scaling ensure that the migration jobs are handled efficiently and reliably, even in large-scale environments.

### Changes Introduced

1. **README.md**:
   - Added instructions on how to run the migration as a Kubernetes job.
   - Updated the example command to include new parameters: `-queue` and `-mode`.
   - Documented the new parameters: 
     - `-queue`: Specifies the integration used to transfer events to the hub pipeline.
     - `-mode`: Allows users to choose between `dry-run` and `live` modes.

2. **kubernetes-job.yaml**:
   - Introduced a Kubernetes job configuration to run the migration.
   - Included parameters such as `-mongodb-uri`, `-mongodb-source-database`, `-mongodb-destination-database`, `-username`, `-queue`, `-start-timestamp`, `-end-timestamp`, `-timezone`, `-pipeline`, `-mode`, `-batch-size`, and `-batch-delay`.
   - Configured the job to use an init-container with the `uugai/cli:latest` image.
   - Set the restart policy to `Never` to ensure jobs do not restart automatically upon completion.

### Conclusion

This pull request significantly enhances the usability, security, and scalability of the migration tool by integrating Kubernetes job support. Users can now effortlessly deploy and manage migrations within their Kubernetes clusters, benefiting from the robust orchestration capabilities of Kubernetes.