### PR TITLE
Add share indexes

### DIFF
--- a/indexes/hub-01-06-2026.txt
+++ b/indexes/hub-01-06-2026.txt
@@ -32,7 +32,12 @@ case_media
   { v: 2, key: { task_id: 1, parent_id: 1, action: 1, role: 1, version: -1 }, name: 'case_media_next_version_desc' }
 ]
 case_shares
-[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { task_id: 1, user_id: 1, created_at: -1 }, name: 'task_id_1_user_id_1_created_at_-1' },
+  { v: 2, key: { token: 1 }, name: 'token_1' },
+  { v: 2, key: { token: 1, is_active: 1 }, name: 'token_1_is_active_1' }
+]
 category_options
 [ { v: 2, key: { _id: 1 }, name: '_id_' } ]
 comments


### PR DESCRIPTION
## Description

### Motivation

Queries on `case_shares` are currently under-indexed, relying mostly on `_id_`. This leads to inefficient scans for common access patterns such as:
- Listing shares by task and user ordered by creation date
- Resolving shares by token
- Validating active share tokens

### Why this improves the project

This PR adds targeted indexes to `case_shares` to match real query usage. As a result:
- Share-related reads become faster and more predictable
- Token-based access paths are optimized
- Overall database load is reduced for a frequently accessed collection

These changes improve performance and scalability without altering application logic.