### PR TITLE
build(deps): bump markers to v1.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,9 @@ require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.12.0
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/rabbitmq/amqp091-go v1.10.0
-	github.com/uug-ai/markers v1.1.0
-	github.com/uug-ai/models v1.4.19
+	github.com/uug-ai/markers v1.2.4
+	github.com/uug-ai/models v1.4.26
+	github.com/uug-ai/trace v1.1.0
 	go.mongodb.org/mongo-driver v1.17.6
 	golang.org/x/crypto v0.46.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
@@ -32,7 +33,6 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
-	github.com/uug-ai/trace v1.1.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -321,10 +321,10 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
-github.com/uug-ai/markers v1.1.0 h1:wiHZ4uf0Xv/3vTV7t2nVN+4V+mjxjZxNpPNsesMrKQo=
-github.com/uug-ai/markers v1.1.0/go.mod h1:VmFgul7+CJvAf+5+D5/ulgUEQL+4bzyCRd9EhIzwniU=
-github.com/uug-ai/models v1.4.19 h1:2gnws5OngvGpwSTeguidPawclpp6n9XaQ1QONRpDhGs=
-github.com/uug-ai/models v1.4.19/go.mod h1:cOHAqis0dHSc4pjuedqRPVCcUngvfHG28Uezgy5suUo=
+github.com/uug-ai/markers v1.2.4 h1:TKpTlHOz7mSKKWhVrsFZLaDaesMTvoFEu9Rkiw8ax8k=
+github.com/uug-ai/markers v1.2.4/go.mod h1:WvDWCIP8RB3fqybWbQuKJoQ26YrcJQA6IGwLqw3cfTE=
+github.com/uug-ai/models v1.4.26 h1:kq0Q0YNWBGSf66FVMdxHApXhFJpgxYmb19tr5FHLO5s=
+github.com/uug-ai/models v1.4.26/go.mod h1:cOHAqis0dHSc4pjuedqRPVCcUngvfHG28Uezgy5suUo=
 github.com/uug-ai/trace v1.1.0 h1:JNLfwrs8A23LDHR+JXpDszI+O423k78B8nq9GeAgzSs=
 github.com/uug-ai/trace v1.1.0/go.mod h1:V1uDCf2a5QhF2/bwymmh6xabUJ41KY8M079oWT1xyfE=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=


### PR DESCRIPTION
## Description

This PR upgrades `github.com/uug-ai/markers` from `v1.1.0` to `v1.2.4` and aligns related dependencies, including `github.com/uug-ai/models` and `github.com/uug-ai/trace`.

Keeping these libraries up to date improves compatibility across the shared UUG AI ecosystem and ensures the project benefits from the latest fixes and improvements delivered in newer releases. The update also promotes dependency consistency by making `trace` a direct dependency instead of relying on it transitively.

In addition, refreshing `go.sum` guarantees reproducible builds with the updated module versions.