### PR TITLE
Update index version in check-indexes job 

### DIFF
--- a/indexes/hub-03-04-2026.txt
+++ b/indexes/hub-03-04-2026.txt
@@ -1,0 +1,343 @@
+alerts
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { master_user_id: 1, enabled: 1 },
+    name: 'master_user_id_1_enabled_1'
+  }
+]
+analysis
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { userid: 1, key: 1 }, name: 'userid_1_key_1' },
+  { v: 2, key: { userid: 1, start: 1 }, name: 'userid_1_start_1' },
+  { v: 2, key: { start: 1 }, name: 'start_1' },
+  {
+    v: 2,
+    key: {
+      userid: 1,
+      deviceid: 1,
+      timestamp: 1,
+      favourite: 1,
+      'data.classify.properties': 1
+    },
+    name: 'userid_1_deviceid_1_timestamp_1_favourite_1_data.classify.properties_1'
+  },
+  { v: 2, key: { user_id: 1, key: 1 }, name: 'user_id_1_key_1' }
+]
+cache
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1, expiry: 1 }, name: 'key_1_expiry_1' },
+  { v: 2, key: { key: 1 }, name: 'key_1' }
+]
+category_options
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+comments
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+counting
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { user_id: 1, timestamp: 1 },
+    name: 'user_id_1_timestamp_1'
+  },
+  { v: 2, key: { timestamp: 1 }, name: 'timestamp_1' }
+]
+devices
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1, user_id: 1 }, name: 'key_1_user_id_1' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' }
+]
+event_option_ranges
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, createdAt: 1 },
+    name: 'organisationId_1_createdAt_1'
+  },
+  { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' }
+]
+event_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, updatedAt: 1 },
+    name: 'organisationId_1_updatedAt_1'
+  },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+groups
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' }
+]
+heatmap
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { user_id: 1, timestamp: 1 },
+    name: 'user_id_1_timestamp_1'
+  },
+  { v: 2, key: { timestamp: 1 }, name: 'timestamp_1' }
+]
+io
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+labels
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { is_private: 1, owner_id: 1 },
+    name: 'is_private_1_owner_id_1'
+  }
+]
+marker_category_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, updatedAt: 1 },
+    name: 'organisationId_1_updatedAt_1'
+  },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+marker_option_ranges
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, createdAt: 1 },
+    name: 'organisationId_1_createdAt_1'
+  },
+  { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' },
+  {
+    v: 2,
+    key: { organisationId: 1, start: 1, deviceId: 1, end: 1 },
+    name: 'organisationId_1_start_1_deviceId_1_end_1'
+  },
+  {
+    v: 2,
+    key: { organisationId: 1, deviceId: 1, start: 1, end: 1 },
+    name: 'org_device_start_end'
+  },
+  {
+    v: 2,
+    key: { organisationId: 1, deviceKey: 1, start: 1, end: 1 },
+    name: 'org_deviceKey_start_end'
+  }
+]
+marker_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, updatedAt: 1 },
+    name: 'organisationId_1_updatedAt_1'
+  },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+markers
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1 }, name: 'organisationId_1' },
+  {
+    v: 2,
+    key: { organisationId: 1, startTimestamp: 1 },
+    name: 'organisationId_1_startTimestamp_1'
+  },
+  { v: 2, key: { startTimestamp: 1 }, name: 'startTimestamp_1' }
+]
+media
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, deviceId: 1, startTimestamp: -1, _id: -1 },
+    name: 'org_device_start_id'
+  },
+  {
+    v: 2,
+    key: { organisationId: 1, startTimestamp: -1, _id: -1 },
+    name: 'org_start_id'
+  },
+  {
+    v: 2,
+    key: { organisationId: 1, videoFile: 1 },
+    name: 'organisationId_1_videoFile_1'
+  },
+  {
+    v: 2,
+    key: { organisationId: 1, deviceKey: 1, startTimestamp: -1, _id: -1 },
+    name: 'organisationId_1_deviceKey_1_startTimestamp_-1__id_-1'
+  },
+  {
+    v: 2,
+    key: {
+      organisationId: 1,
+      markerNames: 1,
+      deviceKey: 1,
+      startTimestamp: 1,
+      endTimestamp: 1,
+      tagNames: 1,
+      eventNames: 1
+    },
+    name: 'organisationId_1_markerNames_1_deviceKey_1_startTimestamp_1_endTimestamp_1_tagNames_1_eventNames_1'
+  },
+  {
+    v: 2,
+    key: { deviceId: 1, endTimestamp: 1, startTimestamp: 1 },
+    name: 'deviceId_1_endTimestamp_1_startTimestamp_1'
+  },
+  { v: 2, key: { startTimestamp: 1 }, name: 'startTimestamp_1' },
+  {
+    v: 2,
+    key: { organisationId: 1, startTimestamp: 1 },
+    name: 'organisationId_1_startTimestamp_1'
+  },
+  { v: 2, key: { start: 1 }, name: 'start_1' },
+  {
+    v: 2,
+    key: { 'metadata.classifications.centroids': '2d' },
+    name: 'media_classification_centroids_2d'
+  }
+]
+notifications
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' },
+  { v: 2, key: { user: 1 }, name: 'user_1' },
+  {
+    v: 2,
+    key: { userid: 1, timestamp: 1 },
+    name: 'userid_1_timestamp_1'
+  },
+  {
+    v: 2,
+    key: { alert_master_user: 1, media_key: 1 },
+    name: 'alert_master_user_1_media_key_1'
+  },
+  {
+    v: 2,
+    key: { userid: 1, media_key: 1 },
+    name: 'userid_1_media_key_1'
+  },
+  { v: 2, key: { timestamp: 1 }, name: 'timestamp_1' },
+  {
+    v: 2,
+    key: { alert_master_user: 1, timestamp: -1 },
+    name: 'alert_master_user_1_timestamp_-1'
+  },
+  { v: 2, key: { userid: 1 }, name: 'userid_1' }
+]
+organisation
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+organisation_users
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+queues
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+roles
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+sequences
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { user_id: 1, start: 1, end: 1, 'images.instanceName': 1 },
+    name: 'user_id_1_start_1_end_1_images.instanceName_1'
+  },
+  {
+    v: 2,
+    key: { user_id: 1, 'images.key': 1 },
+    name: 'user_id_1_images.key_1'
+  },
+  {
+    v: 2,
+    key: { user_id: 1, end: 1, start: -1, devices: 1 },
+    name: 'user_id_1_end_1_start_-1_devices_1'
+  },
+  { v: 2, key: { start: 1 }, name: 'start_1' },
+  { v: 2, key: { user_id: 1, start: 1 }, name: 'user_id_1_start_1' }
+]
+settings
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1 }, name: 'key_1' }
+]
+sites
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' }
+]
+subscriptions
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' }
+]
+subscriptions_items
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+tag_option_ranges
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, createdAt: 1 },
+    name: 'organisationId_1_createdAt_1'
+  },
+  { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' }
+]
+tag_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { organisationId: 1, updatedAt: 1 },
+    name: 'organisationId_1_updatedAt_1'
+  },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+tasks
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+tokens
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+users
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  {
+    v: 2,
+    key: { 'devices.key': 1, amazon_access_key_id: 1 },
+    name: 'devices.key_1_amazon_access_key_id_1'
+  },
+  {
+    v: 2,
+    key: { username: 1, amazon_access_key_id: 1 },
+    name: 'username_1_amazon_access_key_id_1'
+  },
+  {
+    v: 2,
+    key: { amazon_access_key_id: 1, username: 1 },
+    name: 'amazon_access_key_id_1_username_1'
+  },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' },
+  { v: 2, key: { reachedLimit: 1 }, name: 'reachedLimit_1' },
+  { v: 2, key: { role: 1 }, name: 'role_1' },
+  { v: 2, key: { email: 1 }, name: 'email_1' },
+  {
+    v: 2,
+    key: { 'cleanup.next_scan_at': 1 },
+    name: 'cleanup.next_scan_at_1'
+  },
+  {
+    v: 2,
+    key: { 'cleanup.next_scan_at': 1, _id: 1 },
+    name: 'cleanup.next_scan_at_1__id_1'
+  }
+]
+videowalls
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]

