### PR TITLE
fix(check-indexes): handle serialized BSON Long index directions

### DIFF
--- a/actions/check-indexes.go
+++ b/actions/check-indexes.go
@@ -528,6 +528,7 @@ func parseKeyFields(doc string) bson.D {
 		parts   []string
 		cur     strings.Builder
 		inQuote rune
+		depth   int
 	)
 
 	for _, r := range doc {
@@ -539,8 +540,18 @@ func parseKeyFields(doc string) bson.D {
 				inQuote = 0
 			}
 			cur.WriteRune(r)
-		case ',':
+		case '{', '[':
 			if inQuote == 0 {
+				depth++
+			}
+			cur.WriteRune(r)
+		case '}', ']':
+			if inQuote == 0 && depth > 0 {
+				depth--
+			}
+			cur.WriteRune(r)
+		case ',':
+			if inQuote == 0 && depth == 0 {
 				segment := strings.TrimSpace(cur.String())
 				if segment != "" {
 					parts = append(parts, segment)
@@ -620,6 +631,22 @@ func parseInt(s string) (int, error) {
 // returned unchanged so they can still be used as index plugin names.
 func unwrapNumericConstructor(val string) string {
 	v := strings.TrimSpace(val)
+	// Serialized BSON Long object: {"high":0,"low":1,"unsigned":false}
+	// (produced when a Long(1) direction is JSON.stringify'd). Use the low word
+	// as the effective direction value.
+	if strings.HasPrefix(v, "{") && strings.Contains(v, "\"low\"") {
+		if i := strings.Index(v, "\"low\""); i != -1 {
+			rest := v[i+len("\"low\""):]
+			if c := strings.Index(rest, ":"); c != -1 {
+				rest = rest[c+1:]
+				// read until the next comma or closing brace
+				end := strings.IndexAny(rest, ",}")
+				if end != -1 {
+					return strings.Trim(strings.TrimSpace(rest[:end]), "'\"")
+				}
+			}
+		}
+	}
 	// EJSON: { "$numberLong": "1" } / { "$numberInt": "1" } / { "$numberDouble": "1" }
 	if strings.HasPrefix(v, "{") && strings.Contains(v, "$number") {
 		if i := strings.Index(v, ":"); i != -1 {

--- a/indexes/hub-01-06-2026.txt
+++ b/indexes/hub-01-06-2026.txt
@@ -99,7 +99,7 @@ marker_option_ranges
   { v: 2, key: { _id: 1 }, name: '_id_' },
   { v: 2, key: { organisationId: 1, createdAt: 1 }, name: 'organisationId_1_createdAt_1' },
   { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' },
-  { v: 2, key: { organisationId: {"high":0,"low":1,"unsigned":false}, start: {"high":0,"low":1,"unsigned":false}, deviceKey: {"high":0,"low":1,"unsigned":false}, end: {"high":0,"low":1,"unsigned":false} }, name: 'organisationId_1_start_1_deviceKey_1_end_1' },
+  { v: 2, key: { organisationId: 1, start: 1, deviceKey: 1, end: 1 }, name: 'organisationId_1_start_1_deviceKey_1_end_1' },
   { v: 2, key: { organisationId: 1, start: 1, deviceId: 1, end: 1 }, name: 'organisationId_1_start_1_deviceId_1_end_1' },
   { v: 2, key: { organisationId: 1, deviceId: 1, start: 1, end: 1 }, name: 'org_device_start_end' },
   { v: 2, key: { organisationId: 1, deviceKey: 1, start: 1, end: 1 }, name: 'org_deviceKey_start_end' }

--- a/indexes/hub-22-06-2026.txt
+++ b/indexes/hub-22-06-2026.txt
@@ -104,7 +104,7 @@ marker_option_ranges
   { v: 2, key: { _id: 1 }, name: '_id_' },
   { v: 2, key: { organisationId: 1, createdAt: 1 }, name: 'organisationId_1_createdAt_1' },
   { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' },
-  { v: 2, key: { organisationId: {"high":0,"low":1,"unsigned":false}, start: {"high":0,"low":1,"unsigned":false}, deviceKey: {"high":0,"low":1,"unsigned":false}, end: {"high":0,"low":1,"unsigned":false} }, name: 'organisationId_1_start_1_deviceKey_1_end_1' },
+  { v: 2, key: { organisationId: 1, start: 1, deviceKey: 1, end: 1 }, name: 'organisationId_1_start_1_deviceKey_1_end_1' },
   { v: 2, key: { organisationId: 1, start: 1, deviceId: 1, end: 1 }, name: 'organisationId_1_start_1_deviceId_1_end_1' },
   { v: 2, key: { organisationId: 1, deviceId: 1, start: 1, end: 1 }, name: 'org_device_start_end' },
   { v: 2, key: { organisationId: 1, deviceKey: 1, start: 1, end: 1 }, name: 'org_deviceKey_start_end' }


### PR DESCRIPTION
## Description

### Motivation

`check-indexes` was failing to correctly parse index definitions when index directions were serialized as BSON `Long` objects (e.g. `{"high":0,"low":1,"unsigned":false}`), which can happen when indexes are exported via `JSON.stringify`. This caused false positives and noisy diffs, even though the actual index definitions were logically identical.

### Why this improves the project

This change makes index parsing more robust and format-tolerant by:
- Correctly handling serialized BSON `Long` values and normalizing them to standard numeric directions.
- Fixing key parsing so commas inside nested objects no longer break field splitting.
- Ensuring index snapshots remain stable and comparable across different serialization formats.

As a result, `check-indexes` becomes more reliable, reduces unnecessary churn in index snapshots, and avoids misleading CI failures.