--- a/jobs/check-indexes.yaml
+++ b/jobs/check-indexes.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: init-container
-        image: ghcr.io/uug-ai/cli:v1.2.14
+        image: ghcr.io/uug-ai/cli:v1.2.15
         command: ['/main', '-action', 'check-indexes',
           '-mongodb-uri', 'mongodb+srv://<username>:<password>@<host>/<database>?retryWrites=true&w=majority&appName=<appName>',
           '-mongodb-destination-database', 'Kerberos', # specify the target database

--- a/jobs/check-indexes.yaml
+++ b/jobs/check-indexes.yaml
@@ -13,7 +13,7 @@ spec:
           '-mongodb-destination-database', 'Kerberos', # specify the target database
           '-collections', '', # comma separated list of collections to check (default empty for all)
           '-mode', 'dry-run', # or live to execute for real.
-          '-index-version', '20-03-2026-media-migration',
+          '-index-version', 'hub-03-04-2026',
         ]
             
       restartPolicy: Never


### PR DESCRIPTION
## Description

This PR updates the **check-indexes** job to point to the latest index snapshot (`hub-03-04-2026`) and bumps the CLI image to a version that understands this new index format.

**Why this matters**
- The current job was validating against an outdated index version, which no longer reflects the actual database state.
- Adding the new index definition keeps CI in sync with the latest schema changes across collections.
- Updating the CLI ensures compatibility and prevents false positives or missed drift in index validation.

Overall, this improves the reliability of our index checks and ensures CI accurately enforces the current database contract.