### PR TITLE
Add organisation backfill preflight

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,6 +15,6 @@ jobs:
       runner_matrix: >-
         [
           {"architecture":"amd64","runner":"ubuntu-24.04"},
-          {"architecture":"arm64","runner":"github-runner-set-arm64"}
+          {"architecture":"arm64","runner":"ubuntu-24.04-arm"}
         ]
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains CLI tools for performing specific automations.
 - `reprocess-media`: Re-queue hub media for analysis when analysis is missing.
 - `audit-legacy-compat`: Auditing legacy data shape compatibility across domains.
 - `migrate-legacy-media`: Backfilling legacy media documents to current media shape.
+- `organisations-bootstrap`: Bootstrapping Phase 3 organisation identity and memberships in ordered stages.
 - `organisations-backfill`: Auditing canonical organisation ownership before the Phase 4 resource backfill.
 - `generate-default-labels`: Adding labels to existing users.
 
@@ -49,6 +50,36 @@ kubectl apply -f jobs/migrate-legacy-media-job.yaml
    ```
 
 ## Usage
+
+### Organisation identity bootstrap
+
+Run the Phase 3 identity migration in order: `owners`, `sub-users`, then the
+read-only `verify` stage. Start each mutating stage in `dry-run`; existing
+non-zero selections are preserved.
+
+```sh
+go run . -action organisations-bootstrap \
+         -stage owners \
+         -mode dry-run \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -legacy-org-policy report \
+         -report-file organisations-bootstrap-owners.json
+```
+
+Repeat with `-stage sub-users` only after the owner stage verifies green, then
+run `-stage verify -mode dry-run`. Scope canaries with either `-username` or
+`-organisation-id`; those flags are mutually exclusive. Exit codes are `0` for
+a green run, `2` for identity conflicts or failed verification, `1` for an
+operational failure, and `64` for invalid or unsafe arguments.
+
+Live owner and sub-user runs require the canonical organisation and membership
+indexes. They acquire a stage/scope-specific lease in `migration_checkpoints`,
+advance only after a complete tenant verifies, and support `-resume` or
+`-restart`. Live writes are limited to `organisation`, `organisation_users`,
+missing `users.organisation_id` values, and the checkpoint. The destructive
+`archive-delete` policy remains disabled until guarded archive/reference checks
+are implemented.
 
 ### Organisation ownership backfill
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains CLI tools for performing specific automations.
 - `reprocess-media`: Re-queue hub media for analysis when analysis is missing.
 - `audit-legacy-compat`: Auditing legacy data shape compatibility across domains.
 - `migrate-legacy-media`: Backfilling legacy media documents to current media shape.
+- `organisations-backfill`: Auditing canonical organisation ownership before the Phase 4 resource backfill.
 - `generate-default-labels`: Adding labels to existing users.
 
 
@@ -48,6 +49,29 @@ kubectl apply -f jobs/migrate-legacy-media-job.yaml
    ```
 
 ## Usage
+
+### Organisation ownership backfill
+
+This action currently implements the read-only Phase 4 preflight. It inventories
+canonical tenant presence, BSON type and ObjectID-hex validity, legacy candidate
+coverage, and current indexes for the registered `sites`, `groups`, `devices`,
+and `alerts` adapters. Live writes, scoped tenant resolution, checkpoint resume,
+and index creation deliberately remain disabled until their compare-and-set and
+reconciliation paths are implemented.
+
+```sh
+go run . -action organisations-backfill \
+         -mode dry-run \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collection sites \
+         -adapter-version v1 \
+         -report-file organisations-backfill-sites.json
+```
+
+Use `-all` instead of `-collection` to inspect every ready adapter. The command
+exits `0` when preflight passes, `2` for invalid canonical tenant data, `1` for
+operational failures, and `64` for unsafe or invalid arguments.
 
 ### Vault to Hub Migration
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Live owner and sub-user runs require the canonical organisation and membership
 indexes. They acquire a stage/scope-specific lease in `migration_checkpoints`,
 advance only after a complete tenant verifies, and support `-resume` or
 `-restart`. Live writes are limited to `organisation`, `organisation_users`,
-missing `users.organisation_id` values, and the checkpoint. The destructive
+missing `users.organisationId` values, and the checkpoint. The destructive
 `archive-delete` policy remains disabled until guarded archive/reference checks
 are implemented.
 

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -1,0 +1,474 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/uug-ai/cli/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+const (
+	organisationsBackfillAdapterVersion  = "v1"
+	organisationsBackfillExitOperational = 1
+	organisationsBackfillExitData        = 2
+	organisationsBackfillExitUsage       = 64
+)
+
+type OrganisationsBackfillConfig struct {
+	Mode                       string
+	MongoDBURI                 string
+	MongoDBHost                string
+	MongoDBPort                string
+	MongoDBSourceDatabase      string
+	MongoDBDestinationDatabase string
+	MongoDBDatabaseCredentials string
+	MongoDBUsername            string
+	MongoDBPassword            string
+	MigrationVersion           int
+	AdapterVersion             string
+	Collection                 string
+	AllCollections             bool
+	BatchSize                  int
+	MigrationTimeoutMinutes    int
+	OrganisationID             string
+	DocumentID                 string
+	Resume                     bool
+	Restart                    bool
+	CheckMigrationIndexes      bool
+	ApplyMigrationIndexes      bool
+	StopOnConflict             bool
+	ReportFile                 string
+}
+
+type organisationsBackfillAdapter struct {
+	Collection       string
+	TargetField      string
+	TargetBSONType   string
+	LegacyCandidates []string
+	PreservedFields  []string
+}
+
+type organisationsBackfillReport struct {
+	Mode             string                                     `json:"mode"`
+	Database         string                                     `json:"database"`
+	MigrationVersion int                                        `json:"migrationVersion"`
+	AdapterVersion   string                                     `json:"adapterVersion"`
+	BatchSize        int                                        `json:"batchSize"`
+	StartedAt        string                                     `json:"startedAt"`
+	CompletedAt      string                                     `json:"completedAt"`
+	PreflightStatus  string                                     `json:"preflightStatus"`
+	Collections      map[string]organisationsBackfillCollection `json:"collections"`
+}
+
+type organisationsBackfillCollection struct {
+	TargetField          string           `json:"targetField"`
+	TargetBSONType       string           `json:"targetBsonType"`
+	LegacyCandidates     []string         `json:"legacyCandidates"`
+	PreservedFields      []string         `json:"preservedFields"`
+	Total                int64            `json:"total"`
+	CanonicalPresent     int64            `json:"canonicalPresent"`
+	CanonicalMissing     int64            `json:"canonicalMissing"`
+	CanonicalWrongType   int64            `json:"canonicalWrongType"`
+	CanonicalInvalidHex  int64            `json:"canonicalInvalidHex"`
+	LegacyCandidateCount map[string]int64 `json:"legacyCandidateCount"`
+	Indexes              []string         `json:"indexes"`
+	TargetIndexCovered   bool             `json:"targetIndexCovered"`
+}
+
+type organisationsBackfillError struct {
+	code int
+	err  error
+}
+
+func (e *organisationsBackfillError) Error() string {
+	return e.err.Error()
+}
+
+func (e *organisationsBackfillError) Unwrap() error {
+	return e.err
+}
+
+func OrganisationsBackfillExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var backfillError *organisationsBackfillError
+	if errors.As(err, &backfillError) {
+		return backfillError.code
+	}
+	return organisationsBackfillExitOperational
+}
+
+func OrganisationsBackfill(config OrganisationsBackfillConfig) error {
+	config = normalizeOrganisationsBackfillConfig(config)
+	adapters, err := validateOrganisationsBackfillConfig(config)
+	if err != nil {
+		return &organisationsBackfillError{code: organisationsBackfillExitUsage, err: err}
+	}
+
+	ctx := context.Background()
+	cancel := func() {}
+	if config.MigrationTimeoutMinutes > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(config.MigrationTimeoutMinutes)*time.Minute)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	var db *database.DB
+	if config.MongoDBURI != "" {
+		db = database.NewMongoDBURI(config.MongoDBURI)
+	} else {
+		db = database.NewMongoDBHost(
+			config.MongoDBHost,
+			config.MongoDBPort,
+			config.MongoDBDatabaseCredentials,
+			config.MongoDBUsername,
+			config.MongoDBPassword,
+		)
+	}
+	client := db.Client
+	defer client.Disconnect(context.Background())
+
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: fmt.Errorf("MongoDB preflight failed: %w", err)}
+	}
+
+	hubDB := client.Database(config.MongoDBDestinationDatabase)
+	for _, collection := range []string{"users", "organisation"} {
+		if _, err := hubDB.Collection(collection).EstimatedDocumentCount(ctx); err != nil {
+			return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: fmt.Errorf("cannot read %s: %w", collection, err)}
+		}
+	}
+
+	startedAt := time.Now().UTC()
+	report := organisationsBackfillReport{
+		Mode:             config.Mode,
+		Database:         config.MongoDBDestinationDatabase,
+		MigrationVersion: config.MigrationVersion,
+		AdapterVersion:   config.AdapterVersion,
+		BatchSize:        config.BatchSize,
+		StartedAt:        startedAt.Format(time.RFC3339),
+		PreflightStatus:  "passed",
+		Collections:      make(map[string]organisationsBackfillCollection, len(adapters)),
+	}
+
+	hasDataConflict := false
+	for _, adapter := range adapters {
+		collectionReport, err := inspectOrganisationsBackfillCollection(ctx, hubDB.Collection(adapter.Collection), adapter, config.DocumentID)
+		if err != nil {
+			return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: fmt.Errorf("inspect %s: %w", adapter.Collection, err)}
+		}
+		if collectionReport.CanonicalWrongType > 0 || collectionReport.CanonicalInvalidHex > 0 {
+			hasDataConflict = true
+			report.PreflightStatus = "blocked"
+		}
+		report.Collections[adapter.Collection] = collectionReport
+		if hasDataConflict && config.StopOnConflict {
+			break
+		}
+	}
+
+	report.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := writeOrganisationsBackfillReport(report, config.ReportFile); err != nil {
+		return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: err}
+	}
+	if hasDataConflict {
+		return &organisationsBackfillError{code: organisationsBackfillExitData, err: errors.New("preflight found canonical tenant values with invalid BSON type or ObjectID hex")}
+	}
+	return nil
+}
+
+func normalizeOrganisationsBackfillConfig(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+	config.Mode = strings.ToLower(strings.TrimSpace(config.Mode))
+	if config.Mode == "" {
+		config.Mode = "dry-run"
+	}
+	config.Collection = strings.ToLower(strings.TrimSpace(config.Collection))
+	config.AdapterVersion = strings.TrimSpace(config.AdapterVersion)
+	if config.AdapterVersion == "" {
+		config.AdapterVersion = organisationsBackfillAdapterVersion
+	}
+	config.OrganisationID = strings.TrimSpace(config.OrganisationID)
+	config.DocumentID = strings.TrimSpace(config.DocumentID)
+	config.ReportFile = strings.TrimSpace(config.ReportFile)
+	config.MongoDBURI = strings.TrimSpace(config.MongoDBURI)
+	config.MongoDBDestinationDatabase = strings.TrimSpace(config.MongoDBDestinationDatabase)
+	if config.MongoDBDestinationDatabase == "" {
+		config.MongoDBDestinationDatabase = strings.TrimSpace(config.MongoDBSourceDatabase)
+	}
+	if config.MigrationVersion == 0 {
+		config.MigrationVersion = 1
+	}
+	if config.BatchSize == 0 {
+		config.BatchSize = 500
+	}
+	return config
+}
+
+func validateOrganisationsBackfillConfig(config OrganisationsBackfillConfig) ([]organisationsBackfillAdapter, error) {
+	if config.Mode != "dry-run" && config.Mode != "live" {
+		return nil, fmt.Errorf("mode must be dry-run or live, got %q", config.Mode)
+	}
+	if config.Mode == "live" {
+		return nil, errors.New("live mode is disabled until checkpointed compare-and-set writes are implemented")
+	}
+	if config.MongoDBDestinationDatabase == "" || strings.HasPrefix(config.MongoDBDestinationDatabase, "-") {
+		return nil, errors.New("an explicit MongoDB source or destination database is required")
+	}
+	if config.MongoDBURI == "" && strings.TrimSpace(config.MongoDBHost) == "" {
+		return nil, errors.New("provide -mongodb-uri or -mongodb-host")
+	}
+	if config.MigrationVersion != 1 {
+		return nil, fmt.Errorf("unsupported migration version %d", config.MigrationVersion)
+	}
+	if config.AdapterVersion != organisationsBackfillAdapterVersion {
+		return nil, fmt.Errorf("unsupported adapter version %q", config.AdapterVersion)
+	}
+	if config.BatchSize <= 0 {
+		return nil, errors.New("batch-size must be greater than zero")
+	}
+	if config.Collection == "" && !config.AllCollections {
+		return nil, errors.New("provide exactly one of -collection or -all")
+	}
+	if config.Collection != "" && config.AllCollections {
+		return nil, errors.New("-collection and -all are mutually exclusive")
+	}
+	if config.Resume && config.Restart {
+		return nil, errors.New("-resume and -restart are mutually exclusive")
+	}
+	if config.Resume || config.Restart {
+		return nil, errors.New("checkpoint resume/restart is disabled until live mode is implemented")
+	}
+	if config.ApplyMigrationIndexes {
+		return nil, errors.New("index creation is disabled until adapter-specific index contracts are registered")
+	}
+	if config.OrganisationID != "" {
+		if _, err := primitive.ObjectIDFromHex(config.OrganisationID); err != nil {
+			return nil, fmt.Errorf("invalid organisation-id: %w", err)
+		}
+		return nil, errors.New("organisation-scoped resolution is disabled until collection resolvers are implemented")
+	}
+	if config.DocumentID != "" {
+		if config.AllCollections || config.Collection == "" {
+			return nil, errors.New("document-id requires exactly one -collection")
+		}
+		if _, err := primitive.ObjectIDFromHex(config.DocumentID); err != nil {
+			return nil, fmt.Errorf("invalid document-id: %w", err)
+		}
+	}
+	return selectOrganisationsBackfillAdapters(config.Collection, config.AllCollections)
+}
+
+func selectOrganisationsBackfillAdapters(collection string, all bool) ([]organisationsBackfillAdapter, error) {
+	registry := organisationsBackfillAdapters()
+	if all {
+		collections := make([]string, 0, len(registry))
+		for name := range registry {
+			collections = append(collections, name)
+		}
+		sort.Strings(collections)
+		adapters := make([]organisationsBackfillAdapter, 0, len(collections))
+		for _, name := range collections {
+			adapters = append(adapters, registry[name])
+		}
+		return adapters, nil
+	}
+	if adapter, ok := registry[collection]; ok {
+		return []organisationsBackfillAdapter{adapter}, nil
+	}
+	if reason, blocked := organisationsBackfillBlockedAdapters()[collection]; blocked {
+		return nil, fmt.Errorf("collection %q is blocked: %s", collection, reason)
+	}
+	return nil, fmt.Errorf("collection %q has no registered adapter", collection)
+}
+
+func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
+	return map[string]organisationsBackfillAdapter{
+		"alerts": {
+			Collection:       "alerts",
+			TargetField:      "organisationId",
+			TargetBSONType:   "string",
+			LegacyCandidates: []string{"master_user_id"},
+			PreservedFields:  []string{"user_id"},
+		},
+		"devices": {
+			Collection:       "devices",
+			TargetField:      "organisationId",
+			TargetBSONType:   "string",
+			LegacyCandidates: []string{"user_id"},
+			PreservedFields:  []string{"user_id"},
+		},
+		"groups": {
+			Collection:       "groups",
+			TargetField:      "organisationId",
+			TargetBSONType:   "string",
+			LegacyCandidates: []string{"user_id"},
+			PreservedFields:  []string{"created_by", "updated_by"},
+		},
+		"sites": {
+			Collection:       "sites",
+			TargetField:      "organisationId",
+			TargetBSONType:   "string",
+			LegacyCandidates: []string{"user_id"},
+			PreservedFields:  []string{"created_by", "updated_by"},
+		},
+	}
+}
+
+func organisationsBackfillBlockedAdapters() map[string]string {
+	return map[string]string{
+		"analysis":      "shared model and canonical BSON type are not declared",
+		"channels":      "persistence and ownership contracts are unverified",
+		"counting":      "persisted shapes require a production audit",
+		"heatmap":       "persisted shapes require a production audit",
+		"io":            "product ownership remains undecided",
+		"labels":        "shared model does not declare organisationId",
+		"notifications": "shape-specific canonical models and writers are missing",
+		"sequences":     "shared model and canonical BSON type are not declared",
+		"settings":      "shared model does not declare a canonical tenant field",
+		"tasks":         "shared model and canonical BSON type are not declared",
+		"videowalls":    "shared model does not declare organisationId",
+		"workflow_runs": "persisted canonical BSON type is not verified",
+	}
+}
+
+func inspectOrganisationsBackfillCollection(
+	ctx context.Context,
+	collection *mongo.Collection,
+	adapter organisationsBackfillAdapter,
+	documentID string,
+) (organisationsBackfillCollection, error) {
+	baseFilter := bson.M{}
+	if documentID != "" {
+		id, _ := primitive.ObjectIDFromHex(documentID)
+		baseFilter["_id"] = id
+	}
+
+	report := organisationsBackfillCollection{
+		TargetField:          adapter.TargetField,
+		TargetBSONType:       adapter.TargetBSONType,
+		LegacyCandidates:     append([]string(nil), adapter.LegacyCandidates...),
+		PreservedFields:      append([]string(nil), adapter.PreservedFields...),
+		LegacyCandidateCount: make(map[string]int64, len(adapter.LegacyCandidates)),
+	}
+
+	counts := []struct {
+		target *int64
+		filter bson.M
+	}{
+		{&report.Total, baseFilter},
+		{&report.CanonicalPresent, combineOrganisationsBackfillFilters(baseFilter, bson.M{adapter.TargetField: bson.M{"$type": adapter.TargetBSONType, "$ne": ""}})},
+		{&report.CanonicalMissing, combineOrganisationsBackfillFilters(baseFilter, bson.M{"$or": bson.A{
+			bson.M{adapter.TargetField: bson.M{"$exists": false}},
+			bson.M{adapter.TargetField: nil},
+			bson.M{adapter.TargetField: ""},
+		}})},
+		{&report.CanonicalWrongType, combineOrganisationsBackfillFilters(baseFilter, bson.M{
+			adapter.TargetField: bson.M{"$exists": true, "$ne": nil},
+			"$expr":             bson.M{"$ne": bson.A{bson.M{"$type": "$" + adapter.TargetField}, adapter.TargetBSONType}},
+		})},
+		{&report.CanonicalInvalidHex, combineOrganisationsBackfillFilters(baseFilter, bson.M{adapter.TargetField: bson.M{
+			"$type": adapter.TargetBSONType,
+			"$ne":   "",
+			"$not":  primitive.Regex{Pattern: "^[0-9a-fA-F]{24}$"},
+		}})},
+	}
+	for _, count := range counts {
+		value, err := collection.CountDocuments(ctx, count.filter)
+		if err != nil {
+			return report, err
+		}
+		*count.target = value
+	}
+	for _, candidate := range adapter.LegacyCandidates {
+		count, err := collection.CountDocuments(ctx, combineOrganisationsBackfillFilters(baseFilter, bson.M{candidate: bson.M{"$exists": true, "$nin": bson.A{nil, ""}}}))
+		if err != nil {
+			return report, err
+		}
+		report.LegacyCandidateCount[candidate] = count
+	}
+
+	indexCursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return report, err
+	}
+	defer indexCursor.Close(ctx)
+	for indexCursor.Next(ctx) {
+		var index bson.M
+		if err := indexCursor.Decode(&index); err != nil {
+			return report, err
+		}
+		if name, ok := index["name"].(string); ok {
+			report.Indexes = append(report.Indexes, name)
+		}
+		if organisationsBackfillIndexCoversField(index["key"], adapter.TargetField) {
+			report.TargetIndexCovered = true
+		}
+	}
+	if err := indexCursor.Err(); err != nil {
+		return report, err
+	}
+	sort.Strings(report.Indexes)
+	return report, nil
+}
+
+func combineOrganisationsBackfillFilters(filters ...bson.M) bson.M {
+	nonEmpty := make([]bson.M, 0, len(filters))
+	for _, filter := range filters {
+		if len(filter) > 0 {
+			nonEmpty = append(nonEmpty, filter)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return bson.M{}
+	}
+	if len(nonEmpty) == 1 {
+		return nonEmpty[0]
+	}
+	clauses := make(bson.A, len(nonEmpty))
+	for index, filter := range nonEmpty {
+		clauses[index] = filter
+	}
+	return bson.M{"$and": clauses}
+}
+
+func organisationsBackfillIndexCoversField(key any, field string) bool {
+	switch value := key.(type) {
+	case bson.D:
+		for _, element := range value {
+			if element.Key == field {
+				return true
+			}
+		}
+	case bson.M:
+		_, ok := value[field]
+		return ok
+	}
+	return false
+}
+
+func writeOrganisationsBackfillReport(report organisationsBackfillReport, reportFile string) error {
+	output, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	fmt.Println(string(output))
+	if reportFile == "" {
+		return nil
+	}
+	if err := os.WriteFile(reportFile, append(output, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -1,0 +1,152 @@
+package actions
+
+import (
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestValidateOrganisationsBackfillConfig(t *testing.T) {
+	valid := normalizeOrganisationsBackfillConfig(OrganisationsBackfillConfig{
+		Mode:                       "dry-run",
+		MongoDBURI:                 "mongodb://localhost:27017",
+		MongoDBDestinationDatabase: "hub",
+		Collection:                 "sites",
+	})
+
+	tests := []struct {
+		name      string
+		mutate    func(OrganisationsBackfillConfig) OrganisationsBackfillConfig
+		wantError string
+	}{
+		{
+			name: "valid collection",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				return config
+			},
+		},
+		{
+			name: "requires connection settings",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.MongoDBURI = ""
+				return config
+			},
+			wantError: "mongodb-uri",
+		},
+		{
+			name: "requires selection",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.Collection = ""
+				return config
+			},
+			wantError: "exactly one",
+		},
+		{
+			name: "rejects collection and all",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.AllCollections = true
+				return config
+			},
+			wantError: "mutually exclusive",
+		},
+		{
+			name: "rejects live mode",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.Mode = "live"
+				return config
+			},
+			wantError: "live mode is disabled",
+		},
+		{
+			name: "rejects index writes",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.ApplyMigrationIndexes = true
+				return config
+			},
+			wantError: "index creation is disabled",
+		},
+		{
+			name: "rejects invalid document id",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.DocumentID = "invalid"
+				return config
+			},
+			wantError: "invalid document-id",
+		},
+		{
+			name: "rejects scoped run before resolvers exist",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.OrganisationID = "507f1f77bcf86cd799439011"
+				return config
+			},
+			wantError: "scoped resolution is disabled",
+		},
+		{
+			name: "reports blocked adapter",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.Collection = "videowalls"
+				return config
+			},
+			wantError: "blocked",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := validateOrganisationsBackfillConfig(test.mutate(valid))
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateOrganisationsBackfillConfig() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validateOrganisationsBackfillConfig() error = %v, want containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
+	adapters, err := selectOrganisationsBackfillAdapters("", true)
+	if err != nil {
+		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
+	}
+	want := []string{"alerts", "devices", "groups", "sites"}
+	if len(adapters) != len(want) {
+		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
+	}
+	for index := range want {
+		if adapters[index].Collection != want[index] {
+			t.Errorf("adapters[%d].Collection = %q, want %q", index, adapters[index].Collection, want[index])
+		}
+	}
+}
+
+func TestOrganisationsBackfillIndexCoversField(t *testing.T) {
+	key := bson.D{{Key: "organisationId", Value: 1}, {Key: "timestamp", Value: -1}}
+	if !organisationsBackfillIndexCoversField(key, "organisationId") {
+		t.Fatal("organisationsBackfillIndexCoversField() did not find leading field")
+	}
+	if organisationsBackfillIndexCoversField(key, "user_id") {
+		t.Fatal("organisationsBackfillIndexCoversField() found absent field")
+	}
+}
+
+func TestOrganisationsBackfillExitCode(t *testing.T) {
+	err := &organisationsBackfillError{code: organisationsBackfillExitData, err: errTestDataConflict}
+	if got := OrganisationsBackfillExitCode(err); got != organisationsBackfillExitData {
+		t.Fatalf("OrganisationsBackfillExitCode() = %d, want %d", got, organisationsBackfillExitData)
+	}
+}
+
+var errTestDataConflict = &testBackfillError{"data conflict"}
+
+type testBackfillError struct {
+	message string
+}
+
+func (e *testBackfillError) Error() string {
+	return e.message
+}

--- a/actions/organisations-bootstrap-checkpoint.go
+++ b/actions/organisations-bootstrap-checkpoint.go
@@ -1,0 +1,235 @@
+package actions
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const organisationsBootstrapLeaseDuration = 5 * time.Minute
+
+type organisationsBootstrapCheckpointDocument struct {
+	ID                   string             `bson:"_id"`
+	MigrationVersion     int                `bson:"migrationVersion"`
+	Database             string             `bson:"database"`
+	Stage                string             `bson:"stage"`
+	Scope                string             `bson:"scope"`
+	Mode                 string             `bson:"mode"`
+	Status               string             `bson:"status"`
+	LeaseOwner           string             `bson:"leaseOwner"`
+	LeaseExpiresAt       time.Time          `bson:"leaseExpiresAt"`
+	LastVerifiedMasterID primitive.ObjectID `bson:"lastVerifiedMasterId,omitempty"`
+	StartedAt            time.Time          `bson:"startedAt"`
+	UpdatedAt            time.Time          `bson:"updatedAt"`
+	CompletedAt          time.Time          `bson:"completedAt,omitempty"`
+}
+
+func (r *organisationsBootstrapRunner) acquireCheckpoint(ctx context.Context) error {
+	if r.config.Mode != "live" {
+		return nil
+	}
+	collection := r.database.Collection("migration_checkpoints")
+	now := time.Now().UTC()
+	checkpointID := r.report.Checkpoint.ID
+	leaseOwner := primitive.NewObjectID().Hex()
+
+	if r.config.Restart {
+		result, err := collection.DeleteOne(ctx, bson.M{
+			"_id": checkpointID,
+			"$or": bson.A{
+				bson.M{"status": bson.M{"$ne": "running"}},
+				bson.M{"leaseExpiresAt": bson.M{"$lte": now}},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("restart bootstrap checkpoint: %w", err)
+		}
+		if result.DeletedCount == 0 {
+			count, countErr := collection.CountDocuments(ctx, bson.M{"_id": checkpointID}, options.Count().SetLimit(1))
+			if countErr != nil {
+				return fmt.Errorf("inspect bootstrap checkpoint: %w", countErr)
+			}
+			if count == 1 {
+				return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: errors.New("bootstrap checkpoint has an active lease")}
+			}
+		}
+	}
+
+	if r.config.Resume {
+		var checkpoint organisationsBootstrapCheckpointDocument
+		err := collection.FindOneAndUpdate(ctx, bson.M{
+			"_id":    checkpointID,
+			"status": bson.M{"$in": bson.A{"running", "failed", "blocked"}},
+			"$or": bson.A{
+				bson.M{"status": bson.M{"$ne": "running"}},
+				bson.M{"leaseExpiresAt": bson.M{"$lte": now}},
+			},
+		}, bson.M{
+			"$set": bson.M{
+				"status":         "running",
+				"leaseOwner":     leaseOwner,
+				"leaseExpiresAt": now.Add(organisationsBootstrapLeaseDuration),
+				"updatedAt":      now,
+			},
+			"$unset": bson.M{"completedAt": ""},
+		}, options.FindOneAndUpdate().SetReturnDocument(options.After)).Decode(&checkpoint)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return &organisationsBootstrapError{code: organisationsBootstrapExitUsage, err: errors.New("no resumable bootstrap checkpoint exists; use a fresh run or -restart")}
+		}
+		if err != nil {
+			return fmt.Errorf("resume bootstrap checkpoint: %w", err)
+		}
+		r.checkpointLastMaster = checkpoint.LastVerifiedMasterID
+	} else {
+		document := organisationsBootstrapCheckpointDocument{
+			ID:               checkpointID,
+			MigrationVersion: r.config.MigrationVersion,
+			Database:         r.config.MongoDBDestinationDatabase,
+			Stage:            r.config.Stage,
+			Scope:            organisationsBootstrapScope(r.config),
+			Mode:             r.config.Mode,
+			Status:           "running",
+			LeaseOwner:       leaseOwner,
+			LeaseExpiresAt:   now.Add(organisationsBootstrapLeaseDuration),
+			StartedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := collection.InsertOne(ctx, document); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				return &organisationsBootstrapError{code: organisationsBootstrapExitUsage, err: errors.New("bootstrap checkpoint already exists; use -resume or -restart")}
+			}
+			return fmt.Errorf("create bootstrap checkpoint: %w", err)
+		}
+	}
+
+	r.checkpointAcquired = true
+	r.checkpointLeaseOwner = leaseOwner
+	r.checkpointLeaseExpiry = now.Add(organisationsBootstrapLeaseDuration)
+	r.report.Checkpoint.Status = "running"
+	if !r.checkpointLastMaster.IsZero() {
+		r.report.Checkpoint.LastVerifiedMasterID = r.checkpointLastMaster.Hex()
+	}
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) advanceCheckpoint(ctx context.Context, masterID primitive.ObjectID) error {
+	if !r.checkpointAcquired {
+		return nil
+	}
+	now := time.Now().UTC()
+	result, err := r.database.Collection("migration_checkpoints").UpdateOne(ctx, bson.M{
+		"_id":        r.report.Checkpoint.ID,
+		"status":     "running",
+		"leaseOwner": r.checkpointLeaseOwner,
+	}, bson.M{"$set": bson.M{
+		"lastVerifiedMasterId": masterID,
+		"leaseExpiresAt":       now.Add(organisationsBootstrapLeaseDuration),
+		"updatedAt":            now,
+		"counters": bson.M{
+			"masters":      r.report.Masters,
+			"subUsers":     r.report.SubUsers,
+			"memberships":  r.report.Memberships,
+			"writes":       r.report.Writes,
+			"verification": r.report.Verification,
+		},
+		"conflicts": r.report.Conflicts,
+	}})
+	if err != nil {
+		return fmt.Errorf("advance bootstrap checkpoint: %w", err)
+	}
+	if result.MatchedCount != 1 {
+		return errors.New("bootstrap checkpoint lease was lost")
+	}
+	r.checkpointLastMaster = masterID
+	r.checkpointLeaseExpiry = now.Add(organisationsBootstrapLeaseDuration)
+	r.report.Checkpoint.LastVerifiedMasterID = masterID.Hex()
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) renewCheckpoint(ctx context.Context) error {
+	if !r.checkpointAcquired || time.Now().UTC().Before(r.checkpointLeaseExpiry.Add(-organisationsBootstrapLeaseDuration/2)) {
+		return nil
+	}
+	now := time.Now().UTC()
+	leaseExpiresAt := now.Add(organisationsBootstrapLeaseDuration)
+	result, err := r.database.Collection("migration_checkpoints").UpdateOne(ctx, bson.M{
+		"_id":        r.report.Checkpoint.ID,
+		"status":     "running",
+		"leaseOwner": r.checkpointLeaseOwner,
+	}, bson.M{"$set": bson.M{
+		"leaseExpiresAt": leaseExpiresAt,
+		"updatedAt":      now,
+	}})
+	if err != nil {
+		return fmt.Errorf("renew bootstrap checkpoint: %w", err)
+	}
+	if result.MatchedCount != 1 {
+		return errors.New("bootstrap checkpoint lease was lost")
+	}
+	r.checkpointLeaseExpiry = leaseExpiresAt
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) finishCheckpoint(status string) error {
+	if !r.checkpointAcquired {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	now := time.Now().UTC()
+	result, err := r.database.Collection("migration_checkpoints").UpdateOne(ctx, bson.M{
+		"_id":        r.report.Checkpoint.ID,
+		"status":     "running",
+		"leaseOwner": r.checkpointLeaseOwner,
+	}, bson.M{
+		"$set": bson.M{
+			"status":      status,
+			"updatedAt":   now,
+			"completedAt": now,
+			"counters": bson.M{
+				"masters":      r.report.Masters,
+				"subUsers":     r.report.SubUsers,
+				"memberships":  r.report.Memberships,
+				"writes":       r.report.Writes,
+				"verification": r.report.Verification,
+			},
+			"conflicts": r.report.Conflicts,
+		},
+		"$unset": bson.M{
+			"leaseOwner":     "",
+			"leaseExpiresAt": "",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("finalize bootstrap checkpoint: %w", err)
+	}
+	if result.MatchedCount != 1 {
+		return errors.New("bootstrap checkpoint lease was lost before finalization")
+	}
+	r.report.Checkpoint.Status = status
+	r.checkpointAcquired = false
+	return nil
+}
+
+func organisationsBootstrapResumeFilter(filter bson.M, lastVerifiedMasterID primitive.ObjectID) bson.M {
+	if lastVerifiedMasterID.IsZero() {
+		return filter
+	}
+	if exactID, exists := filter["_id"]; exists {
+		scopedID, ok := exactID.(primitive.ObjectID)
+		if ok && bytes.Compare(scopedID[:], lastVerifiedMasterID[:]) > 0 {
+			return filter
+		}
+		filter["_id"] = bson.M{"$exists": false}
+		return filter
+	}
+	filter["_id"] = bson.M{"$gt": lastVerifiedMasterID}
+	return filter
+}

--- a/actions/organisations-bootstrap-checkpoint.go
+++ b/actions/organisations-bootstrap-checkpoint.go
@@ -16,19 +16,31 @@ import (
 const organisationsBootstrapLeaseDuration = 5 * time.Minute
 
 type organisationsBootstrapCheckpointDocument struct {
-	ID                   string             `bson:"_id"`
-	MigrationVersion     int                `bson:"migrationVersion"`
-	Database             string             `bson:"database"`
-	Stage                string             `bson:"stage"`
-	Scope                string             `bson:"scope"`
-	Mode                 string             `bson:"mode"`
-	Status               string             `bson:"status"`
-	LeaseOwner           string             `bson:"leaseOwner"`
-	LeaseExpiresAt       time.Time          `bson:"leaseExpiresAt"`
-	LastVerifiedMasterID primitive.ObjectID `bson:"lastVerifiedMasterId,omitempty"`
-	StartedAt            time.Time          `bson:"startedAt"`
-	UpdatedAt            time.Time          `bson:"updatedAt"`
-	CompletedAt          time.Time          `bson:"completedAt,omitempty"`
+	ID                   string                                   `bson:"_id"`
+	MigrationVersion     int                                      `bson:"migrationVersion"`
+	Database             string                                   `bson:"database"`
+	Stage                string                                   `bson:"stage"`
+	Scope                string                                   `bson:"scope"`
+	Mode                 string                                   `bson:"mode"`
+	Status               string                                   `bson:"status"`
+	LeaseOwner           string                                   `bson:"leaseOwner"`
+	LeaseExpiresAt       time.Time                                `bson:"leaseExpiresAt"`
+	LastVerifiedMasterID primitive.ObjectID                       `bson:"lastVerifiedMasterId,omitempty"`
+	StartedAt            time.Time                                `bson:"startedAt"`
+	UpdatedAt            time.Time                                `bson:"updatedAt"`
+	CompletedAt          time.Time                                `bson:"completedAt,omitempty"`
+	Counters             organisationsBootstrapCheckpointCounters `bson:"counters,omitempty"`
+	Conflicts            []organisationsBootstrapConflict         `bson:"conflicts,omitempty"`
+}
+
+type organisationsBootstrapCheckpointCounters struct {
+	Masters       organisationsBootstrapMasterCounts       `bson:"masters"`
+	SubUsers      organisationsBootstrapSubUserCounts      `bson:"subUsers"`
+	Users         organisationsBootstrapUserCounts         `bson:"users"`
+	Memberships   organisationsBootstrapMembershipCounts   `bson:"memberships"`
+	Organisations organisationsBootstrapOrganisationCounts `bson:"organisations"`
+	Writes        organisationsBootstrapWriteCounts        `bson:"writes"`
+	Verification  organisationsBootstrapVerificationCounts `bson:"verification"`
 }
 
 func (r *organisationsBootstrapRunner) acquireCheckpoint(ctx context.Context) error {
@@ -87,6 +99,7 @@ func (r *organisationsBootstrapRunner) acquireCheckpoint(ctx context.Context) er
 			return fmt.Errorf("resume bootstrap checkpoint: %w", err)
 		}
 		r.checkpointLastMaster = checkpoint.LastVerifiedMasterID
+		r.restoreCheckpoint(checkpoint)
 	} else {
 		document := organisationsBootstrapCheckpointDocument{
 			ID:               checkpointID,
@@ -119,6 +132,28 @@ func (r *organisationsBootstrapRunner) acquireCheckpoint(ctx context.Context) er
 	return nil
 }
 
+func (r *organisationsBootstrapRunner) restoreCheckpoint(checkpoint organisationsBootstrapCheckpointDocument) {
+	r.report.Masters = checkpoint.Counters.Masters
+	r.report.SubUsers = checkpoint.Counters.SubUsers
+	r.report.Users = checkpoint.Counters.Users
+	r.report.Memberships = checkpoint.Counters.Memberships
+	r.report.Organisations = checkpoint.Counters.Organisations
+	r.report.Writes = checkpoint.Counters.Writes
+	r.report.Verification = checkpoint.Counters.Verification
+}
+
+func (r *organisationsBootstrapRunner) checkpointCounters() organisationsBootstrapCheckpointCounters {
+	return organisationsBootstrapCheckpointCounters{
+		Masters:       r.report.Masters,
+		SubUsers:      r.report.SubUsers,
+		Users:         r.report.Users,
+		Memberships:   r.report.Memberships,
+		Organisations: r.report.Organisations,
+		Writes:        r.report.Writes,
+		Verification:  r.report.Verification,
+	}
+}
+
 func (r *organisationsBootstrapRunner) advanceCheckpoint(ctx context.Context, masterID primitive.ObjectID) error {
 	if !r.checkpointAcquired {
 		return nil
@@ -132,14 +167,8 @@ func (r *organisationsBootstrapRunner) advanceCheckpoint(ctx context.Context, ma
 		"lastVerifiedMasterId": masterID,
 		"leaseExpiresAt":       now.Add(organisationsBootstrapLeaseDuration),
 		"updatedAt":            now,
-		"counters": bson.M{
-			"masters":      r.report.Masters,
-			"subUsers":     r.report.SubUsers,
-			"memberships":  r.report.Memberships,
-			"writes":       r.report.Writes,
-			"verification": r.report.Verification,
-		},
-		"conflicts": r.report.Conflicts,
+		"counters":             r.checkpointCounters(),
+		"conflicts":            r.report.Conflicts,
 	}})
 	if err != nil {
 		return fmt.Errorf("advance bootstrap checkpoint: %w", err)
@@ -177,6 +206,59 @@ func (r *organisationsBootstrapRunner) renewCheckpoint(ctx context.Context) erro
 	return nil
 }
 
+func (r *organisationsBootstrapRunner) withCheckpointHeartbeat(ctx context.Context, operation func(context.Context) error) error {
+	if !r.checkpointAcquired {
+		return operation(ctx)
+	}
+	operationContext, cancelOperation := context.WithCancelCause(ctx)
+	defer cancelOperation(nil)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(organisationsBootstrapLeaseDuration / 3)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				done <- nil
+				return
+			case <-ticker.C:
+				if err := r.refreshCheckpointLease(operationContext); err != nil {
+					cancelOperation(err)
+					done <- err
+					return
+				}
+			}
+		}
+	}()
+
+	operationErr := operation(operationContext)
+	close(stop)
+	if heartbeatErr := <-done; heartbeatErr != nil {
+		return errors.Join(operationErr, heartbeatErr)
+	}
+	return operationErr
+}
+
+func (r *organisationsBootstrapRunner) refreshCheckpointLease(ctx context.Context) error {
+	now := time.Now().UTC()
+	result, err := r.database.Collection("migration_checkpoints").UpdateOne(ctx, bson.M{
+		"_id":        r.report.Checkpoint.ID,
+		"status":     "running",
+		"leaseOwner": r.checkpointLeaseOwner,
+	}, bson.M{"$set": bson.M{
+		"leaseExpiresAt": now.Add(organisationsBootstrapLeaseDuration),
+		"updatedAt":      now,
+	}})
+	if err != nil {
+		return fmt.Errorf("heartbeat bootstrap checkpoint: %w", err)
+	}
+	if result.MatchedCount != 1 {
+		return errors.New("bootstrap checkpoint lease was lost")
+	}
+	return nil
+}
+
 func (r *organisationsBootstrapRunner) finishCheckpoint(status string) error {
 	if !r.checkpointAcquired {
 		return nil
@@ -193,14 +275,8 @@ func (r *organisationsBootstrapRunner) finishCheckpoint(status string) error {
 			"status":      status,
 			"updatedAt":   now,
 			"completedAt": now,
-			"counters": bson.M{
-				"masters":      r.report.Masters,
-				"subUsers":     r.report.SubUsers,
-				"memberships":  r.report.Memberships,
-				"writes":       r.report.Writes,
-				"verification": r.report.Verification,
-			},
-			"conflicts": r.report.Conflicts,
+			"counters":    r.checkpointCounters(),
+			"conflicts":   r.report.Conflicts,
 		},
 		"$unset": bson.M{
 			"leaseOwner":     "",

--- a/actions/organisations-bootstrap-data.go
+++ b/actions/organisations-bootstrap-data.go
@@ -1,0 +1,853 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type organisationsBootstrapFieldState int
+
+const (
+	organisationsBootstrapFieldEmpty organisationsBootstrapFieldState = iota
+	organisationsBootstrapFieldValue
+	organisationsBootstrapFieldWrong
+)
+
+type organisationsBootstrapUser struct {
+	ID                    primitive.ObjectID
+	Username              string
+	OrganisationName      string
+	ParentID              primitive.ObjectID
+	ParentState           organisationsBootstrapFieldState
+	Selection             primitive.ObjectID
+	SelectionState        organisationsBootstrapFieldState
+	Timezone              string
+	Domain                string
+	CreatedAt             time.Time
+	OrganisationCreatedAt time.Time
+	OrganisationUpdatedAt time.Time
+}
+
+type organisationsBootstrapLegacyCandidate struct {
+	ID        primitive.ObjectID
+	Name      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func parseOrganisationsBootstrapUser(document bson.Raw) (organisationsBootstrapUser, error) {
+	user := organisationsBootstrapUser{}
+	id, state := organisationsBootstrapObjectID(document, "_id")
+	if state != organisationsBootstrapFieldValue {
+		return user, errors.New("user _id must be a non-zero BSON ObjectID")
+	}
+	user.ID = id
+	user.Username, _ = organisationsBootstrapString(document, "username")
+	user.Timezone, _ = organisationsBootstrapString(document, "timezone")
+	user.Domain, _ = organisationsBootstrapString(document, "domain")
+	user.CreatedAt, _ = organisationsBootstrapTime(document, "created_at")
+
+	parentHex, parentState := organisationsBootstrapString(document, "user_id")
+	user.ParentState = parentState
+	if parentState == organisationsBootstrapFieldValue {
+		parentID, err := primitive.ObjectIDFromHex(parentHex)
+		if err != nil {
+			user.ParentState = organisationsBootstrapFieldWrong
+		} else {
+			user.ParentID = parentID
+		}
+	}
+	user.Selection, user.SelectionState = organisationsBootstrapObjectID(document, "organisation_id")
+	return user, nil
+}
+
+func organisationsBootstrapObjectID(document bson.Raw, path ...string) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	value := document.Lookup(path...)
+	switch value.Type {
+	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
+		return primitive.NilObjectID, organisationsBootstrapFieldEmpty
+	case bsontype.ObjectID:
+		id := value.ObjectID()
+		if id.IsZero() {
+			return primitive.NilObjectID, organisationsBootstrapFieldEmpty
+		}
+		return id, organisationsBootstrapFieldValue
+	default:
+		return primitive.NilObjectID, organisationsBootstrapFieldWrong
+	}
+}
+
+func organisationsBootstrapString(document bson.Raw, path ...string) (string, organisationsBootstrapFieldState) {
+	value := document.Lookup(path...)
+	switch value.Type {
+	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
+		return "", organisationsBootstrapFieldEmpty
+	case bsontype.String:
+		text := value.StringValue()
+		if text == "" {
+			return "", organisationsBootstrapFieldEmpty
+		}
+		return text, organisationsBootstrapFieldValue
+	default:
+		return "", organisationsBootstrapFieldWrong
+	}
+}
+
+func organisationsBootstrapTime(document bson.Raw, path ...string) (time.Time, organisationsBootstrapFieldState) {
+	value := document.Lookup(path...)
+	switch value.Type {
+	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
+		return time.Time{}, organisationsBootstrapFieldEmpty
+	case bsontype.DateTime:
+		return value.Time(), organisationsBootstrapFieldValue
+	default:
+		return time.Time{}, organisationsBootstrapFieldWrong
+	}
+}
+
+func organisationsBootstrapBool(document bson.Raw, path ...string) (bool, organisationsBootstrapFieldState) {
+	value := document.Lookup(path...)
+	switch value.Type {
+	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
+		return false, organisationsBootstrapFieldEmpty
+	case bsontype.Boolean:
+		return value.Boolean(), organisationsBootstrapFieldValue
+	default:
+		return false, organisationsBootstrapFieldWrong
+	}
+}
+
+func organisationsBootstrapOrganisationDocument(user organisationsBootstrapUser, now time.Time) bson.M {
+	createdAt, updatedAt := organisationsBootstrapOrganisationTimestamps(user, now)
+	document := bson.M{
+		"_id":      user.ID,
+		"name":     organisationsBootstrapOrganisationName(user),
+		"ownerId":  user.ID,
+		"isActive": true,
+		"audit": bson.M{
+			"createdBy":  user.ID.Hex(),
+			"createdAt":  createdAt,
+			"updatedBy":  user.ID.Hex(),
+			"updatedAt":  updatedAt,
+			"lastAction": "organisation.migrated",
+		},
+	}
+	if user.Timezone != "" {
+		document["settings"] = bson.M{"timezone": user.Timezone}
+	}
+	return document
+}
+
+func organisationsBootstrapMissingOrganisationFields(document bson.Raw, user organisationsBootstrapUser, now time.Time) bson.M {
+	createdAt, updatedAt := organisationsBootstrapOrganisationTimestamps(user, now)
+	if legacyCreatedAt, state := organisationsBootstrapTime(document, "created_at"); state == organisationsBootstrapFieldValue {
+		createdAt = legacyCreatedAt
+	}
+	if canonicalCreatedAt, state := organisationsBootstrapTime(document, "audit", "createdAt"); state == organisationsBootstrapFieldValue {
+		createdAt = canonicalCreatedAt
+	}
+	if legacyUpdatedAt, state := organisationsBootstrapTime(document, "updated_at"); state == organisationsBootstrapFieldValue {
+		updatedAt = legacyUpdatedAt
+	} else if user.OrganisationUpdatedAt.IsZero() {
+		updatedAt = createdAt
+	}
+
+	candidates := bson.M{
+		"ownerId":          user.ID,
+		"name":             organisationsBootstrapOrganisationName(user),
+		"isActive":         true,
+		"audit.createdBy":  user.ID.Hex(),
+		"audit.createdAt":  createdAt,
+		"audit.updatedBy":  user.ID.Hex(),
+		"audit.updatedAt":  updatedAt,
+		"audit.lastAction": "organisation.migrated",
+	}
+	if user.Timezone != "" {
+		candidates["settings.timezone"] = user.Timezone
+	}
+
+	missing := bson.M{}
+	for field, value := range candidates {
+		if field == "ownerId" {
+			_, state := organisationsBootstrapObjectID(document, field)
+			if state == organisationsBootstrapFieldEmpty {
+				missing[field] = value
+			}
+			continue
+		}
+		if document.Lookup(splitOrganisationsBootstrapPath(field)...).Type == bsontype.Type(0) {
+			missing[field] = value
+		}
+	}
+	return missing
+}
+
+func organisationsBootstrapOrganisationName(user organisationsBootstrapUser) string {
+	if user.OrganisationName != "" {
+		return user.OrganisationName
+	}
+	return user.Username
+}
+
+func organisationsBootstrapOrganisationTimestamps(user organisationsBootstrapUser, now time.Time) (time.Time, time.Time) {
+	createdAt := user.OrganisationCreatedAt
+	if createdAt.IsZero() {
+		createdAt = user.CreatedAt
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	updatedAt := user.OrganisationUpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = createdAt
+	}
+	return createdAt, updatedAt
+}
+
+func (r *organisationsBootstrapRunner) legacyOrganisationCandidates(ctx context.Context, masterID primitive.ObjectID, report bool) ([]organisationsBootstrapLegacyCandidate, bool, error) {
+	cursor, err := r.database.Collection("organisation").Find(ctx, bson.M{
+		"_id":      bson.M{"$ne": masterID},
+		"owner_id": masterID.Hex(),
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	defer cursor.Close(ctx)
+	candidates := []organisationsBootstrapLegacyCandidate{}
+	invalid := false
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return nil, false, err
+		}
+		documentID, idState := organisationsBootstrapObjectID(document, "_id")
+		ownerID, ownerState := organisationsBootstrapObjectID(document, "ownerId")
+		if idState != organisationsBootstrapFieldValue {
+			invalid = true
+			continue
+		}
+		if ownerState == organisationsBootstrapFieldValue && ownerID == masterID {
+			continue
+		}
+		if ownerState != organisationsBootstrapFieldEmpty || document.Lookup("ownerId").Type != bsontype.Type(0) {
+			invalid = true
+			if report {
+				r.addConflict("legacy-organisation-owner-conflict", masterID.Hex(), documentID.Hex(), "legacy organisation has an invalid or conflicting canonical owner")
+			}
+			continue
+		}
+		candidate := organisationsBootstrapLegacyCandidate{ID: documentID}
+		candidate.Name, _ = organisationsBootstrapString(document, "name")
+		candidate.CreatedAt, _ = organisationsBootstrapTime(document, "created_at")
+		candidate.UpdatedAt, _ = organisationsBootstrapTime(document, "updated_at")
+		candidates = append(candidates, candidate)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, false, err
+	}
+	if report && len(candidates) > 0 {
+		ids := make([]primitive.ObjectID, len(candidates))
+		for index := range candidates {
+			ids[index] = candidates[index].ID
+		}
+		referenced, err := r.database.Collection("users").CountDocuments(ctx, bson.M{"organisation_id": bson.M{"$in": ids}})
+		if err != nil {
+			return nil, false, err
+		}
+		r.report.Organisations.Referenced += referenced
+	}
+	return candidates, invalid, nil
+}
+
+func organisationsBootstrapContainerValid(document bson.Raw, field string) bool {
+	typeOfField := document.Lookup(field).Type
+	return typeOfField == bsontype.Type(0) || typeOfField == bsontype.EmbeddedDocument
+}
+
+func organisationsBootstrapOrganisationFieldsValid(document bson.Raw, requireTimezone bool) bool {
+	if _, state := organisationsBootstrapString(document, "name"); state != organisationsBootstrapFieldValue {
+		return false
+	}
+	if _, state := organisationsBootstrapBool(document, "isActive"); state != organisationsBootstrapFieldValue {
+		return false
+	}
+	for _, path := range [][]string{
+		{"audit", "createdBy"},
+		{"audit", "updatedBy"},
+		{"audit", "lastAction"},
+	} {
+		if _, state := organisationsBootstrapString(document, path...); state != organisationsBootstrapFieldValue {
+			return false
+		}
+	}
+	for _, path := range [][]string{
+		{"audit", "createdAt"},
+		{"audit", "updatedAt"},
+	} {
+		if _, state := organisationsBootstrapTime(document, path...); state != organisationsBootstrapFieldValue {
+			return false
+		}
+	}
+	if requireTimezone {
+		if _, state := organisationsBootstrapString(document, "settings", "timezone"); state != organisationsBootstrapFieldValue {
+			return false
+		}
+	}
+	return true
+}
+
+func organisationsBootstrapExistingOrganisationTypesValid(document bson.Raw, requireTimezone bool) bool {
+	checks := []struct {
+		path     []string
+		expected bsontype.Type
+	}{
+		{[]string{"name"}, bsontype.String},
+		{[]string{"isActive"}, bsontype.Boolean},
+		{[]string{"audit", "createdBy"}, bsontype.String},
+		{[]string{"audit", "createdAt"}, bsontype.DateTime},
+		{[]string{"audit", "updatedBy"}, bsontype.String},
+		{[]string{"audit", "updatedAt"}, bsontype.DateTime},
+		{[]string{"audit", "lastAction"}, bsontype.String},
+	}
+	if requireTimezone {
+		checks = append(checks, struct {
+			path     []string
+			expected bsontype.Type
+		}{[]string{"settings", "timezone"}, bsontype.String})
+	}
+	for _, check := range checks {
+		value := document.Lookup(check.path...)
+		if value.Type == bsontype.Type(0) {
+			continue
+		}
+		if value.Type != check.expected {
+			return false
+		}
+		if check.expected == bsontype.String && value.StringValue() == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func organisationsBootstrapMissingFieldFilter(documentID primitive.ObjectID, field string) bson.M {
+	filter := bson.M{"_id": documentID, field: bson.M{"$exists": false}}
+	if field == "ownerId" {
+		filter["$or"] = bson.A{
+			bson.M{"ownerId": bson.M{"$exists": false}},
+			bson.M{"ownerId": nil},
+			bson.M{"ownerId": primitive.NilObjectID},
+		}
+		delete(filter, field)
+	}
+	return filter
+}
+
+func splitOrganisationsBootstrapPath(path string) []string {
+	for index := range path {
+		if path[index] == '.' {
+			return []string{path[:index], path[index+1:]}
+		}
+	}
+	return []string{path}
+}
+
+func sortedOrganisationsBootstrapFields(fields bson.M) []string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (r *organisationsBootstrapRunner) organisationAccessibleToMaster(ctx context.Context, organisationID, masterID primitive.ObjectID) (bool, error) {
+	return r.organisationAccessibleToUser(ctx, organisationID, masterID, masterID)
+}
+
+func (r *organisationsBootstrapRunner) organisationAccessibleToUser(ctx context.Context, organisationID, userID, masterID primitive.ObjectID) (bool, error) {
+	var organisation bson.Raw
+	err := r.database.Collection("organisation").FindOne(ctx, bson.M{"_id": organisationID}).Decode(&organisation)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	ownerID, ownerState := organisationsBootstrapObjectID(organisation, "ownerId")
+	if ownerState == organisationsBootstrapFieldValue {
+		if ownerID == masterID || ownerID == userID {
+			return true, nil
+		}
+		return organisationsBootstrapMembershipActive(ctx, r.database.Collection("organisation_users"), bson.M{
+			"userId":         userID,
+			"organisationId": organisationID,
+		}, r.now)
+	}
+	if ownerState == organisationsBootstrapFieldWrong {
+		return false, nil
+	}
+	legacyOwner, legacyState := organisationsBootstrapString(organisation, "owner_id")
+	if legacyState == organisationsBootstrapFieldValue && (legacyOwner == masterID.Hex() || legacyOwner == userID.Hex()) {
+		return true, nil
+	}
+	return organisationsBootstrapMembershipActive(ctx, r.database.Collection("organisation_users"), bson.M{
+		"userId":         userID,
+		"organisationId": organisationID,
+	}, r.now)
+}
+
+func (r *organisationsBootstrapRunner) ensureMembership(ctx context.Context, userID, organisationID, actorID primitive.ObjectID) (bool, error) {
+	collection := r.database.Collection("organisation_users")
+	filter := bson.M{"userId": userID, "organisationId": organisationID}
+	count, err := collection.CountDocuments(ctx, filter, options.Count().SetLimit(2))
+	if err != nil {
+		return false, err
+	}
+	if count > 1 {
+		r.report.Memberships.Conflicted++
+		r.addConflict("duplicate-membership", actorID.Hex(), userID.Hex(), "more than one membership exists for the user and organisation pair")
+		return false, nil
+	}
+	if count == 1 {
+		active, activeErr := organisationsBootstrapMembershipActive(ctx, collection, filter, r.now)
+		if activeErr != nil {
+			return false, activeErr
+		}
+		if !active {
+			r.report.Memberships.Conflicted++
+			r.addConflict("inactive-membership", actorID.Hex(), userID.Hex(), "existing membership is not effectively active")
+			return false, nil
+		}
+		r.report.Memberships.AlreadyPresent++
+		return true, nil
+	}
+
+	if r.strict {
+		r.report.Memberships.Conflicted++
+		r.addConflict("membership-missing", actorID.Hex(), userID.Hex(), "required active membership is missing")
+		return false, nil
+	}
+	r.report.Memberships.Planned++
+	if r.config.Mode == "dry-run" {
+		return true, nil
+	}
+	membership := bson.M{
+		"_id":            primitive.NewObjectID(),
+		"userId":         userID,
+		"organisationId": organisationID,
+		"status":         "active",
+		"joinedAt":       r.now,
+		"audit": bson.M{
+			"createdBy":  actorID.Hex(),
+			"createdAt":  r.now,
+			"updatedBy":  actorID.Hex(),
+			"updatedAt":  r.now,
+			"lastAction": "organisation.membership.created",
+		},
+	}
+	r.report.Writes.Attempted++
+	result, writeErr := collection.UpdateOne(ctx, filter, bson.M{"$setOnInsert": membership}, options.Update().SetUpsert(true))
+	if writeErr != nil && !mongo.IsDuplicateKeyError(writeErr) {
+		r.report.Writes.Failed++
+		return false, writeErr
+	}
+	if writeErr == nil && result.UpsertedCount == 1 {
+		r.report.Writes.Applied++
+		r.report.Memberships.Inserted++
+	}
+	active, reconcileErr := organisationsBootstrapMembershipActive(ctx, collection, filter, r.now)
+	if reconcileErr != nil {
+		return false, reconcileErr
+	}
+	if !active {
+		r.report.Memberships.Conflicted++
+		r.addConflict("membership-reconcile-failed", actorID.Hex(), userID.Hex(), "membership write did not reconcile as active")
+		return false, nil
+	}
+	r.report.Memberships.Reconciled++
+	r.report.Writes.Reconciled++
+	return true, nil
+}
+
+func organisationsBootstrapMembershipActive(ctx context.Context, collection *mongo.Collection, filter bson.M, now time.Time) (bool, error) {
+	var membership bson.Raw
+	if err := collection.FindOne(ctx, filter).Decode(&membership); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return false, nil
+		}
+		return false, err
+	}
+	status, state := organisationsBootstrapString(membership, "status")
+	if state != organisationsBootstrapFieldValue || status != "active" {
+		return false, nil
+	}
+	expiresAt, expiryState := organisationsBootstrapTime(membership, "expiresAt")
+	if expiryState == organisationsBootstrapFieldWrong {
+		return false, nil
+	}
+	return expiryState != organisationsBootstrapFieldValue || expiresAt.After(now), nil
+}
+
+func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, user organisationsBootstrapUser, targetID, masterID primitive.ObjectID) (bool, bool, error) {
+	if user.SelectionState == organisationsBootstrapFieldWrong {
+		r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "organisation_id must be a BSON ObjectID")
+		return false, false, nil
+	}
+	if user.SelectionState == organisationsBootstrapFieldValue {
+		accessible, err := r.organisationAccessibleToUser(ctx, user.Selection, user.ID, masterID)
+		if err != nil {
+			return false, false, err
+		}
+		if !accessible {
+			r.report.Users.MissingSelectedOrganisation++
+			r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "preserved organisation_id is missing or not owned by the master")
+			return false, false, nil
+		}
+		return true, false, nil
+	}
+	if r.strict {
+		r.addConflict("user-selection-missing", masterID.Hex(), user.ID.Hex(), "required organisation_id is missing")
+		return false, false, nil
+	}
+	if r.config.Mode == "dry-run" {
+		return true, false, nil
+	}
+
+	collection := r.database.Collection("users")
+	filter := bson.M{
+		"_id": user.ID,
+		"$or": bson.A{
+			bson.M{"organisation_id": bson.M{"$exists": false}},
+			bson.M{"organisation_id": nil},
+			bson.M{"organisation_id": primitive.NilObjectID},
+		},
+	}
+	r.report.Writes.Attempted++
+	result, err := collection.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"organisation_id": targetID}})
+	if err != nil {
+		r.report.Writes.Failed++
+		return false, false, err
+	}
+	if result.ModifiedCount == 1 {
+		r.report.Writes.Applied++
+	}
+
+	var stored bson.Raw
+	if err := collection.FindOne(ctx, bson.M{"_id": user.ID}).Decode(&stored); err != nil {
+		return false, false, err
+	}
+	selection, state := organisationsBootstrapObjectID(stored, "organisation_id")
+	if state != organisationsBootstrapFieldValue {
+		r.addConflict("user-selection-reconcile-failed", masterID.Hex(), user.ID.Hex(), "organisation_id update did not reconcile")
+		return false, true, nil
+	}
+	accessible, err := r.organisationAccessibleToUser(ctx, selection, user.ID, masterID)
+	if err != nil {
+		return false, true, err
+	}
+	if !accessible {
+		r.addConflict("user-selection-concurrent-conflict", masterID.Hex(), user.ID.Hex(), "concurrent organisation selection is not owned by the master")
+		return false, true, nil
+	}
+	r.report.Writes.Reconciled++
+	return true, result.ModifiedCount == 1, nil
+}
+
+func (r *organisationsBootstrapRunner) runSubUsers(ctx context.Context) error {
+	conflictsBeforePreflight := r.conflictCount
+	if err := r.inspectSubUserOrphans(ctx); err != nil {
+		return err
+	}
+	if r.config.Mode == "live" && r.conflictCount > conflictsBeforePreflight {
+		return nil
+	}
+	masterFilter, err := r.masterFilter(ctx)
+	if err != nil {
+		return err
+	}
+	masterFilter = organisationsBootstrapResumeFilter(masterFilter, r.checkpointLastMaster)
+	masters, err := r.database.Collection("users").Find(ctx, masterFilter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}).SetBatchSize(int32(r.config.BatchSize)))
+	if err != nil {
+		return err
+	}
+	defer masters.Close(ctx)
+	mastersScanned := int64(0)
+	for masters.Next(ctx) {
+		if err := r.renewCheckpoint(ctx); err != nil {
+			return err
+		}
+		master, parseErr := parseOrganisationsBootstrapUser(masters.Current)
+		if parseErr != nil || master.ParentState != organisationsBootstrapFieldEmpty {
+			r.addConflict("invalid-master", "", "", "master user is invalid during sub-user processing")
+			if r.config.StopOnConflict {
+				break
+			}
+			continue
+		}
+		mastersScanned++
+		conflictsBefore := r.conflictCount
+		ready, readyErr := r.ownerBootstrapReady(ctx, master.ID)
+		if readyErr != nil {
+			return readyErr
+		}
+		if !ready {
+			r.report.SubUsers.Conflicted++
+			r.addConflict("owner-bootstrap-incomplete", master.ID.Hex(), master.ID.Hex(), "owner stage invariants are not complete")
+			if r.config.StopOnConflict {
+				break
+			}
+			continue
+		}
+
+		subUsers, findErr := r.database.Collection("users").Find(ctx, bson.M{"user_id": master.ID.Hex()}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}).SetBatchSize(int32(r.config.BatchSize)))
+		if findErr != nil {
+			return findErr
+		}
+		for subUsers.Next(ctx) {
+			if err := r.renewCheckpoint(ctx); err != nil {
+				subUsers.Close(ctx)
+				return err
+			}
+			user, userErr := parseOrganisationsBootstrapUser(subUsers.Current)
+			r.report.SubUsers.Scanned++
+			if userErr != nil || user.ParentState != organisationsBootstrapFieldValue || user.ParentID != master.ID {
+				r.report.SubUsers.Orphaned++
+				r.addConflict("invalid-sub-user-parent", master.ID.Hex(), "", "sub-user relationship changed during processing")
+				if r.config.StopOnConflict {
+					break
+				}
+				continue
+			}
+			if processErr := r.processSubUser(ctx, user); processErr != nil {
+				subUsers.Close(ctx)
+				return processErr
+			}
+			if r.hasConflict && r.config.StopOnConflict {
+				break
+			}
+		}
+		if cursorErr := subUsers.Err(); cursorErr != nil {
+			subUsers.Close(ctx)
+			return cursorErr
+		}
+		subUsers.Close(ctx)
+		if conflictsBefore == r.conflictCount && !r.hasConflict {
+			if checkpointErr := r.advanceCheckpoint(ctx, master.ID); checkpointErr != nil {
+				return checkpointErr
+			}
+		}
+		if r.hasConflict && r.config.StopOnConflict {
+			break
+		}
+	}
+	if err := masters.Err(); err != nil {
+		return err
+	}
+	if mastersScanned == 0 && r.checkpointLastMaster.IsZero() && (r.config.Username != "" || r.config.OrganisationID != "") {
+		r.addConflict("master-scope-not-found", "", "", "the requested scope does not resolve to a master user")
+	}
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) inspectSubUserOrphans(ctx context.Context) error {
+	filter := bson.M{"user_id": bson.M{"$exists": true, "$nin": bson.A{nil, ""}}}
+	if masterID, scoped, err := r.scopedMasterID(ctx); err != nil {
+		return err
+	} else if scoped {
+		filter["user_id"] = masterID.Hex()
+	}
+	cursor, err := r.database.Collection("users").Find(ctx, filter, options.Find().SetProjection(bson.M{"_id": 1, "user_id": 1}))
+	if err != nil {
+		return err
+	}
+	defer cursor.Close(ctx)
+	masterExists := map[primitive.ObjectID]bool{}
+	masterChecked := map[primitive.ObjectID]bool{}
+	for cursor.Next(ctx) {
+		user, parseErr := parseOrganisationsBootstrapUser(cursor.Current)
+		if parseErr != nil || user.ParentState != organisationsBootstrapFieldValue {
+			r.report.SubUsers.Scanned++
+			r.report.SubUsers.Orphaned++
+			documentID := ""
+			if parseErr == nil {
+				documentID = user.ID.Hex()
+			}
+			r.addConflict("invalid-sub-user-parent", "", documentID, "sub-user user_id must contain a valid master ObjectID hex")
+			continue
+		}
+		if !masterChecked[user.ParentID] {
+			count, countErr := r.database.Collection("users").CountDocuments(ctx, bson.M{
+				"_id": user.ParentID,
+				"$or": bson.A{
+					bson.M{"user_id": bson.M{"$exists": false}},
+					bson.M{"user_id": nil},
+					bson.M{"user_id": ""},
+				},
+			}, options.Count().SetLimit(1))
+			if countErr != nil {
+				return countErr
+			}
+			masterExists[user.ParentID] = count == 1
+			masterChecked[user.ParentID] = true
+		}
+		if !masterExists[user.ParentID] {
+			r.report.SubUsers.Scanned++
+			r.report.SubUsers.Orphaned++
+			r.addConflict("orphan-sub-user", user.ParentID.Hex(), user.ID.Hex(), "sub-user user_id does not resolve to a master user")
+		}
+	}
+	return cursor.Err()
+}
+
+func (r *organisationsBootstrapRunner) ownerBootstrapReady(ctx context.Context, masterID primitive.ObjectID) (bool, error) {
+	var masterDocument bson.Raw
+	if err := r.database.Collection("users").FindOne(ctx, bson.M{"_id": masterID}).Decode(&masterDocument); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return false, nil
+		}
+		return false, err
+	}
+	master, err := parseOrganisationsBootstrapUser(masterDocument)
+	if err != nil || master.ParentState != organisationsBootstrapFieldEmpty {
+		return false, nil
+	}
+	var organisation bson.Raw
+	if err := r.database.Collection("organisation").FindOne(ctx, bson.M{"_id": masterID}).Decode(&organisation); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return false, nil
+		}
+		return false, err
+	}
+	ownerID, state := organisationsBootstrapObjectID(organisation, "ownerId")
+	if state != organisationsBootstrapFieldValue || ownerID != masterID {
+		return false, nil
+	}
+	if len(organisationsBootstrapMissingOrganisationFields(organisation, master, r.now)) != 0 || !organisationsBootstrapOrganisationFieldsValid(organisation, master.Timezone != "") {
+		return false, nil
+	}
+	legacyCandidates, legacyInvalid, err := r.legacyOrganisationCandidates(ctx, masterID, false)
+	if err != nil || legacyInvalid || len(legacyCandidates) != 0 {
+		return false, err
+	}
+	if master.SelectionState != organisationsBootstrapFieldValue {
+		return false, nil
+	}
+	accessible, err := r.organisationAccessibleToMaster(ctx, master.Selection, masterID)
+	if err != nil || !accessible {
+		return false, err
+	}
+	canonicalMembership, err := organisationsBootstrapMembershipActive(ctx, r.database.Collection("organisation_users"), bson.M{"userId": masterID, "organisationId": masterID}, r.now)
+	if err != nil || !canonicalMembership {
+		return false, err
+	}
+	ownedOrganisations, err := r.database.Collection("organisation").Find(ctx, bson.M{"ownerId": masterID}, options.Find().SetProjection(bson.M{"_id": 1}))
+	if err != nil {
+		return false, err
+	}
+	defer ownedOrganisations.Close(ctx)
+	for ownedOrganisations.Next(ctx) {
+		var owned struct {
+			ID primitive.ObjectID `bson:"_id"`
+		}
+		if err := ownedOrganisations.Decode(&owned); err != nil {
+			return false, err
+		}
+		active, err := organisationsBootstrapMembershipActive(ctx, r.database.Collection("organisation_users"), bson.M{"userId": masterID, "organisationId": owned.ID}, r.now)
+		if err != nil || !active {
+			return false, err
+		}
+	}
+	if err := ownedOrganisations.Err(); err != nil {
+		return false, err
+	}
+	selectedMembership, err := organisationsBootstrapMembershipActive(ctx, r.database.Collection("organisation_users"), bson.M{"userId": masterID, "organisationId": master.Selection}, r.now)
+	return selectedMembership, err
+}
+
+func (r *organisationsBootstrapRunner) processSubUser(ctx context.Context, user organisationsBootstrapUser) error {
+	masterID := user.ParentID
+	targetSet := map[primitive.ObjectID]struct{}{masterID: {}}
+	ownedCursor, err := r.database.Collection("organisation").Find(ctx, bson.M{"ownerId": user.ID}, options.Find().SetProjection(bson.M{"_id": 1}))
+	if err != nil {
+		return err
+	}
+	for ownedCursor.Next(ctx) {
+		var organisation struct {
+			ID primitive.ObjectID `bson:"_id"`
+		}
+		if err := ownedCursor.Decode(&organisation); err != nil {
+			ownedCursor.Close(ctx)
+			return err
+		}
+		targetSet[organisation.ID] = struct{}{}
+		r.report.Organisations.SecondaryOwned++
+	}
+	if err := ownedCursor.Err(); err != nil {
+		ownedCursor.Close(ctx)
+		return err
+	}
+	ownedCursor.Close(ctx)
+	if user.SelectionState == organisationsBootstrapFieldWrong {
+		r.report.SubUsers.Conflicted++
+		r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "organisation_id must be a BSON ObjectID")
+		r.report.Verification.Failed++
+		return nil
+	}
+	if user.SelectionState == organisationsBootstrapFieldValue {
+		accessible, err := r.organisationAccessibleToUser(ctx, user.Selection, user.ID, masterID)
+		if err != nil {
+			return err
+		}
+		if !accessible {
+			r.report.SubUsers.Conflicted++
+			r.report.Users.MissingSelectedOrganisation++
+			r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "preserved organisation_id is missing or not owned by the master")
+			r.report.Verification.Failed++
+			return nil
+		}
+		targetSet[user.Selection] = struct{}{}
+		r.report.SubUsers.AlreadySelected++
+		r.report.Users.SelectionsPreserved++
+	} else {
+		r.report.SubUsers.Planned++
+	}
+	targets := make([]primitive.ObjectID, 0, len(targetSet))
+	for organisationID := range targetSet {
+		targets = append(targets, organisationID)
+	}
+	sort.Slice(targets, func(left, right int) bool { return targets[left].Hex() < targets[right].Hex() })
+	for _, organisationID := range targets {
+		ok, err := r.ensureMembership(ctx, user.ID, organisationID, masterID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			r.report.SubUsers.Conflicted++
+			r.report.Verification.Failed++
+			return nil
+		}
+	}
+	selectionOK, updated, err := r.ensureUserSelection(ctx, user, masterID, masterID)
+	if err != nil {
+		return err
+	}
+	if !selectionOK {
+		r.report.SubUsers.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	if updated {
+		r.report.SubUsers.Updated++
+	}
+	r.report.Verification.Passed++
+	return nil
+}

--- a/actions/organisations-bootstrap-data.go
+++ b/actions/organisations-bootstrap-data.go
@@ -456,19 +456,22 @@ func (r *organisationsBootstrapRunner) ensureMembership(ctx context.Context, use
 	}
 	r.report.Writes.Attempted++
 	result, writeErr := collection.UpdateOne(ctx, filter, bson.M{"$setOnInsert": membership}, options.Update().SetUpsert(true))
-	if writeErr != nil && !mongo.IsDuplicateKeyError(writeErr) {
-		r.report.Writes.Failed++
-		return false, writeErr
-	}
 	if writeErr == nil && result.UpsertedCount == 1 {
 		r.report.Writes.Applied++
 		r.report.Memberships.Inserted++
 	}
 	active, reconcileErr := organisationsBootstrapMembershipActive(ctx, collection, filter, r.now)
 	if reconcileErr != nil {
+		if writeErr != nil {
+			r.report.Writes.Failed++
+			return false, errors.Join(writeErr, reconcileErr)
+		}
 		return false, reconcileErr
 	}
 	if !active {
+		if writeErr != nil {
+			r.report.Writes.Failed++
+		}
 		r.report.Memberships.Conflicted++
 		r.addConflict("membership-reconcile-failed", actorID.Hex(), userID.Hex(), "membership write did not reconcile as active")
 		return false, nil
@@ -534,8 +537,18 @@ func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, 
 	r.report.Writes.Attempted++
 	result, err := collection.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"organisation_id": targetID}})
 	if err != nil {
-		r.report.Writes.Failed++
-		return false, false, err
+		selectionOK, reconcileErr := r.reconcileUserSelection(ctx, user.ID, targetID, masterID)
+		if reconcileErr != nil {
+			r.report.Writes.Failed++
+			return false, false, errors.Join(err, reconcileErr)
+		}
+		if !selectionOK {
+			r.report.Writes.Failed++
+			return false, false, nil
+		}
+		r.report.Writes.Applied++
+		r.report.Writes.Reconciled++
+		return true, true, nil
 	}
 	if result.ModifiedCount == 1 {
 		r.report.Writes.Applied++
@@ -562,6 +575,19 @@ func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, 
 	return true, result.ModifiedCount == 1, nil
 }
 
+func (r *organisationsBootstrapRunner) reconcileUserSelection(ctx context.Context, userID, targetID, masterID primitive.ObjectID) (bool, error) {
+	var stored bson.Raw
+	if err := r.database.Collection("users").FindOne(ctx, bson.M{"_id": userID}).Decode(&stored); err != nil {
+		return false, err
+	}
+	selection, state := organisationsBootstrapObjectID(stored, "organisation_id")
+	if state == organisationsBootstrapFieldValue && selection == targetID {
+		return true, nil
+	}
+	r.addConflict("user-selection-write-inconclusive", masterID.Hex(), userID.Hex(), "organisation_id update did not reconcile to the intended value")
+	return false, nil
+}
+
 func (r *organisationsBootstrapRunner) runSubUsers(ctx context.Context) error {
 	conflictsBeforePreflight := r.conflictCount
 	if err := r.inspectSubUserOrphans(ctx); err != nil {
@@ -582,6 +608,9 @@ func (r *organisationsBootstrapRunner) runSubUsers(ctx context.Context) error {
 	defer masters.Close(ctx)
 	mastersScanned := int64(0)
 	for masters.Next(ctx) {
+		if r.interrupted() {
+			return errOrganisationsBootstrapInterrupted
+		}
 		if err := r.renewCheckpoint(ctx); err != nil {
 			return err
 		}
@@ -594,7 +623,6 @@ func (r *organisationsBootstrapRunner) runSubUsers(ctx context.Context) error {
 			continue
 		}
 		mastersScanned++
-		conflictsBefore := r.conflictCount
 		ready, readyErr := r.ownerBootstrapReady(ctx, master.ID)
 		if readyErr != nil {
 			return readyErr
@@ -640,10 +668,13 @@ func (r *organisationsBootstrapRunner) runSubUsers(ctx context.Context) error {
 			return cursorErr
 		}
 		subUsers.Close(ctx)
-		if conflictsBefore == r.conflictCount && !r.hasConflict {
+		if r.blockingConflictCount == 0 {
 			if checkpointErr := r.advanceCheckpoint(ctx, master.ID); checkpointErr != nil {
 				return checkpointErr
 			}
+		}
+		if r.interrupted() {
+			return errOrganisationsBootstrapInterrupted
 		}
 		if r.hasConflict && r.config.StopOnConflict {
 			break
@@ -735,7 +766,7 @@ func (r *organisationsBootstrapRunner) ownerBootstrapReady(ctx context.Context, 
 		return false, nil
 	}
 	legacyCandidates, legacyInvalid, err := r.legacyOrganisationCandidates(ctx, masterID, false)
-	if err != nil || legacyInvalid || len(legacyCandidates) != 0 {
+	if err != nil || legacyInvalid || len(legacyCandidates) > 1 {
 		return false, err
 	}
 	if master.SelectionState != organisationsBootstrapFieldValue {

--- a/actions/organisations-bootstrap-data.go
+++ b/actions/organisations-bootstrap-data.go
@@ -22,18 +22,19 @@ const (
 )
 
 type organisationsBootstrapUser struct {
-	ID                    primitive.ObjectID
-	Username              string
-	OrganisationName      string
-	ParentID              primitive.ObjectID
-	ParentState           organisationsBootstrapFieldState
-	Selection             primitive.ObjectID
-	SelectionState        organisationsBootstrapFieldState
-	Timezone              string
-	Domain                string
-	CreatedAt             time.Time
-	OrganisationCreatedAt time.Time
-	OrganisationUpdatedAt time.Time
+	ID                     primitive.ObjectID
+	Username               string
+	OrganisationName       string
+	ParentID               primitive.ObjectID
+	ParentState            organisationsBootstrapFieldState
+	Selection              primitive.ObjectID
+	SelectionState         organisationsBootstrapFieldState
+	LegacySelectionPresent bool
+	Timezone               string
+	Domain                 string
+	CreatedAt              time.Time
+	OrganisationCreatedAt  time.Time
+	OrganisationUpdatedAt  time.Time
 }
 
 type organisationsBootstrapLegacyCandidate struct {
@@ -65,7 +66,8 @@ func parseOrganisationsBootstrapUser(document bson.Raw) (organisationsBootstrapU
 			user.ParentID = parentID
 		}
 	}
-	user.Selection, user.SelectionState = organisationsBootstrapObjectID(document, "organisation_id")
+	user.Selection, user.SelectionState = organisationsBootstrapObjectID(document, "organisationId")
+	user.LegacySelectionPresent = document.Lookup("organisation_id").Type != bsontype.Type(0)
 	return user, nil
 }
 
@@ -258,7 +260,7 @@ func (r *organisationsBootstrapRunner) legacyOrganisationCandidates(ctx context.
 		for index := range candidates {
 			ids[index] = candidates[index].ID
 		}
-		referenced, err := r.database.Collection("users").CountDocuments(ctx, bson.M{"organisation_id": bson.M{"$in": ids}})
+		referenced, err := r.database.Collection("users").CountDocuments(ctx, bson.M{"organisationId": bson.M{"$in": ids}})
 		if err != nil {
 			return nil, false, err
 		}
@@ -502,7 +504,7 @@ func organisationsBootstrapMembershipActive(ctx context.Context, collection *mon
 
 func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, user organisationsBootstrapUser, targetID, masterID primitive.ObjectID) (bool, bool, error) {
 	if user.SelectionState == organisationsBootstrapFieldWrong {
-		r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "organisation_id must be a BSON ObjectID")
+		r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "organisationId must be a BSON ObjectID")
 		return false, false, nil
 	}
 	if user.SelectionState == organisationsBootstrapFieldValue {
@@ -512,13 +514,13 @@ func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, 
 		}
 		if !accessible {
 			r.report.Users.MissingSelectedOrganisation++
-			r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "preserved organisation_id is missing or not owned by the master")
+			r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "preserved organisationId is missing or not owned by the master")
 			return false, false, nil
 		}
 		return true, false, nil
 	}
 	if r.strict {
-		r.addConflict("user-selection-missing", masterID.Hex(), user.ID.Hex(), "required organisation_id is missing")
+		r.addConflict("user-selection-missing", masterID.Hex(), user.ID.Hex(), "required organisationId is missing")
 		return false, false, nil
 	}
 	if r.config.Mode == "dry-run" {
@@ -529,13 +531,13 @@ func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, 
 	filter := bson.M{
 		"_id": user.ID,
 		"$or": bson.A{
-			bson.M{"organisation_id": bson.M{"$exists": false}},
-			bson.M{"organisation_id": nil},
-			bson.M{"organisation_id": primitive.NilObjectID},
+			bson.M{"organisationId": bson.M{"$exists": false}},
+			bson.M{"organisationId": nil},
+			bson.M{"organisationId": primitive.NilObjectID},
 		},
 	}
 	r.report.Writes.Attempted++
-	result, err := collection.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"organisation_id": targetID}})
+	result, err := collection.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"organisationId": targetID}})
 	if err != nil {
 		selectionOK, reconcileErr := r.reconcileUserSelection(ctx, user.ID, targetID, masterID)
 		if reconcileErr != nil {
@@ -558,9 +560,9 @@ func (r *organisationsBootstrapRunner) ensureUserSelection(ctx context.Context, 
 	if err := collection.FindOne(ctx, bson.M{"_id": user.ID}).Decode(&stored); err != nil {
 		return false, false, err
 	}
-	selection, state := organisationsBootstrapObjectID(stored, "organisation_id")
+	selection, state := organisationsBootstrapObjectID(stored, "organisationId")
 	if state != organisationsBootstrapFieldValue {
-		r.addConflict("user-selection-reconcile-failed", masterID.Hex(), user.ID.Hex(), "organisation_id update did not reconcile")
+		r.addConflict("user-selection-reconcile-failed", masterID.Hex(), user.ID.Hex(), "organisationId update did not reconcile")
 		return false, true, nil
 	}
 	accessible, err := r.organisationAccessibleToUser(ctx, selection, user.ID, masterID)
@@ -580,11 +582,11 @@ func (r *organisationsBootstrapRunner) reconcileUserSelection(ctx context.Contex
 	if err := r.database.Collection("users").FindOne(ctx, bson.M{"_id": userID}).Decode(&stored); err != nil {
 		return false, err
 	}
-	selection, state := organisationsBootstrapObjectID(stored, "organisation_id")
+	selection, state := organisationsBootstrapObjectID(stored, "organisationId")
 	if state == organisationsBootstrapFieldValue && selection == targetID {
 		return true, nil
 	}
-	r.addConflict("user-selection-write-inconclusive", masterID.Hex(), userID.Hex(), "organisation_id update did not reconcile to the intended value")
+	r.addConflict("user-selection-write-inconclusive", masterID.Hex(), userID.Hex(), "organisationId update did not reconcile to the intended value")
 	return false, nil
 }
 
@@ -748,7 +750,7 @@ func (r *organisationsBootstrapRunner) ownerBootstrapReady(ctx context.Context, 
 		return false, err
 	}
 	master, err := parseOrganisationsBootstrapUser(masterDocument)
-	if err != nil || master.ParentState != organisationsBootstrapFieldEmpty {
+	if err != nil || master.ParentState != organisationsBootstrapFieldEmpty || master.LegacySelectionPresent {
 		return false, nil
 	}
 	var organisation bson.Raw
@@ -806,6 +808,12 @@ func (r *organisationsBootstrapRunner) ownerBootstrapReady(ctx context.Context, 
 
 func (r *organisationsBootstrapRunner) processSubUser(ctx context.Context, user organisationsBootstrapUser) error {
 	masterID := user.ParentID
+	if user.LegacySelectionPresent {
+		r.report.SubUsers.Conflicted++
+		r.addConflict("legacy-user-selection-field", masterID.Hex(), user.ID.Hex(), "rename users.organisation_id to organisationId before bootstrap")
+		r.report.Verification.Failed++
+		return nil
+	}
 	targetSet := map[primitive.ObjectID]struct{}{masterID: {}}
 	ownedCursor, err := r.database.Collection("organisation").Find(ctx, bson.M{"ownerId": user.ID}, options.Find().SetProjection(bson.M{"_id": 1}))
 	if err != nil {
@@ -829,7 +837,7 @@ func (r *organisationsBootstrapRunner) processSubUser(ctx context.Context, user 
 	ownedCursor.Close(ctx)
 	if user.SelectionState == organisationsBootstrapFieldWrong {
 		r.report.SubUsers.Conflicted++
-		r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "organisation_id must be a BSON ObjectID")
+		r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "organisationId must be a BSON ObjectID")
 		r.report.Verification.Failed++
 		return nil
 	}
@@ -841,7 +849,7 @@ func (r *organisationsBootstrapRunner) processSubUser(ctx context.Context, user 
 		if !accessible {
 			r.report.SubUsers.Conflicted++
 			r.report.Users.MissingSelectedOrganisation++
-			r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "preserved organisation_id is missing or not owned by the master")
+			r.addConflict("invalid-user-selection", masterID.Hex(), user.ID.Hex(), "preserved organisationId is missing or not owned by the master")
 			r.report.Verification.Failed++
 			return nil
 		}

--- a/actions/organisations-bootstrap.go
+++ b/actions/organisations-bootstrap.go
@@ -1,0 +1,940 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/uug-ai/cli/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+const (
+	organisationsBootstrapExitOperational = 1
+	organisationsBootstrapExitData        = 2
+	organisationsBootstrapExitUsage       = 64
+)
+
+type OrganisationsBootstrapConfig struct {
+	Mode                       string
+	Stage                      string
+	MongoDBURI                 string
+	MongoDBHost                string
+	MongoDBPort                string
+	MongoDBSourceDatabase      string
+	MongoDBDestinationDatabase string
+	MongoDBDatabaseCredentials string
+	MongoDBUsername            string
+	MongoDBPassword            string
+	MigrationVersion           int
+	MigrationTimeoutMinutes    int
+	Username                   string
+	OrganisationID             string
+	BatchSize                  int
+	LegacyOrganisationPolicy   string
+	Resume                     bool
+	Restart                    bool
+	StopOnConflict             bool
+	ReportFile                 string
+}
+
+type organisationsBootstrapReport struct {
+	Mode             string                                   `json:"mode"`
+	Stage            string                                   `json:"stage"`
+	Database         string                                   `json:"database"`
+	Scope            string                                   `json:"scope"`
+	MigrationVersion int                                      `json:"migrationVersion"`
+	StartedAt        string                                   `json:"startedAt"`
+	CompletedAt      string                                   `json:"completedAt"`
+	Masters          organisationsBootstrapMasterCounts       `json:"masters"`
+	SubUsers         organisationsBootstrapSubUserCounts      `json:"subUsers"`
+	Users            organisationsBootstrapUserCounts         `json:"users"`
+	Memberships      organisationsBootstrapMembershipCounts   `json:"memberships"`
+	Organisations    organisationsBootstrapOrganisationCounts `json:"organisations"`
+	Domains          organisationsBootstrapDomainCounts       `json:"domains"`
+	Writes           organisationsBootstrapWriteCounts        `json:"writes"`
+	Verification     organisationsBootstrapVerificationCounts `json:"verification"`
+	Indexes          organisationsBootstrapIndexStatus        `json:"indexes"`
+	Checkpoint       organisationsBootstrapCheckpoint         `json:"checkpoint"`
+	Conflicts        []organisationsBootstrapConflict         `json:"conflicts"`
+	Warnings         []organisationsBootstrapWarning          `json:"warnings"`
+}
+
+type organisationsBootstrapMasterCounts struct {
+	Scanned          int64 `json:"scanned"`
+	Planned          int64 `json:"planned"`
+	AlreadyCanonical int64 `json:"alreadyCanonical"`
+	Inserted         int64 `json:"inserted"`
+	Canonicalized    int64 `json:"canonicalized"`
+	Conflicted       int64 `json:"conflicted"`
+}
+
+type organisationsBootstrapSubUserCounts struct {
+	Scanned         int64 `json:"scanned"`
+	Planned         int64 `json:"planned"`
+	Updated         int64 `json:"updated"`
+	AlreadySelected int64 `json:"alreadySelected"`
+	Orphaned        int64 `json:"orphaned"`
+	Conflicted      int64 `json:"conflicted"`
+}
+
+type organisationsBootstrapUserCounts struct {
+	MastersUpdated              int64 `json:"mastersUpdated"`
+	SelectionsPreserved         int64 `json:"selectionsPreserved"`
+	MissingSelectedOrganisation int64 `json:"missingSelectedOrganisation"`
+}
+
+type organisationsBootstrapMembershipCounts struct {
+	Planned        int64 `json:"planned"`
+	Inserted       int64 `json:"inserted"`
+	AlreadyPresent int64 `json:"alreadyPresent"`
+	Reconciled     int64 `json:"reconciled"`
+	Conflicted     int64 `json:"conflicted"`
+}
+
+type organisationsBootstrapOrganisationCounts struct {
+	SecondaryOwned  int64 `json:"secondaryOwned"`
+	LegacyReported  int64 `json:"legacyReported"`
+	LegacyAmbiguous int64 `json:"legacyAmbiguous"`
+	Archived        int64 `json:"archived"`
+	Deleted         int64 `json:"deleted"`
+	Referenced      int64 `json:"referenced"`
+}
+
+type organisationsBootstrapDomainCounts struct {
+	NonEmpty          int64 `json:"nonEmpty"`
+	Distinct          int64 `json:"distinct"`
+	MultipleMasters   int64 `json:"multipleMasters"`
+	SubUserMismatches int64 `json:"subUserMismatches"`
+}
+
+type organisationsBootstrapWriteCounts struct {
+	Attempted  int64 `json:"attempted"`
+	Applied    int64 `json:"applied"`
+	Reconciled int64 `json:"reconciled"`
+	Failed     int64 `json:"failed"`
+}
+
+type organisationsBootstrapVerificationCounts struct {
+	Passed int64 `json:"passed"`
+	Failed int64 `json:"failed"`
+}
+
+type organisationsBootstrapIndexStatus struct {
+	OrganisationOwner      bool `json:"organisationOwner"`
+	OrganisationSlugUnique bool `json:"organisationSlugUnique"`
+	MembershipUnique       bool `json:"membershipUnique"`
+	MembershipStatus       bool `json:"membershipStatus"`
+}
+
+type organisationsBootstrapCheckpoint struct {
+	ID                   string `json:"id"`
+	LastVerifiedMasterID string `json:"lastVerifiedMasterId,omitempty"`
+	Status               string `json:"status"`
+}
+
+type organisationsBootstrapConflict struct {
+	Code       string `json:"code"`
+	MasterID   string `json:"masterId,omitempty"`
+	DocumentID string `json:"documentId,omitempty"`
+	Message    string `json:"message"`
+}
+
+type organisationsBootstrapWarning struct {
+	Code       string `json:"code"`
+	MasterID   string `json:"masterId,omitempty"`
+	DocumentID string `json:"documentId,omitempty"`
+	Message    string `json:"message"`
+}
+
+type organisationsBootstrapRunner struct {
+	config                OrganisationsBootstrapConfig
+	database              *mongo.Database
+	now                   time.Time
+	report                *organisationsBootstrapReport
+	strict                bool
+	hasConflict           bool
+	conflictCount         int64
+	checkpointAcquired    bool
+	checkpointLeaseOwner  string
+	checkpointLeaseExpiry time.Time
+	checkpointLastMaster  primitive.ObjectID
+}
+
+type organisationsBootstrapError struct {
+	code int
+	err  error
+}
+
+func (e *organisationsBootstrapError) Error() string {
+	return e.err.Error()
+}
+
+func (e *organisationsBootstrapError) Unwrap() error {
+	return e.err
+}
+
+func OrganisationsBootstrapExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var bootstrapError *organisationsBootstrapError
+	if errors.As(err, &bootstrapError) {
+		return bootstrapError.code
+	}
+	return organisationsBootstrapExitOperational
+}
+
+func OrganisationsBootstrap(config OrganisationsBootstrapConfig) error {
+	config = normalizeOrganisationsBootstrapConfig(config)
+	if err := validateOrganisationsBootstrapConfig(config); err != nil {
+		return &organisationsBootstrapError{code: organisationsBootstrapExitUsage, err: err}
+	}
+
+	signalContext, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+	ctx := signalContext
+	cancel := func() {}
+	if config.MigrationTimeoutMinutes > 0 {
+		ctx, cancel = context.WithTimeout(signalContext, time.Duration(config.MigrationTimeoutMinutes)*time.Minute)
+	}
+	defer cancel()
+
+	var connection *database.DB
+	if config.MongoDBURI != "" {
+		connection = database.NewMongoDBURI(config.MongoDBURI)
+	} else {
+		connection = database.NewMongoDBHost(
+			config.MongoDBHost,
+			config.MongoDBPort,
+			config.MongoDBDatabaseCredentials,
+			config.MongoDBUsername,
+			config.MongoDBPassword,
+		)
+	}
+	client := connection.Client
+	defer client.Disconnect(context.Background())
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: fmt.Errorf("MongoDB bootstrap preflight failed: %w", err)}
+	}
+
+	hubDatabase := client.Database(config.MongoDBDestinationDatabase)
+	for _, collection := range []string{"users", "organisation", "organisation_users"} {
+		if _, err := hubDatabase.Collection(collection).EstimatedDocumentCount(ctx); err != nil {
+			return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: fmt.Errorf("cannot read %s: %w", collection, err)}
+		}
+	}
+
+	startedAt := time.Now().UTC()
+	report := organisationsBootstrapReport{
+		Mode:             config.Mode,
+		Stage:            config.Stage,
+		Database:         config.MongoDBDestinationDatabase,
+		Scope:            organisationsBootstrapScope(config),
+		MigrationVersion: config.MigrationVersion,
+		StartedAt:        startedAt.Format(time.RFC3339),
+		Checkpoint: organisationsBootstrapCheckpoint{
+			ID:     organisationsBootstrapCheckpointID(config),
+			Status: "not-written",
+		},
+	}
+	runner := organisationsBootstrapRunner{
+		config:   config,
+		database: hubDatabase,
+		now:      startedAt,
+		report:   &report,
+		strict:   config.Stage == "verify",
+	}
+
+	if err := runner.inspectDomains(ctx); err != nil {
+		var bootstrapError *organisationsBootstrapError
+		if errors.As(err, &bootstrapError) {
+			return bootstrapError
+		}
+		return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: fmt.Errorf("inspect bootstrap domains: %w", err)}
+	}
+	if err := runner.inspectIndexes(ctx); err != nil {
+		return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: fmt.Errorf("inspect bootstrap indexes: %w", err)}
+	}
+	if config.Mode == "live" && (!report.Indexes.OrganisationOwner || !report.Indexes.OrganisationSlugUnique || !report.Indexes.MembershipUnique || !report.Indexes.MembershipStatus) {
+		runner.addConflict("bootstrap-index-missing", "", "", "live bootstrap requires the canonical organisation and organisation_users indexes")
+	}
+	if !runner.hasConflict {
+		if err := runner.acquireCheckpoint(ctx); err != nil {
+			var bootstrapError *organisationsBootstrapError
+			if errors.As(err, &bootstrapError) {
+				return bootstrapError
+			}
+			return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: err}
+		}
+	}
+
+	var runErr error
+	if !runner.hasConflict {
+		switch config.Stage {
+		case "owners":
+			runErr = runner.runOwners(ctx)
+		case "sub-users":
+			runErr = runner.runSubUsers(ctx)
+		case "verify":
+			if runErr = runner.runOwners(ctx); runErr == nil && (!runner.hasConflict || !config.StopOnConflict) {
+				runErr = runner.runSubUsers(ctx)
+			}
+		}
+	}
+	if runErr != nil {
+		if checkpointErr := runner.finishCheckpoint("failed"); checkpointErr != nil {
+			runErr = errors.Join(runErr, checkpointErr)
+		}
+		report.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		if reportErr := writeOrganisationsBootstrapReport(report, config.ReportFile); reportErr != nil {
+			runErr = errors.Join(runErr, reportErr)
+		}
+		var bootstrapError *organisationsBootstrapError
+		if errors.As(runErr, &bootstrapError) {
+			return bootstrapError
+		}
+		return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: runErr}
+	}
+	checkpointStatus := "completed"
+	if runner.hasConflict {
+		checkpointStatus = "blocked"
+	}
+	if err := runner.finishCheckpoint(checkpointStatus); err != nil {
+		return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: err}
+	}
+
+	report.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := writeOrganisationsBootstrapReport(report, config.ReportFile); err != nil {
+		return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: err}
+	}
+	if runner.hasConflict {
+		return &organisationsBootstrapError{code: organisationsBootstrapExitData, err: errors.New("bootstrap found identity conflicts or failed verification")}
+	}
+	return nil
+}
+
+func normalizeOrganisationsBootstrapConfig(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+	config.Mode = strings.ToLower(strings.TrimSpace(config.Mode))
+	if config.Mode == "" {
+		config.Mode = "dry-run"
+	}
+	config.Stage = strings.ToLower(strings.TrimSpace(config.Stage))
+	config.MongoDBURI = strings.TrimSpace(config.MongoDBURI)
+	config.MongoDBHost = strings.TrimSpace(config.MongoDBHost)
+	config.MongoDBDestinationDatabase = strings.TrimSpace(config.MongoDBDestinationDatabase)
+	if config.MongoDBDestinationDatabase == "" {
+		config.MongoDBDestinationDatabase = strings.TrimSpace(config.MongoDBSourceDatabase)
+	}
+	config.Username = strings.TrimSpace(config.Username)
+	config.OrganisationID = strings.TrimSpace(config.OrganisationID)
+	config.ReportFile = strings.TrimSpace(config.ReportFile)
+	config.LegacyOrganisationPolicy = strings.ToLower(strings.TrimSpace(config.LegacyOrganisationPolicy))
+	if config.LegacyOrganisationPolicy == "" {
+		config.LegacyOrganisationPolicy = "report"
+	}
+	if config.MigrationVersion == 0 {
+		config.MigrationVersion = 1
+	}
+	if config.BatchSize == 0 {
+		config.BatchSize = 500
+	}
+	return config
+}
+
+func validateOrganisationsBootstrapConfig(config OrganisationsBootstrapConfig) error {
+	if config.Mode != "dry-run" && config.Mode != "live" {
+		return fmt.Errorf("mode must be dry-run or live, got %q", config.Mode)
+	}
+	switch config.Stage {
+	case "owners", "sub-users":
+	case "verify":
+		if config.Mode == "live" {
+			return errors.New("verify is read-only and requires -mode dry-run")
+		}
+	default:
+		return fmt.Errorf("stage must be owners, sub-users, or verify, got %q", config.Stage)
+	}
+	if config.MongoDBDestinationDatabase == "" || strings.HasPrefix(config.MongoDBDestinationDatabase, "-") {
+		return errors.New("an explicit MongoDB source or destination database is required")
+	}
+	if config.MongoDBURI == "" && config.MongoDBHost == "" {
+		return errors.New("provide -mongodb-uri or -mongodb-host")
+	}
+	if config.MigrationVersion != 1 {
+		return fmt.Errorf("unsupported migration version %d", config.MigrationVersion)
+	}
+	if config.BatchSize <= 0 {
+		return errors.New("bootstrap-batch-size must be greater than zero")
+	}
+	if config.LegacyOrganisationPolicy != "report" {
+		if config.LegacyOrganisationPolicy == "archive-delete" {
+			return errors.New("legacy-org-policy archive-delete is disabled until guarded archive and reference checks are implemented")
+		}
+		return fmt.Errorf("legacy-org-policy must be report or archive-delete, got %q", config.LegacyOrganisationPolicy)
+	}
+	if config.Username != "" && config.OrganisationID != "" {
+		return errors.New("-username and -organisation-id are mutually exclusive")
+	}
+	if config.OrganisationID != "" {
+		if _, err := primitive.ObjectIDFromHex(config.OrganisationID); err != nil {
+			return fmt.Errorf("invalid organisation-id: %w", err)
+		}
+	}
+	if config.Resume && config.Restart {
+		return errors.New("-resume and -restart are mutually exclusive")
+	}
+	if (config.Resume || config.Restart) && config.Mode != "live" {
+		return errors.New("-resume and -restart require -mode live")
+	}
+	return nil
+}
+
+func organisationsBootstrapScope(config OrganisationsBootstrapConfig) string {
+	if config.OrganisationID != "" {
+		return config.OrganisationID
+	}
+	if config.Username != "" {
+		return "username:" + config.Username
+	}
+	return "all"
+}
+
+func organisationsBootstrapCheckpointID(config OrganisationsBootstrapConfig) string {
+	return fmt.Sprintf(
+		"organisations-bootstrap:v%d:%s:%s:%s",
+		config.MigrationVersion,
+		config.MongoDBDestinationDatabase,
+		config.Stage,
+		organisationsBootstrapScope(config),
+	)
+}
+
+func (r *organisationsBootstrapRunner) addConflict(code, masterID, documentID, message string) {
+	r.hasConflict = true
+	r.conflictCount++
+	if len(r.report.Conflicts) < 100 {
+		r.report.Conflicts = append(r.report.Conflicts, organisationsBootstrapConflict{
+			Code:       code,
+			MasterID:   masterID,
+			DocumentID: documentID,
+			Message:    message,
+		})
+	}
+}
+
+func (r *organisationsBootstrapRunner) addWarning(code, masterID, documentID, message string) {
+	if len(r.report.Warnings) < 100 {
+		r.report.Warnings = append(r.report.Warnings, organisationsBootstrapWarning{
+			Code:       code,
+			MasterID:   masterID,
+			DocumentID: documentID,
+			Message:    message,
+		})
+	}
+}
+
+func (r *organisationsBootstrapRunner) inspectDomains(ctx context.Context) error {
+	filter, err := r.masterFilter(ctx)
+	if err != nil {
+		return err
+	}
+	cursor, err := r.database.Collection("users").Find(ctx, filter, options.Find().SetProjection(bson.M{
+		"_id":    1,
+		"domain": 1,
+	}))
+	if err != nil {
+		return err
+	}
+	defer cursor.Close(ctx)
+
+	masterDomains := map[primitive.ObjectID]string{}
+	domainMasters := map[string]int64{}
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return err
+		}
+		masterID, state := organisationsBootstrapObjectID(document, "_id")
+		if state != organisationsBootstrapFieldValue {
+			continue
+		}
+		domain, domainState := organisationsBootstrapString(document, "domain")
+		if domainState == organisationsBootstrapFieldWrong {
+			domain = ""
+		}
+		masterDomains[masterID] = domain
+		if domain != "" {
+			r.report.Domains.NonEmpty++
+			domainMasters[domain]++
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		return err
+	}
+	r.report.Domains.Distinct = int64(len(domainMasters))
+	for _, count := range domainMasters {
+		if count > 1 {
+			r.report.Domains.MultipleMasters++
+		}
+	}
+	if len(masterDomains) == 0 {
+		return nil
+	}
+
+	subUserFilter := bson.M{"user_id": bson.M{"$exists": true, "$nin": bson.A{nil, ""}}}
+	if len(masterDomains) == 1 {
+		for masterID := range masterDomains {
+			subUserFilter["user_id"] = masterID.Hex()
+		}
+	}
+	subUsers, err := r.database.Collection("users").Find(ctx, subUserFilter, options.Find().SetProjection(bson.M{
+		"_id":     1,
+		"user_id": 1,
+		"domain":  1,
+	}))
+	if err != nil {
+		return err
+	}
+	defer subUsers.Close(ctx)
+	for subUsers.Next(ctx) {
+		var document bson.Raw
+		if err := subUsers.Decode(&document); err != nil {
+			return err
+		}
+		subUser, parseErr := parseOrganisationsBootstrapUser(document)
+		if parseErr != nil || subUser.ParentState != organisationsBootstrapFieldValue {
+			continue
+		}
+		masterDomain, exists := masterDomains[subUser.ParentID]
+		if !exists || subUser.Domain == masterDomain {
+			continue
+		}
+		r.report.Domains.SubUserMismatches++
+		r.addWarning("sub-user-domain-mismatch", subUser.ParentID.Hex(), subUser.ID.Hex(), "sub-user login domain differs from its master; user_id remains authoritative")
+	}
+	return subUsers.Err()
+}
+
+func (r *organisationsBootstrapRunner) inspectIndexes(ctx context.Context) error {
+	organisationIndexes, err := readOrganisationsBootstrapIndexes(ctx, r.database.Collection("organisation"))
+	if err != nil {
+		return err
+	}
+	membershipIndexes, err := readOrganisationsBootstrapIndexes(ctx, r.database.Collection("organisation_users"))
+	if err != nil {
+		return err
+	}
+	r.report.Indexes.OrganisationOwner = organisationsBootstrapHasIndex(organisationIndexes, bson.D{{Key: "ownerId", Value: int32(1)}}, false)
+	r.report.Indexes.OrganisationSlugUnique = organisationsBootstrapHasSlugIndex(organisationIndexes)
+	r.report.Indexes.MembershipUnique = organisationsBootstrapHasIndex(membershipIndexes, bson.D{{Key: "userId", Value: int32(1)}, {Key: "organisationId", Value: int32(1)}}, true)
+	r.report.Indexes.MembershipStatus = organisationsBootstrapHasIndex(membershipIndexes, bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "status", Value: int32(1)}}, false)
+	return nil
+}
+
+func readOrganisationsBootstrapIndexes(ctx context.Context, collection *mongo.Collection) ([]bson.M, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []bson.M
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	return indexes, nil
+}
+
+func organisationsBootstrapHasIndex(indexes []bson.M, expected bson.D, unique bool) bool {
+	for _, index := range indexes {
+		key, ok := index["key"].(bson.D)
+		if !ok || len(key) != len(expected) {
+			continue
+		}
+		matches := true
+		for position := range expected {
+			if key[position].Key != expected[position].Key || fmt.Sprint(key[position].Value) != fmt.Sprint(expected[position].Value) {
+				matches = false
+				break
+			}
+		}
+		if !matches {
+			continue
+		}
+		isUnique, _ := index["unique"].(bool)
+		if !unique || isUnique {
+			return true
+		}
+	}
+	return false
+}
+
+func organisationsBootstrapHasSlugIndex(indexes []bson.M) bool {
+	for _, index := range indexes {
+		if !organisationsBootstrapHasIndex([]bson.M{index}, bson.D{{Key: "slug", Value: int32(1)}}, true) {
+			continue
+		}
+		partial, ok := index["partialFilterExpression"].(bson.M)
+		if !ok {
+			continue
+		}
+		slug, ok := partial["slug"].(bson.M)
+		if ok && slug["$type"] == "string" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeOrganisationsBootstrapReport(report organisationsBootstrapReport, reportFile string) error {
+	output, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap report: %w", err)
+	}
+	fmt.Println(string(output))
+	if reportFile == "" {
+		return nil
+	}
+	if err := os.WriteFile(reportFile, append(output, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write bootstrap report: %w", err)
+	}
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) masterFilter(ctx context.Context) (bson.M, error) {
+	filter := bson.M{"$or": bson.A{
+		bson.M{"user_id": bson.M{"$exists": false}},
+		bson.M{"user_id": nil},
+		bson.M{"user_id": ""},
+	}}
+	if r.config.OrganisationID != "" {
+		id, _ := primitive.ObjectIDFromHex(r.config.OrganisationID)
+		filter["_id"] = id
+		return filter, nil
+	}
+	if r.config.Username == "" {
+		return filter, nil
+	}
+	filter["username"] = r.config.Username
+	count, err := r.database.Collection("users").CountDocuments(ctx, filter, options.Count().SetLimit(2))
+	if err != nil {
+		return nil, err
+	}
+	if count != 1 {
+		return nil, &organisationsBootstrapError{code: organisationsBootstrapExitData, err: fmt.Errorf("username scope resolves to %d master users", count)}
+	}
+	return filter, nil
+}
+
+func (r *organisationsBootstrapRunner) scopedMasterID(ctx context.Context) (primitive.ObjectID, bool, error) {
+	if r.config.OrganisationID != "" {
+		id, _ := primitive.ObjectIDFromHex(r.config.OrganisationID)
+		return id, true, nil
+	}
+	if r.config.Username == "" {
+		return primitive.NilObjectID, false, nil
+	}
+	filter, err := r.masterFilter(ctx)
+	if err != nil {
+		return primitive.NilObjectID, false, err
+	}
+	var document struct {
+		ID primitive.ObjectID `bson:"_id"`
+	}
+	if err := r.database.Collection("users").FindOne(ctx, filter).Decode(&document); err != nil {
+		return primitive.NilObjectID, false, err
+	}
+	return document.ID, true, nil
+}
+
+func (r *organisationsBootstrapRunner) runOwners(ctx context.Context) error {
+	filter, err := r.masterFilter(ctx)
+	if err != nil {
+		return err
+	}
+	filter = organisationsBootstrapResumeFilter(filter, r.checkpointLastMaster)
+	cursor, err := r.database.Collection("users").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}).SetBatchSize(int32(r.config.BatchSize)))
+	if err != nil {
+		return err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		if err := r.renewCheckpoint(ctx); err != nil {
+			return err
+		}
+		user, parseErr := parseOrganisationsBootstrapUser(cursor.Current)
+		if parseErr != nil {
+			r.addConflict("invalid-master", "", "", parseErr.Error())
+			r.report.Masters.Conflicted++
+			if r.config.StopOnConflict {
+				break
+			}
+			continue
+		}
+		r.report.Masters.Scanned++
+		conflictsBefore := r.conflictCount
+		verifiedBefore := r.report.Verification.Passed
+		if processErr := r.processOwner(ctx, user); processErr != nil {
+			return processErr
+		}
+		if conflictsBefore == r.conflictCount && verifiedBefore < r.report.Verification.Passed && !r.hasConflict {
+			if checkpointErr := r.advanceCheckpoint(ctx, user.ID); checkpointErr != nil {
+				return checkpointErr
+			}
+		}
+		if r.hasConflict && r.config.StopOnConflict {
+			break
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		return err
+	}
+	if r.report.Masters.Scanned == 0 && r.checkpointLastMaster.IsZero() && (r.config.Username != "" || r.config.OrganisationID != "") {
+		r.addConflict("master-scope-not-found", "", "", "the requested scope does not resolve to a master user")
+	}
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) processOwner(ctx context.Context, user organisationsBootstrapUser) error {
+	masterID := user.ID.Hex()
+	if user.ParentState != organisationsBootstrapFieldEmpty {
+		r.addConflict("invalid-master", masterID, masterID, "master user has a non-empty user_id")
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	if user.Username == "" {
+		r.addConflict("missing-master-username", masterID, masterID, "master user has no username for the canonical organisation name")
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	legacyCandidates, legacyInvalid, err := r.legacyOrganisationCandidates(ctx, user.ID, true)
+	if err != nil {
+		return err
+	}
+	if legacyInvalid {
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	if len(legacyCandidates) > 1 {
+		r.report.Organisations.LegacyAmbiguous += int64(len(legacyCandidates))
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		r.addConflict("legacy-organisations-ambiguous", masterID, "", "multiple random-id legacy organisations reference this master")
+		return nil
+	}
+	if len(legacyCandidates) == 1 {
+		candidate := legacyCandidates[0]
+		user.OrganisationName = candidate.Name
+		user.OrganisationCreatedAt = candidate.CreatedAt
+		user.OrganisationUpdatedAt = candidate.UpdatedAt
+		r.report.Organisations.LegacyReported++
+		r.report.Masters.Conflicted++
+		r.addConflict("legacy-organisation-unresolved", masterID, "", "a random-id legacy organisation remains for operator review")
+		if r.config.StopOnConflict {
+			r.report.Verification.Failed++
+			return nil
+		}
+	}
+
+	canonicalReady, changed, err := r.ensureCanonicalOrganisation(ctx, user)
+	if err != nil {
+		return err
+	}
+	if !canonicalReady {
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	if changed {
+		r.report.Masters.Planned++
+	} else {
+		r.report.Masters.AlreadyCanonical++
+	}
+
+	targets, err := r.ownerMembershipTargets(ctx, user)
+	if err != nil {
+		return err
+	}
+	if targets == nil {
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	for _, organisationID := range targets {
+		if ok, ensureErr := r.ensureMembership(ctx, user.ID, organisationID, user.ID); ensureErr != nil {
+			return ensureErr
+		} else if !ok {
+			r.report.Masters.Conflicted++
+			r.report.Verification.Failed++
+			return nil
+		}
+	}
+
+	selectionOK, updated, err := r.ensureUserSelection(ctx, user, user.ID, user.ID)
+	if err != nil {
+		return err
+	}
+	if !selectionOK {
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	if updated {
+		r.report.Users.MastersUpdated++
+	}
+	r.report.Verification.Passed++
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) ensureCanonicalOrganisation(ctx context.Context, user organisationsBootstrapUser) (bool, bool, error) {
+	collection := r.database.Collection("organisation")
+	var stored bson.Raw
+	err := collection.FindOne(ctx, bson.M{"_id": user.ID}).Decode(&stored)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		if r.strict {
+			r.addConflict("canonical-organisation-missing", user.ID.Hex(), user.ID.Hex(), "canonical organisation is missing")
+			return false, true, nil
+		}
+		if r.config.Mode == "dry-run" {
+			return true, true, nil
+		}
+		document := organisationsBootstrapOrganisationDocument(user, r.now)
+		r.report.Writes.Attempted++
+		result, writeErr := collection.UpdateOne(ctx, bson.M{"_id": user.ID}, bson.M{"$setOnInsert": document}, options.Update().SetUpsert(true))
+		if writeErr != nil {
+			r.report.Writes.Failed++
+			return false, true, writeErr
+		}
+		if result.UpsertedCount == 1 {
+			r.report.Writes.Applied++
+			r.report.Masters.Inserted++
+		}
+		return r.reconcileCanonicalOrganisation(ctx, user, true)
+	}
+	if err != nil {
+		return false, false, err
+	}
+	if !organisationsBootstrapContainerValid(stored, "audit") || (user.Timezone != "" && !organisationsBootstrapContainerValid(stored, "settings")) {
+		r.addConflict("canonical-organisation-invalid", user.ID.Hex(), user.ID.Hex(), "organisation audit or settings has an incompatible BSON type")
+		return false, false, nil
+	}
+	if !organisationsBootstrapExistingOrganisationTypesValid(stored, user.Timezone != "") {
+		r.addConflict("canonical-organisation-invalid", user.ID.Hex(), user.ID.Hex(), "organisation has an incompatible canonical field type")
+		return false, false, nil
+	}
+
+	ownerID, ownerState := organisationsBootstrapObjectID(stored, "ownerId")
+	legacyOwner, legacyState := organisationsBootstrapString(stored, "owner_id")
+	if ownerState == organisationsBootstrapFieldValue && ownerID != user.ID {
+		r.addConflict("canonical-owner-conflict", user.ID.Hex(), user.ID.Hex(), "organisation at bootstrap id is owned by another principal")
+		return false, false, nil
+	}
+	if ownerState == organisationsBootstrapFieldWrong || (legacyState == organisationsBootstrapFieldValue && legacyOwner != user.ID.Hex()) || legacyState == organisationsBootstrapFieldWrong {
+		r.addConflict("canonical-owner-invalid", user.ID.Hex(), user.ID.Hex(), "organisation at bootstrap id has an invalid canonical or legacy owner")
+		return false, false, nil
+	}
+
+	set := organisationsBootstrapMissingOrganisationFields(stored, user, r.now)
+	if len(set) == 0 {
+		return true, false, nil
+	}
+	if r.strict {
+		r.addConflict("canonical-organisation-incomplete", user.ID.Hex(), user.ID.Hex(), "canonical organisation is missing required bootstrap fields")
+		return false, true, nil
+	}
+	if r.config.Mode == "dry-run" {
+		return true, true, nil
+	}
+	for _, field := range sortedOrganisationsBootstrapFields(set) {
+		r.report.Writes.Attempted++
+		result, writeErr := collection.UpdateOne(ctx, organisationsBootstrapMissingFieldFilter(user.ID, field), bson.M{"$set": bson.M{field: set[field]}})
+		if writeErr != nil {
+			r.report.Writes.Failed++
+			return false, true, writeErr
+		}
+		if result.ModifiedCount == 1 {
+			r.report.Writes.Applied++
+		}
+	}
+	r.report.Masters.Canonicalized++
+	return r.reconcileCanonicalOrganisation(ctx, user, true)
+}
+
+func (r *organisationsBootstrapRunner) reconcileCanonicalOrganisation(ctx context.Context, user organisationsBootstrapUser, changed bool) (bool, bool, error) {
+	var stored bson.Raw
+	if err := r.database.Collection("organisation").FindOne(ctx, bson.M{"_id": user.ID}).Decode(&stored); err != nil {
+		return false, changed, err
+	}
+	ownerID, state := organisationsBootstrapObjectID(stored, "ownerId")
+	if state != organisationsBootstrapFieldValue || ownerID != user.ID || len(organisationsBootstrapMissingOrganisationFields(stored, user, r.now)) != 0 || !organisationsBootstrapOrganisationFieldsValid(stored, user.Timezone != "") {
+		r.addConflict("canonical-reconcile-failed", user.ID.Hex(), user.ID.Hex(), "canonical organisation did not reconcile to the required identity fields")
+		return false, changed, nil
+	}
+	if changed {
+		r.report.Writes.Reconciled++
+	}
+	return true, changed, nil
+}
+
+func (r *organisationsBootstrapRunner) ownerMembershipTargets(ctx context.Context, user organisationsBootstrapUser) ([]primitive.ObjectID, error) {
+	targets := map[primitive.ObjectID]struct{}{user.ID: {}}
+	cursor, err := r.database.Collection("organisation").Find(ctx, bson.M{"ownerId": user.ID}, options.Find().SetProjection(bson.M{"_id": 1}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var organisation struct {
+			ID primitive.ObjectID `bson:"_id"`
+		}
+		if err := cursor.Decode(&organisation); err != nil {
+			return nil, err
+		}
+		if organisation.ID != user.ID {
+			r.report.Organisations.SecondaryOwned++
+		}
+		targets[organisation.ID] = struct{}{}
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+
+	if user.SelectionState == organisationsBootstrapFieldWrong {
+		r.addConflict("invalid-user-selection", user.ID.Hex(), user.ID.Hex(), "organisation_id must be a BSON ObjectID")
+		return nil, nil
+	}
+	if user.SelectionState == organisationsBootstrapFieldValue {
+		accessible, accessErr := r.organisationAccessibleToUser(ctx, user.Selection, user.ID, user.ID)
+		if accessErr != nil {
+			return nil, accessErr
+		}
+		if !accessible {
+			r.report.Users.MissingSelectedOrganisation++
+			r.addConflict("invalid-user-selection", user.ID.Hex(), user.ID.Hex(), "preserved organisation_id does not reference an organisation owned by the master")
+			return nil, nil
+		}
+		targets[user.Selection] = struct{}{}
+		r.report.Users.SelectionsPreserved++
+	}
+
+	ids := make([]primitive.ObjectID, 0, len(targets))
+	for id := range targets {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(left, right int) bool { return ids[left].Hex() < ids[right].Hex() })
+	return ids, nil
+}

--- a/actions/organisations-bootstrap.go
+++ b/actions/organisations-bootstrap.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -163,9 +164,11 @@ type organisationsBootstrapRunner struct {
 	database              *mongo.Database
 	now                   time.Time
 	report                *organisationsBootstrapReport
+	stopRequested         <-chan struct{}
 	strict                bool
 	hasConflict           bool
 	conflictCount         int64
+	blockingConflictCount int64
 	checkpointAcquired    bool
 	checkpointLeaseOwner  string
 	checkpointLeaseExpiry time.Time
@@ -176,6 +179,8 @@ type organisationsBootstrapError struct {
 	code int
 	err  error
 }
+
+var errOrganisationsBootstrapInterrupted = errors.New("bootstrap interrupted")
 
 func (e *organisationsBootstrapError) Error() string {
 	return e.err.Error()
@@ -204,10 +209,10 @@ func OrganisationsBootstrap(config OrganisationsBootstrapConfig) error {
 
 	signalContext, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignals()
-	ctx := signalContext
+	ctx := context.Background()
 	cancel := func() {}
 	if config.MigrationTimeoutMinutes > 0 {
-		ctx, cancel = context.WithTimeout(signalContext, time.Duration(config.MigrationTimeoutMinutes)*time.Minute)
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(config.MigrationTimeoutMinutes)*time.Minute)
 	}
 	defer cancel()
 
@@ -250,11 +255,12 @@ func OrganisationsBootstrap(config OrganisationsBootstrapConfig) error {
 		},
 	}
 	runner := organisationsBootstrapRunner{
-		config:   config,
-		database: hubDatabase,
-		now:      startedAt,
-		report:   &report,
-		strict:   config.Stage == "verify",
+		config:        config,
+		database:      hubDatabase,
+		now:           startedAt,
+		report:        &report,
+		stopRequested: signalContext.Done(),
+		strict:        config.Stage == "verify",
 	}
 
 	if err := runner.inspectDomains(ctx); err != nil {
@@ -270,7 +276,12 @@ func OrganisationsBootstrap(config OrganisationsBootstrapConfig) error {
 	if config.Mode == "live" && (!report.Indexes.OrganisationOwner || !report.Indexes.OrganisationSlugUnique || !report.Indexes.MembershipUnique || !report.Indexes.MembershipStatus) {
 		runner.addConflict("bootstrap-index-missing", "", "", "live bootstrap requires the canonical organisation and organisation_users indexes")
 	}
-	if !runner.hasConflict {
+	if config.Mode == "live" && runner.blockingConflictCount == 0 && !runner.interrupted() {
+		if err := runner.preflightStage(ctx); err != nil {
+			return &organisationsBootstrapError{code: organisationsBootstrapExitOperational, err: fmt.Errorf("bootstrap stage preflight failed: %w", err)}
+		}
+	}
+	if runner.blockingConflictCount == 0 && !runner.interrupted() {
 		if err := runner.acquireCheckpoint(ctx); err != nil {
 			var bootstrapError *organisationsBootstrapError
 			if errors.As(err, &bootstrapError) {
@@ -281,17 +292,18 @@ func OrganisationsBootstrap(config OrganisationsBootstrapConfig) error {
 	}
 
 	var runErr error
-	if !runner.hasConflict {
-		switch config.Stage {
-		case "owners":
-			runErr = runner.runOwners(ctx)
-		case "sub-users":
-			runErr = runner.runSubUsers(ctx)
-		case "verify":
-			if runErr = runner.runOwners(ctx); runErr == nil && (!runner.hasConflict || !config.StopOnConflict) {
-				runErr = runner.runSubUsers(ctx)
+	if runner.interrupted() {
+		runErr = errOrganisationsBootstrapInterrupted
+	} else if runner.blockingConflictCount == 0 {
+		runErr = runner.withCheckpointHeartbeat(ctx, func(stageContext context.Context) error {
+			if err := runner.runStage(stageContext); err != nil {
+				return err
 			}
-		}
+			if config.Mode == "live" {
+				return runner.verifyStageFresh()
+			}
+			return nil
+		})
 	}
 	if runErr != nil {
 		if checkpointErr := runner.finishCheckpoint("failed"); checkpointErr != nil {
@@ -424,6 +436,9 @@ func organisationsBootstrapCheckpointID(config OrganisationsBootstrapConfig) str
 func (r *organisationsBootstrapRunner) addConflict(code, masterID, documentID, message string) {
 	r.hasConflict = true
 	r.conflictCount++
+	if organisationsBootstrapConflictBlocks(code) {
+		r.blockingConflictCount++
+	}
 	if len(r.report.Conflicts) < 100 {
 		r.report.Conflicts = append(r.report.Conflicts, organisationsBootstrapConflict{
 			Code:       code,
@@ -432,6 +447,10 @@ func (r *organisationsBootstrapRunner) addConflict(code, masterID, documentID, m
 			Message:    message,
 		})
 	}
+}
+
+func organisationsBootstrapConflictBlocks(code string) bool {
+	return code != "legacy-organisation-unresolved"
 }
 
 func (r *organisationsBootstrapRunner) addWarning(code, masterID, documentID, message string) {
@@ -443,6 +462,108 @@ func (r *organisationsBootstrapRunner) addWarning(code, masterID, documentID, me
 			Message:    message,
 		})
 	}
+}
+
+func (r *organisationsBootstrapRunner) interrupted() bool {
+	if r.stopRequested == nil {
+		return false
+	}
+	select {
+	case <-r.stopRequested:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *organisationsBootstrapRunner) runStage(ctx context.Context) error {
+	switch r.config.Stage {
+	case "owners":
+		return r.runOwners(ctx)
+	case "sub-users":
+		return r.runSubUsers(ctx)
+	case "verify":
+		if err := r.runOwners(ctx); err != nil || (r.hasConflict && r.config.StopOnConflict) {
+			return err
+		}
+		return r.runSubUsers(ctx)
+	default:
+		return nil
+	}
+}
+
+func (r *organisationsBootstrapRunner) preflightStage(ctx context.Context) error {
+	preflightConfig := r.config
+	preflightConfig.Mode = "dry-run"
+	preflightConfig.Resume = false
+	preflightConfig.Restart = false
+	preflightConfig.StopOnConflict = false
+	preflightReport := organisationsBootstrapReport{}
+	preflight := organisationsBootstrapRunner{
+		config:        preflightConfig,
+		database:      r.database,
+		now:           r.now,
+		report:        &preflightReport,
+		stopRequested: r.stopRequested,
+	}
+	if err := preflight.runStage(ctx); err != nil {
+		return err
+	}
+	if preflight.blockingConflictCount == 0 {
+		return nil
+	}
+	r.report.Masters = preflightReport.Masters
+	r.report.SubUsers = preflightReport.SubUsers
+	r.report.Users = preflightReport.Users
+	r.report.Memberships = preflightReport.Memberships
+	r.report.Organisations = preflightReport.Organisations
+	r.report.Writes = preflightReport.Writes
+	r.report.Verification = preflightReport.Verification
+	r.report.Conflicts = preflightReport.Conflicts
+	r.report.Warnings = append(r.report.Warnings, preflightReport.Warnings...)
+	r.hasConflict = true
+	r.conflictCount = preflight.conflictCount
+	r.blockingConflictCount = preflight.blockingConflictCount
+	return nil
+}
+
+func (r *organisationsBootstrapRunner) verifyStageFresh() error {
+	freshContext := context.Background()
+	cancel := func() {}
+	if r.config.MigrationTimeoutMinutes > 0 {
+		freshContext, cancel = context.WithTimeout(freshContext, time.Duration(r.config.MigrationTimeoutMinutes)*time.Minute)
+	}
+	defer cancel()
+
+	verificationConfig := r.config
+	verificationConfig.Mode = "dry-run"
+	verificationConfig.Resume = false
+	verificationConfig.Restart = false
+	verificationConfig.StopOnConflict = false
+	verificationReport := organisationsBootstrapReport{}
+	verification := organisationsBootstrapRunner{
+		config:        verificationConfig,
+		database:      r.database,
+		now:           time.Now().UTC(),
+		report:        &verificationReport,
+		stopRequested: r.stopRequested,
+		strict:        true,
+	}
+	if err := verification.runStage(freshContext); err != nil {
+		return fmt.Errorf("fresh bootstrap verification failed: %w", err)
+	}
+	if verification.conflictCount == 0 {
+		return nil
+	}
+	for _, conflict := range verificationReport.Conflicts {
+		r.addConflict(conflict.Code, conflict.MasterID, conflict.DocumentID, conflict.Message)
+	}
+	if verification.blockingConflictCount > 0 && verificationReport.Verification.Failed == 0 {
+		r.report.Verification.Failed++
+	} else if verification.blockingConflictCount > 0 {
+		r.report.Verification.Failed += verificationReport.Verification.Failed
+	}
+	return nil
 }
 
 func (r *organisationsBootstrapRunner) inspectDomains(ctx context.Context) error {
@@ -670,6 +791,9 @@ func (r *organisationsBootstrapRunner) runOwners(ctx context.Context) error {
 	}
 	defer cursor.Close(ctx)
 	for cursor.Next(ctx) {
+		if r.interrupted() {
+			return errOrganisationsBootstrapInterrupted
+		}
 		if err := r.renewCheckpoint(ctx); err != nil {
 			return err
 		}
@@ -683,15 +807,17 @@ func (r *organisationsBootstrapRunner) runOwners(ctx context.Context) error {
 			continue
 		}
 		r.report.Masters.Scanned++
-		conflictsBefore := r.conflictCount
 		verifiedBefore := r.report.Verification.Passed
 		if processErr := r.processOwner(ctx, user); processErr != nil {
 			return processErr
 		}
-		if conflictsBefore == r.conflictCount && verifiedBefore < r.report.Verification.Passed && !r.hasConflict {
+		if r.blockingConflictCount == 0 && verifiedBefore < r.report.Verification.Passed {
 			if checkpointErr := r.advanceCheckpoint(ctx, user.ID); checkpointErr != nil {
 				return checkpointErr
 			}
+		}
+		if r.interrupted() {
+			return errOrganisationsBootstrapInterrupted
 		}
 		if r.hasConflict && r.config.StopOnConflict {
 			break
@@ -816,8 +942,17 @@ func (r *organisationsBootstrapRunner) ensureCanonicalOrganisation(ctx context.C
 		r.report.Writes.Attempted++
 		result, writeErr := collection.UpdateOne(ctx, bson.M{"_id": user.ID}, bson.M{"$setOnInsert": document}, options.Update().SetUpsert(true))
 		if writeErr != nil {
-			r.report.Writes.Failed++
-			return false, true, writeErr
+			ready, _, reconcileErr := r.reconcileCanonicalOrganisation(ctx, user, true)
+			if reconcileErr != nil {
+				r.report.Writes.Failed++
+				return false, true, errors.Join(writeErr, reconcileErr)
+			}
+			if !ready {
+				r.report.Writes.Failed++
+				return false, true, nil
+			}
+			r.report.Writes.Applied++
+			return true, true, nil
 		}
 		if result.UpsertedCount == 1 {
 			r.report.Writes.Applied++
@@ -863,8 +998,18 @@ func (r *organisationsBootstrapRunner) ensureCanonicalOrganisation(ctx context.C
 		r.report.Writes.Attempted++
 		result, writeErr := collection.UpdateOne(ctx, organisationsBootstrapMissingFieldFilter(user.ID, field), bson.M{"$set": bson.M{field: set[field]}})
 		if writeErr != nil {
-			r.report.Writes.Failed++
-			return false, true, writeErr
+			matched, reconcileErr := r.organisationFieldMatches(ctx, user.ID, field, set[field])
+			if reconcileErr != nil {
+				r.report.Writes.Failed++
+				return false, true, errors.Join(writeErr, reconcileErr)
+			}
+			if !matched {
+				r.report.Writes.Failed++
+				r.addConflict("canonical-write-inconclusive", user.ID.Hex(), user.ID.Hex(), "organisation field update did not reconcile")
+				return false, true, nil
+			}
+			r.report.Writes.Applied++
+			continue
 		}
 		if result.ModifiedCount == 1 {
 			r.report.Writes.Applied++
@@ -877,6 +1022,10 @@ func (r *organisationsBootstrapRunner) ensureCanonicalOrganisation(ctx context.C
 func (r *organisationsBootstrapRunner) reconcileCanonicalOrganisation(ctx context.Context, user organisationsBootstrapUser, changed bool) (bool, bool, error) {
 	var stored bson.Raw
 	if err := r.database.Collection("organisation").FindOne(ctx, bson.M{"_id": user.ID}).Decode(&stored); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			r.addConflict("canonical-write-inconclusive", user.ID.Hex(), user.ID.Hex(), "canonical organisation is missing after the write attempt")
+			return false, changed, nil
+		}
 		return false, changed, err
 	}
 	ownerID, state := organisationsBootstrapObjectID(stored, "ownerId")
@@ -888,6 +1037,23 @@ func (r *organisationsBootstrapRunner) reconcileCanonicalOrganisation(ctx contex
 		r.report.Writes.Reconciled++
 	}
 	return true, changed, nil
+}
+
+func (r *organisationsBootstrapRunner) organisationFieldMatches(ctx context.Context, organisationID primitive.ObjectID, field string, expected any) (bool, error) {
+	var stored bson.Raw
+	if err := r.database.Collection("organisation").FindOne(ctx, bson.M{"_id": organisationID}).Decode(&stored); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return false, nil
+		}
+		return false, err
+	}
+	expectedDocument, err := bson.Marshal(bson.M{"value": expected})
+	if err != nil {
+		return false, err
+	}
+	actualValue := stored.Lookup(splitOrganisationsBootstrapPath(field)...)
+	expectedValue := bson.Raw(expectedDocument).Lookup("value")
+	return actualValue.Type == expectedValue.Type && bytes.Equal(actualValue.Value, expectedValue.Value), nil
 }
 
 func (r *organisationsBootstrapRunner) ownerMembershipTargets(ctx context.Context, user organisationsBootstrapUser) ([]primitive.ObjectID, error) {

--- a/actions/organisations-bootstrap.go
+++ b/actions/organisations-bootstrap.go
@@ -664,28 +664,33 @@ func (r *organisationsBootstrapRunner) inspectIndexes(ctx context.Context) error
 	return nil
 }
 
-func readOrganisationsBootstrapIndexes(ctx context.Context, collection *mongo.Collection) ([]bson.M, error) {
+type organisationsBootstrapIndex struct {
+	Key                     bson.D `bson:"key"`
+	Unique                  bool   `bson:"unique,omitempty"`
+	PartialFilterExpression bson.M `bson:"partialFilterExpression,omitempty"`
+}
+
+func readOrganisationsBootstrapIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBootstrapIndex, error) {
 	cursor, err := collection.Indexes().List(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cursor.Close(ctx)
-	var indexes []bson.M
+	var indexes []organisationsBootstrapIndex
 	if err := cursor.All(ctx, &indexes); err != nil {
 		return nil, err
 	}
 	return indexes, nil
 }
 
-func organisationsBootstrapHasIndex(indexes []bson.M, expected bson.D, unique bool) bool {
+func organisationsBootstrapHasIndex(indexes []organisationsBootstrapIndex, expected bson.D, unique bool) bool {
 	for _, index := range indexes {
-		key, ok := index["key"].(bson.D)
-		if !ok || len(key) != len(expected) {
+		if len(index.Key) != len(expected) {
 			continue
 		}
 		matches := true
 		for position := range expected {
-			if key[position].Key != expected[position].Key || fmt.Sprint(key[position].Value) != fmt.Sprint(expected[position].Value) {
+			if index.Key[position].Key != expected[position].Key || fmt.Sprint(index.Key[position].Value) != fmt.Sprint(expected[position].Value) {
 				matches = false
 				break
 			}
@@ -693,24 +698,19 @@ func organisationsBootstrapHasIndex(indexes []bson.M, expected bson.D, unique bo
 		if !matches {
 			continue
 		}
-		isUnique, _ := index["unique"].(bool)
-		if !unique || isUnique {
+		if !unique || index.Unique {
 			return true
 		}
 	}
 	return false
 }
 
-func organisationsBootstrapHasSlugIndex(indexes []bson.M) bool {
+func organisationsBootstrapHasSlugIndex(indexes []organisationsBootstrapIndex) bool {
 	for _, index := range indexes {
-		if !organisationsBootstrapHasIndex([]bson.M{index}, bson.D{{Key: "slug", Value: int32(1)}}, true) {
+		if !organisationsBootstrapHasIndex([]organisationsBootstrapIndex{index}, bson.D{{Key: "slug", Value: int32(1)}}, true) {
 			continue
 		}
-		partial, ok := index["partialFilterExpression"].(bson.M)
-		if !ok {
-			continue
-		}
-		slug, ok := partial["slug"].(bson.M)
+		slug, ok := index.PartialFilterExpression["slug"].(bson.M)
 		if ok && slug["$type"] == "string" {
 			return true
 		}
@@ -836,6 +836,12 @@ func (r *organisationsBootstrapRunner) processOwner(ctx context.Context, user or
 	masterID := user.ID.Hex()
 	if user.ParentState != organisationsBootstrapFieldEmpty {
 		r.addConflict("invalid-master", masterID, masterID, "master user has a non-empty user_id")
+		r.report.Masters.Conflicted++
+		r.report.Verification.Failed++
+		return nil
+	}
+	if user.LegacySelectionPresent {
+		r.addConflict("legacy-user-selection-field", masterID, masterID, "rename users.organisation_id to organisationId before bootstrap")
 		r.report.Masters.Conflicted++
 		r.report.Verification.Failed++
 		return nil
@@ -1080,7 +1086,7 @@ func (r *organisationsBootstrapRunner) ownerMembershipTargets(ctx context.Contex
 	}
 
 	if user.SelectionState == organisationsBootstrapFieldWrong {
-		r.addConflict("invalid-user-selection", user.ID.Hex(), user.ID.Hex(), "organisation_id must be a BSON ObjectID")
+		r.addConflict("invalid-user-selection", user.ID.Hex(), user.ID.Hex(), "organisationId must be a BSON ObjectID")
 		return nil, nil
 	}
 	if user.SelectionState == organisationsBootstrapFieldValue {
@@ -1090,7 +1096,7 @@ func (r *organisationsBootstrapRunner) ownerMembershipTargets(ctx context.Contex
 		}
 		if !accessible {
 			r.report.Users.MissingSelectedOrganisation++
-			r.addConflict("invalid-user-selection", user.ID.Hex(), user.ID.Hex(), "preserved organisation_id does not reference an organisation owned by the master")
+			r.addConflict("invalid-user-selection", user.ID.Hex(), user.ID.Hex(), "preserved organisationId does not reference an organisation owned by the master")
 			return nil, nil
 		}
 		targets[user.Selection] = struct{}{}

--- a/actions/organisations-bootstrap_mongo_test.go
+++ b/actions/organisations-bootstrap_mongo_test.go
@@ -166,7 +166,7 @@ func TestOrganisationsBootstrapAmbiguousUserSelectionReconciles(t *testing.T) {
 			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "ambiguous update result"}),
 			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
 				{Key: "_id", Value: userID},
-				{Key: "organisation_id", Value: targetID},
+				{Key: "organisationId", Value: targetID},
 			}),
 		)
 		report := organisationsBootstrapReport{}
@@ -199,7 +199,7 @@ func TestOrganisationsBootstrapAmbiguousUserSelectionConflictBlocks(t *testing.T
 			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "ambiguous update result"}),
 			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
 				{Key: "_id", Value: userID},
-				{Key: "organisation_id", Value: primitive.NewObjectID()},
+				{Key: "organisationId", Value: primitive.NewObjectID()},
 			}),
 		)
 		report := organisationsBootstrapReport{}

--- a/actions/organisations-bootstrap_mongo_test.go
+++ b/actions/organisations-bootstrap_mongo_test.go
@@ -1,0 +1,292 @@
+package actions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestOrganisationsBootstrapAmbiguousCanonicalInsertReconciles(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("committed organisation", func(mt *mtest.T) {
+		masterID := primitive.NewObjectID()
+		now := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+		user := organisationsBootstrapUser{ID: masterID, Username: "owner", CreatedAt: now}
+		namespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch),
+			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "ambiguous update result"}),
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: masterID},
+				{Key: "name", Value: "owner"},
+				{Key: "ownerId", Value: masterID},
+				{Key: "isActive", Value: true},
+				{Key: "audit", Value: bson.D{
+					{Key: "createdBy", Value: masterID.Hex()},
+					{Key: "createdAt", Value: now},
+					{Key: "updatedBy", Value: masterID.Hex()},
+					{Key: "updatedAt", Value: now},
+					{Key: "lastAction", Value: "organisation.migrated"},
+				}},
+			}),
+		)
+		report := organisationsBootstrapReport{}
+		runner := organisationsBootstrapRunner{
+			config:   OrganisationsBootstrapConfig{Mode: "live"},
+			database: mt.DB,
+			now:      now,
+			report:   &report,
+		}
+
+		ready, changed, err := runner.ensureCanonicalOrganisation(context.Background(), user)
+		if err != nil {
+			t.Fatalf("ensureCanonicalOrganisation() error = %v", err)
+		}
+		if !ready || !changed {
+			t.Fatalf("ensureCanonicalOrganisation() = (%v, %v), want (true, true)", ready, changed)
+		}
+		if report.Writes.Reconciled != 1 || report.Writes.Failed != 0 {
+			t.Fatalf("write counts = %+v", report.Writes)
+		}
+	})
+}
+
+func TestOrganisationsBootstrapAmbiguousMembershipUpsertReconciles(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("committed membership", func(mt *mtest.T) {
+		userID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		now := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+		namespace := mt.DB.Name() + ".organisation_users"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{{Key: "n", Value: int32(0)}}),
+			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "ambiguous update result"}),
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: primitive.NewObjectID()},
+				{Key: "userId", Value: userID},
+				{Key: "organisationId", Value: organisationID},
+				{Key: "status", Value: "active"},
+			}),
+		)
+		report := organisationsBootstrapReport{}
+		runner := organisationsBootstrapRunner{
+			config:   OrganisationsBootstrapConfig{Mode: "live"},
+			database: mt.DB,
+			now:      now,
+			report:   &report,
+		}
+
+		ready, err := runner.ensureMembership(context.Background(), userID, organisationID, userID)
+		if err != nil {
+			t.Fatalf("ensureMembership() error = %v", err)
+		}
+		if !ready {
+			t.Fatal("ensureMembership() did not reconcile the committed membership")
+		}
+		if report.Writes.Reconciled != 1 || report.Writes.Failed != 0 {
+			t.Fatalf("write counts = %+v", report.Writes)
+		}
+	})
+}
+
+func TestOrganisationsBootstrapExistingMembershipIsIdempotent(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("active membership", func(mt *mtest.T) {
+		userID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		namespace := mt.DB.Name() + ".organisation_users"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{{Key: "n", Value: int32(1)}}),
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: primitive.NewObjectID()},
+				{Key: "userId", Value: userID},
+				{Key: "organisationId", Value: organisationID},
+				{Key: "status", Value: "active"},
+			}),
+		)
+		report := organisationsBootstrapReport{}
+		runner := organisationsBootstrapRunner{database: mt.DB, now: time.Now().UTC(), report: &report}
+
+		ready, err := runner.ensureMembership(context.Background(), userID, organisationID, userID)
+		if err != nil || !ready {
+			t.Fatalf("ensureMembership() = (%v, %v), want (true, nil)", ready, err)
+		}
+		if report.Writes.Attempted != 0 || report.Memberships.AlreadyPresent != 1 {
+			t.Fatalf("report = %+v", report)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName == "update" {
+				t.Fatal("idempotent membership rerun issued an update")
+			}
+		}
+	})
+}
+
+func TestOrganisationsBootstrapDryRunMembershipPerformsNoWrite(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("missing membership", func(mt *mtest.T) {
+		userID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		namespace := mt.DB.Name() + ".organisation_users"
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{{Key: "n", Value: int32(0)}}))
+		report := organisationsBootstrapReport{}
+		runner := organisationsBootstrapRunner{
+			config:   OrganisationsBootstrapConfig{Mode: "dry-run"},
+			database: mt.DB,
+			now:      time.Now().UTC(),
+			report:   &report,
+		}
+
+		ready, err := runner.ensureMembership(context.Background(), userID, organisationID, userID)
+		if err != nil || !ready {
+			t.Fatalf("ensureMembership() = (%v, %v), want (true, nil)", ready, err)
+		}
+		if report.Memberships.Planned != 1 || report.Writes.Attempted != 0 {
+			t.Fatalf("report = %+v", report)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName == "update" {
+				t.Fatal("dry-run membership planning issued an update")
+			}
+		}
+	})
+}
+
+func TestOrganisationsBootstrapAmbiguousUserSelectionReconciles(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("committed selection", func(mt *mtest.T) {
+		userID := primitive.NewObjectID()
+		targetID := primitive.NewObjectID()
+		namespace := mt.DB.Name() + ".users"
+		mt.AddMockResponses(
+			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "ambiguous update result"}),
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: userID},
+				{Key: "organisation_id", Value: targetID},
+			}),
+		)
+		report := organisationsBootstrapReport{}
+		runner := organisationsBootstrapRunner{
+			config:   OrganisationsBootstrapConfig{Mode: "live"},
+			database: mt.DB,
+			report:   &report,
+		}
+
+		ready, updated, err := runner.ensureUserSelection(context.Background(), organisationsBootstrapUser{ID: userID}, targetID, userID)
+		if err != nil {
+			t.Fatalf("ensureUserSelection() error = %v", err)
+		}
+		if !ready || !updated {
+			t.Fatalf("ensureUserSelection() = (%v, %v), want (true, true)", ready, updated)
+		}
+		if report.Writes.Applied != 1 || report.Writes.Reconciled != 1 || report.Writes.Failed != 0 {
+			t.Fatalf("write counts = %+v", report.Writes)
+		}
+	})
+}
+
+func TestOrganisationsBootstrapAmbiguousUserSelectionConflictBlocks(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("conflicting selection", func(mt *mtest.T) {
+		userID := primitive.NewObjectID()
+		targetID := primitive.NewObjectID()
+		namespace := mt.DB.Name() + ".users"
+		mt.AddMockResponses(
+			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "ambiguous update result"}),
+			mtest.CreateCursorResponse(0, namespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: userID},
+				{Key: "organisation_id", Value: primitive.NewObjectID()},
+			}),
+		)
+		report := organisationsBootstrapReport{}
+		runner := organisationsBootstrapRunner{
+			config:   OrganisationsBootstrapConfig{Mode: "live"},
+			database: mt.DB,
+			report:   &report,
+		}
+
+		ready, _, err := runner.ensureUserSelection(context.Background(), organisationsBootstrapUser{ID: userID}, targetID, userID)
+		if err != nil {
+			t.Fatalf("ensureUserSelection() error = %v", err)
+		}
+		if ready || !runner.hasConflict || runner.blockingConflictCount != 1 {
+			t.Fatalf("ready = %v, hasConflict = %v, blocking conflicts = %d", ready, runner.hasConflict, runner.blockingConflictCount)
+		}
+		if report.Writes.Failed != 1 {
+			t.Fatalf("write counts = %+v", report.Writes)
+		}
+	})
+}
+
+func TestOrganisationsBootstrapResumeRestoresCheckpoint(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("failed checkpoint", func(mt *mtest.T) {
+		lastVerifiedMasterID := primitive.NewObjectID()
+		checkpointID := "organisations-bootstrap:v1:test:owners:all"
+		mt.AddMockResponses(mtest.CreateSuccessResponse(
+			bson.E{Key: "lastErrorObject", Value: bson.D{{Key: "n", Value: int32(1)}, {Key: "updatedExisting", Value: true}}},
+			bson.E{Key: "value", Value: bson.D{
+				{Key: "_id", Value: checkpointID},
+				{Key: "migrationVersion", Value: 1},
+				{Key: "database", Value: "test"},
+				{Key: "stage", Value: "owners"},
+				{Key: "scope", Value: "all"},
+				{Key: "mode", Value: "live"},
+				{Key: "status", Value: "running"},
+				{Key: "leaseOwner", Value: "new-owner"},
+				{Key: "leaseExpiresAt", Value: time.Now().UTC().Add(organisationsBootstrapLeaseDuration)},
+				{Key: "lastVerifiedMasterId", Value: lastVerifiedMasterID},
+				{Key: "startedAt", Value: time.Now().UTC().Add(-time.Hour)},
+				{Key: "updatedAt", Value: time.Now().UTC()},
+				{Key: "counters", Value: bson.D{
+					{Key: "masters", Value: bson.D{{Key: "scanned", Value: int64(8)}}},
+					{Key: "users", Value: bson.D{{Key: "mastersupdated", Value: int64(4)}}},
+					{Key: "organisations", Value: bson.D{{Key: "legacyreported", Value: int64(3)}}},
+					{Key: "writes", Value: bson.D{{Key: "applied", Value: int64(5)}}},
+				}},
+			}},
+		))
+		report := organisationsBootstrapReport{Checkpoint: organisationsBootstrapCheckpoint{ID: checkpointID}}
+		runner := organisationsBootstrapRunner{
+			config: OrganisationsBootstrapConfig{
+				Mode:                       "live",
+				Stage:                      "owners",
+				Resume:                     true,
+				MigrationVersion:           1,
+				MongoDBDestinationDatabase: "test",
+			},
+			database: mt.DB,
+			report:   &report,
+		}
+
+		if err := runner.acquireCheckpoint(context.Background()); err != nil {
+			t.Fatalf("acquireCheckpoint() error = %v", err)
+		}
+		if runner.checkpointLastMaster != lastVerifiedMasterID || report.Masters.Scanned != 8 || report.Users.MastersUpdated != 4 || report.Organisations.LegacyReported != 3 || report.Writes.Applied != 5 {
+			t.Fatalf("restored checkpoint = last %s, report %+v", runner.checkpointLastMaster.Hex(), report)
+		}
+	})
+}
+
+func TestOrganisationsBootstrapRefreshCheckpointLease(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("owned lease", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateSuccessResponse(
+			bson.E{Key: "n", Value: int32(1)},
+			bson.E{Key: "nModified", Value: int32(1)},
+		))
+		report := organisationsBootstrapReport{Checkpoint: organisationsBootstrapCheckpoint{ID: "checkpoint"}}
+		runner := organisationsBootstrapRunner{
+			database:             mt.DB,
+			report:               &report,
+			checkpointLeaseOwner: "lease-owner",
+		}
+		if err := runner.refreshCheckpointLease(context.Background()); err != nil {
+			t.Fatalf("refreshCheckpointLease() error = %v", err)
+		}
+	})
+}

--- a/actions/organisations-bootstrap_test.go
+++ b/actions/organisations-bootstrap_test.go
@@ -179,16 +179,33 @@ func TestOrganisationsBootstrapResumeFilterPreservesScopedMaster(t *testing.T) {
 }
 
 func TestOrganisationsBootstrapSlugIndexRequiresPartialUniqueContract(t *testing.T) {
-	base := bson.M{
-		"key":    bson.D{{Key: "slug", Value: int32(1)}},
-		"unique": true,
+	base := organisationsBootstrapIndex{
+		Key:    bson.D{{Key: "slug", Value: int32(1)}},
+		Unique: true,
 	}
-	if organisationsBootstrapHasSlugIndex([]bson.M{base}) {
+	if organisationsBootstrapHasSlugIndex([]organisationsBootstrapIndex{base}) {
 		t.Fatal("full unique slug index must not satisfy the partial index contract")
 	}
-	base["partialFilterExpression"] = bson.M{"slug": bson.M{"$type": "string"}}
-	if !organisationsBootstrapHasSlugIndex([]bson.M{base}) {
+	base.PartialFilterExpression = bson.M{"slug": bson.M{"$exists": true, "$type": "string"}}
+	if !organisationsBootstrapHasSlugIndex([]organisationsBootstrapIndex{base}) {
 		t.Fatal("partial unique string slug index did not satisfy the contract")
+	}
+}
+
+func TestOrganisationsBootstrapIndexMetadataDecodesDriverShape(t *testing.T) {
+	raw, err := bson.Marshal(bson.D{
+		{Key: "key", Value: bson.D{{Key: "userId", Value: int32(1)}, {Key: "organisationId", Value: int32(1)}}},
+		{Key: "unique", Value: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var index organisationsBootstrapIndex
+	if err := bson.Unmarshal(raw, &index); err != nil {
+		t.Fatal(err)
+	}
+	if !organisationsBootstrapHasIndex([]organisationsBootstrapIndex{index}, bson.D{{Key: "userId", Value: int32(1)}, {Key: "organisationId", Value: int32(1)}}, true) {
+		t.Fatalf("decoded index metadata did not match: %+v", index)
 	}
 }
 
@@ -197,10 +214,11 @@ func TestParseOrganisationsBootstrapUser(t *testing.T) {
 	subUserID := primitive.NewObjectID()
 
 	tests := []struct {
-		name            string
-		document        bson.M
-		wantParentState organisationsBootstrapFieldState
-		wantParentID    primitive.ObjectID
+		name                       string
+		document                   bson.M
+		wantParentState            organisationsBootstrapFieldState
+		wantParentID               primitive.ObjectID
+		wantLegacySelectionPresent bool
 	}{
 		{
 			name:            "master without parent",
@@ -223,6 +241,12 @@ func TestParseOrganisationsBootstrapUser(t *testing.T) {
 			document:        bson.M{"_id": subUserID, "username": "viewer", "user_id": masterID},
 			wantParentState: organisationsBootstrapFieldWrong,
 		},
+		{
+			name:                       "user with legacy selection key",
+			document:                   bson.M{"_id": masterID, "username": "owner", "organisation_id": primitive.NewObjectID()},
+			wantParentState:            organisationsBootstrapFieldEmpty,
+			wantLegacySelectionPresent: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -241,7 +265,31 @@ func TestParseOrganisationsBootstrapUser(t *testing.T) {
 			if user.ParentID != test.wantParentID {
 				t.Errorf("ParentID = %v, want %v", user.ParentID, test.wantParentID)
 			}
+			if user.LegacySelectionPresent != test.wantLegacySelectionPresent {
+				t.Errorf("LegacySelectionPresent = %v, want %v", user.LegacySelectionPresent, test.wantLegacySelectionPresent)
+			}
 		})
+	}
+}
+
+func TestOrganisationsBootstrapOwnerBlocksLegacySelectionField(t *testing.T) {
+	report := organisationsBootstrapReport{}
+	runner := organisationsBootstrapRunner{report: &report}
+	userID := primitive.NewObjectID()
+
+	err := runner.processOwner(context.Background(), organisationsBootstrapUser{
+		ID:                     userID,
+		Username:               "owner",
+		LegacySelectionPresent: true,
+	})
+	if err != nil {
+		t.Fatalf("processOwner() error = %v", err)
+	}
+	if runner.blockingConflictCount != 1 || report.Verification.Failed != 1 {
+		t.Fatalf("blocking conflicts = %d, verification failures = %d", runner.blockingConflictCount, report.Verification.Failed)
+	}
+	if len(report.Conflicts) != 1 || report.Conflicts[0].Code != "legacy-user-selection-field" {
+		t.Fatalf("conflicts = %+v", report.Conflicts)
 	}
 }
 

--- a/actions/organisations-bootstrap_test.go
+++ b/actions/organisations-bootstrap_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -79,6 +80,68 @@ func TestOrganisationsBootstrapExitCode(t *testing.T) {
 	err := &organisationsBootstrapError{code: organisationsBootstrapExitData, err: errTestDataConflict}
 	if got := OrganisationsBootstrapExitCode(err); got != organisationsBootstrapExitData {
 		t.Fatalf("OrganisationsBootstrapExitCode() = %d, want %d", got, organisationsBootstrapExitData)
+	}
+}
+
+func TestOrganisationsBootstrapInterrupted(t *testing.T) {
+	stopRequested := make(chan struct{})
+	runner := organisationsBootstrapRunner{stopRequested: stopRequested}
+	if runner.interrupted() {
+		t.Fatal("runner reported an interruption before the stop channel closed")
+	}
+	close(stopRequested)
+	if !runner.interrupted() {
+		t.Fatal("runner did not report an interruption after the stop channel closed")
+	}
+}
+
+func TestOrganisationsBootstrapHeartbeatSkipsDryRun(t *testing.T) {
+	called := false
+	runner := organisationsBootstrapRunner{}
+	if err := runner.withCheckpointHeartbeat(t.Context(), func(context.Context) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("withCheckpointHeartbeat() error = %v", err)
+	}
+	if !called {
+		t.Fatal("withCheckpointHeartbeat() did not run the operation")
+	}
+}
+
+func TestOrganisationsBootstrapRestoreCheckpointCounters(t *testing.T) {
+	report := organisationsBootstrapReport{}
+	runner := organisationsBootstrapRunner{report: &report}
+	runner.restoreCheckpoint(organisationsBootstrapCheckpointDocument{
+		Counters: organisationsBootstrapCheckpointCounters{
+			Masters:       organisationsBootstrapMasterCounts{Scanned: 3},
+			SubUsers:      organisationsBootstrapSubUserCounts{Updated: 4},
+			Users:         organisationsBootstrapUserCounts{MastersUpdated: 5},
+			Memberships:   organisationsBootstrapMembershipCounts{Inserted: 6},
+			Organisations: organisationsBootstrapOrganisationCounts{LegacyReported: 7},
+			Writes:        organisationsBootstrapWriteCounts{Applied: 8},
+			Verification:  organisationsBootstrapVerificationCounts{Passed: 9},
+		},
+		Conflicts: []organisationsBootstrapConflict{{Code: "previous-conflict"}},
+	})
+
+	if report.Masters.Scanned != 3 || report.SubUsers.Updated != 4 || report.Users.MastersUpdated != 5 || report.Memberships.Inserted != 6 || report.Organisations.LegacyReported != 7 || report.Writes.Applied != 8 || report.Verification.Passed != 9 {
+		t.Fatalf("restored counters = %+v", report)
+	}
+	if len(report.Conflicts) != 0 {
+		t.Fatalf("historical checkpoint conflicts leaked into resumed report: %+v", report.Conflicts)
+	}
+	if runner.hasConflict {
+		t.Fatal("historical checkpoint conflicts must not block a corrected resume")
+	}
+}
+
+func TestOrganisationsBootstrapLegacyReportConflictDoesNotBlock(t *testing.T) {
+	if organisationsBootstrapConflictBlocks("legacy-organisation-unresolved") {
+		t.Fatal("legacy report conflict must allow the non-destructive live migration path")
+	}
+	if !organisationsBootstrapConflictBlocks("canonical-owner-conflict") {
+		t.Fatal("canonical owner conflict must block live writes during preflight")
 	}
 }
 

--- a/actions/organisations-bootstrap_test.go
+++ b/actions/organisations-bootstrap_test.go
@@ -1,0 +1,279 @@
+package actions
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestValidateOrganisationsBootstrapConfig(t *testing.T) {
+	valid := normalizeOrganisationsBootstrapConfig(OrganisationsBootstrapConfig{
+		Mode:                       "dry-run",
+		Stage:                      "owners",
+		MongoDBURI:                 "mongodb://localhost:27017",
+		MongoDBDestinationDatabase: "hub",
+	})
+
+	tests := []struct {
+		name      string
+		mutate    func(OrganisationsBootstrapConfig) OrganisationsBootstrapConfig
+		wantError string
+	}{
+		{name: "valid owners", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig { return config }},
+		{name: "valid sub-users", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Stage = "sub-users"
+			return config
+		}},
+		{name: "valid verify", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Stage = "verify"
+			return config
+		}},
+		{name: "requires stage", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Stage = ""
+			return config
+		}, wantError: "stage must be"},
+		{name: "verify rejects live mode", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Stage = "verify"
+			config.Mode = "live"
+			return config
+		}, wantError: "verify is read-only"},
+		{name: "owners support checkpointed live mode", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Mode = "live"
+			return config
+		}},
+		{name: "rejects conflicting scopes", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Username = "owner"
+			config.OrganisationID = "507f1f77bcf86cd799439011"
+			return config
+		}, wantError: "mutually exclusive"},
+		{name: "resume requires live mode", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.Resume = true
+			return config
+		}, wantError: "require -mode live"},
+		{name: "rejects destructive legacy policy", mutate: func(config OrganisationsBootstrapConfig) OrganisationsBootstrapConfig {
+			config.LegacyOrganisationPolicy = "archive-delete"
+			return config
+		}, wantError: "archive-delete is disabled"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateOrganisationsBootstrapConfig(test.mutate(valid))
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateOrganisationsBootstrapConfig() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validateOrganisationsBootstrapConfig() error = %v, want containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestOrganisationsBootstrapExitCode(t *testing.T) {
+	err := &organisationsBootstrapError{code: organisationsBootstrapExitData, err: errTestDataConflict}
+	if got := OrganisationsBootstrapExitCode(err); got != organisationsBootstrapExitData {
+		t.Fatalf("OrganisationsBootstrapExitCode() = %d, want %d", got, organisationsBootstrapExitData)
+	}
+}
+
+func TestOrganisationsBootstrapCheckpointIDIncludesStageAndScope(t *testing.T) {
+	config := normalizeOrganisationsBootstrapConfig(OrganisationsBootstrapConfig{
+		Stage:                      "owners",
+		MongoDBDestinationDatabase: "hub",
+		OrganisationID:             "507f1f77bcf86cd799439011",
+	})
+	ownerID := organisationsBootstrapCheckpointID(config)
+	config.Stage = "sub-users"
+	subUserID := organisationsBootstrapCheckpointID(config)
+	if ownerID == subUserID {
+		t.Fatalf("checkpoint IDs must differ by stage: %q", ownerID)
+	}
+	for _, part := range []string{"v1", "hub", "owners", config.OrganisationID} {
+		if !strings.Contains(ownerID, part) {
+			t.Errorf("owner checkpoint ID %q does not contain %q", ownerID, part)
+		}
+	}
+}
+
+func TestOrganisationsBootstrapResumeFilterPreservesScopedMaster(t *testing.T) {
+	scopeID := primitive.ObjectID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+	earlierID := primitive.ObjectID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	filter := organisationsBootstrapResumeFilter(bson.M{"_id": scopeID}, earlierID)
+	if filter["_id"] != scopeID {
+		t.Fatalf("resume filter = %v, want pending exact scope %v", filter, scopeID)
+	}
+	completed := organisationsBootstrapResumeFilter(bson.M{"_id": scopeID}, scopeID)
+	idFilter, ok := completed["_id"].(bson.M)
+	if !ok || idFilter["$exists"] != false {
+		t.Fatalf("completed scope resume filter = %v, want no match", completed)
+	}
+}
+
+func TestOrganisationsBootstrapSlugIndexRequiresPartialUniqueContract(t *testing.T) {
+	base := bson.M{
+		"key":    bson.D{{Key: "slug", Value: int32(1)}},
+		"unique": true,
+	}
+	if organisationsBootstrapHasSlugIndex([]bson.M{base}) {
+		t.Fatal("full unique slug index must not satisfy the partial index contract")
+	}
+	base["partialFilterExpression"] = bson.M{"slug": bson.M{"$type": "string"}}
+	if !organisationsBootstrapHasSlugIndex([]bson.M{base}) {
+		t.Fatal("partial unique string slug index did not satisfy the contract")
+	}
+}
+
+func TestParseOrganisationsBootstrapUser(t *testing.T) {
+	masterID := primitive.NewObjectID()
+	subUserID := primitive.NewObjectID()
+
+	tests := []struct {
+		name            string
+		document        bson.M
+		wantParentState organisationsBootstrapFieldState
+		wantParentID    primitive.ObjectID
+	}{
+		{
+			name:            "master without parent",
+			document:        bson.M{"_id": masterID, "username": "owner"},
+			wantParentState: organisationsBootstrapFieldEmpty,
+		},
+		{
+			name:            "sub-user with valid parent",
+			document:        bson.M{"_id": subUserID, "username": "viewer", "user_id": masterID.Hex()},
+			wantParentState: organisationsBootstrapFieldValue,
+			wantParentID:    masterID,
+		},
+		{
+			name:            "sub-user with invalid parent hex",
+			document:        bson.M{"_id": subUserID, "username": "viewer", "user_id": "invalid"},
+			wantParentState: organisationsBootstrapFieldWrong,
+		},
+		{
+			name:            "sub-user with wrong parent type",
+			document:        bson.M{"_id": subUserID, "username": "viewer", "user_id": masterID},
+			wantParentState: organisationsBootstrapFieldWrong,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := bson.Marshal(test.document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			user, err := parseOrganisationsBootstrapUser(raw)
+			if err != nil {
+				t.Fatalf("parseOrganisationsBootstrapUser() error = %v", err)
+			}
+			if user.ParentState != test.wantParentState {
+				t.Errorf("ParentState = %v, want %v", user.ParentState, test.wantParentState)
+			}
+			if user.ParentID != test.wantParentID {
+				t.Errorf("ParentID = %v, want %v", user.ParentID, test.wantParentID)
+			}
+		})
+	}
+}
+
+func TestOrganisationsBootstrapOrganisationDocumentIsMinimal(t *testing.T) {
+	masterID := primitive.NewObjectID()
+	createdAt := time.Date(2024, time.December, 7, 8, 16, 51, 0, time.UTC)
+	document := organisationsBootstrapOrganisationDocument(organisationsBootstrapUser{
+		ID:        masterID,
+		Username:  "owner",
+		Timezone:  "Europe/Brussels",
+		CreatedAt: createdAt,
+	}, time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC))
+
+	if document["_id"] != masterID || document["ownerId"] != masterID {
+		t.Fatalf("organisation identity = (%v, %v), want %v", document["_id"], document["ownerId"], masterID)
+	}
+	for _, forbidden := range []string{"slug", "role", "subscription", "password", "channels", "groups"} {
+		if _, exists := document[forbidden]; exists {
+			t.Errorf("minimal organisation unexpectedly contains %q", forbidden)
+		}
+	}
+	audit := document["audit"].(bson.M)
+	if audit["createdAt"] != createdAt || audit["updatedAt"] != createdAt {
+		t.Errorf("audit timestamps = (%v, %v), want %v", audit["createdAt"], audit["updatedAt"], createdAt)
+	}
+}
+
+func TestOrganisationsBootstrapMissingOrganisationFieldsPreservesExistingValues(t *testing.T) {
+	masterID := primitive.NewObjectID()
+	raw, err := bson.Marshal(bson.M{
+		"_id":      masterID,
+		"name":     "Existing name",
+		"ownerId":  masterID,
+		"isActive": false,
+		"settings": bson.M{"timezone": "UTC"},
+		"audit": bson.M{
+			"createdBy":  "existing",
+			"createdAt":  time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC),
+			"updatedBy":  "existing",
+			"updatedAt":  time.Date(2020, time.January, 2, 0, 0, 0, 0, time.UTC),
+			"lastAction": "organisation.updated",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := organisationsBootstrapMissingOrganisationFields(raw, organisationsBootstrapUser{
+		ID:       masterID,
+		Username: "owner",
+		Timezone: "Europe/Brussels",
+	}, time.Now())
+	if len(missing) != 0 {
+		t.Fatalf("missing fields = %v, want none", missing)
+	}
+}
+
+func TestOrganisationsBootstrapOrganisationFieldsRejectWrongTypes(t *testing.T) {
+	masterID := primitive.NewObjectID()
+	raw, err := bson.Marshal(bson.M{
+		"name":     "owner",
+		"ownerId":  masterID,
+		"isActive": "true",
+		"settings": bson.M{"timezone": "UTC"},
+		"audit": bson.M{
+			"createdBy":  masterID.Hex(),
+			"createdAt":  time.Now(),
+			"updatedBy":  masterID.Hex(),
+			"updatedAt":  time.Now(),
+			"lastAction": "organisation.migrated",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if organisationsBootstrapOrganisationFieldsValid(raw, true) {
+		t.Fatal("string isActive must not satisfy canonical organisation validation")
+	}
+}
+
+func TestOrganisationsBootstrapMissingUpdatedAtUsesCanonicalCreatedAt(t *testing.T) {
+	masterID := primitive.NewObjectID()
+	canonicalCreatedAt := time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
+	raw, err := bson.Marshal(bson.M{
+		"audit": bson.M{"createdAt": canonicalCreatedAt},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := organisationsBootstrapMissingOrganisationFields(raw, organisationsBootstrapUser{
+		ID:        masterID,
+		Username:  "owner",
+		CreatedAt: time.Date(2024, time.December, 7, 0, 0, 0, 0, time.UTC),
+	}, time.Now())
+	updatedAt, ok := missing["audit.updatedAt"].(time.Time)
+	if !ok || !updatedAt.Equal(canonicalCreatedAt) {
+		t.Fatalf("audit.updatedAt = %v, want canonical createdAt %v", missing["audit.updatedAt"], canonicalCreatedAt)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func promptAction() string {
 	choices := []string{
 		"vault-to-hub-migration",
 		"reprocess-media",
+		"organisations-bootstrap",
 		"organisations-backfill",
 		"migrate-legacy-media",
 		"audit-legacy-compat",
@@ -123,6 +124,9 @@ func main() {
 	restart := flag.Bool("restart", false, "Restart the matching migration checkpoint")
 	stopOnConflict := flag.Bool("stop-on-conflict", false, "Stop after the first tenant conflict")
 	reportFile := flag.String("report-file", "", "Optional path for the JSON migration report")
+	stage := flag.String("stage", "", "Organisations bootstrap stage: owners, sub-users, or verify")
+	bootstrapBatchSize := flag.Int("bootstrap-batch-size", 500, "Source cursor batch size for organisations-bootstrap")
+	legacyOrganisationPolicy := flag.String("legacy-org-policy", "report", "Legacy organisation policy for organisations-bootstrap: report or archive-delete")
 
 	flag.Parse()
 
@@ -205,6 +209,33 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "organisations-backfill: %v\n", err)
 			os.Exit(actions.OrganisationsBackfillExitCode(err))
+		}
+	case "organisations-bootstrap":
+		err := actions.OrganisationsBootstrap(actions.OrganisationsBootstrapConfig{
+			Mode:                       *mode,
+			Stage:                      *stage,
+			MongoDBURI:                 *mongodbURI,
+			MongoDBHost:                *mongodbHost,
+			MongoDBPort:                *mongodbPort,
+			MongoDBSourceDatabase:      *mongodbSourceDatabase,
+			MongoDBDestinationDatabase: *mongodbDestinationDatabase,
+			MongoDBDatabaseCredentials: *mongodbDatabaseCredentials,
+			MongoDBUsername:            *mongodbUsername,
+			MongoDBPassword:            *mongodbPassword,
+			MigrationVersion:           *migrationVersion,
+			MigrationTimeoutMinutes:    *migrationTimeoutMinutes,
+			Username:                   *username,
+			OrganisationID:             *organisationId,
+			BatchSize:                  *bootstrapBatchSize,
+			LegacyOrganisationPolicy:   *legacyOrganisationPolicy,
+			Resume:                     *resume,
+			Restart:                    *restart,
+			StopOnConflict:             *stopOnConflict,
+			ReportFile:                 *reportFile,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "organisations-bootstrap: %v\n", err)
+			os.Exit(actions.OrganisationsBootstrapExitCode(err))
 		}
 	case "migrate-legacy-media":
 		fmt.Printf("Running legacy media migration (%s)...\n", *mode)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/uug-ai/cli/actions"
@@ -12,6 +13,7 @@ func promptAction() string {
 	choices := []string{
 		"vault-to-hub-migration",
 		"reprocess-media",
+		"organisations-backfill",
 		"migrate-legacy-media",
 		"audit-legacy-compat",
 		"generate-default-labels",
@@ -66,11 +68,11 @@ func main() {
 	organisationId := flag.String("organisation-id", "", "Specific organisation/user ID to target")
 	startTimestamp := flag.Int64("start-timestamp", 0, "Start Timestamp")
 	endTimestamp := flag.Int64("end-timestamp", 0, "End Timestamp")
-	migrationTimeoutMinutes := flag.Int("migration-timeout-minutes", 60, "Timeout in minutes for migrate-legacy-media and related long scans (0 disables timeout)")
+	migrationTimeoutMinutes := flag.Int("migration-timeout-minutes", 60, "Timeout in minutes for migration scans (0 disables timeout)")
 	skipMatchedCount := flag.Bool("skip-matched-count", true, "Skip initial CountDocuments in migrate-legacy-media for better performance on large datasets")
-	migrationVersion := flag.Int("migration-version", 1, "Migration step version for migrate-legacy-media (defaults to latest supported)")
-	checkMigrationIndexes := flag.Bool("check-migration-indexes", false, "Check required indexes for migrate-legacy-media and report their status")
-	applyMigrationIndexes := flag.Bool("apply-migration-indexes", false, "Create missing required indexes for migrate-legacy-media")
+	migrationVersion := flag.Int("migration-version", 1, "Migration step version (defaults to latest supported)")
+	checkMigrationIndexes := flag.Bool("check-migration-indexes", false, "Check required migration indexes and report their status")
+	applyMigrationIndexes := flag.Bool("apply-migration-indexes", false, "Create missing registered migration indexes")
 	generateDefaultMarkerOptions := flag.Bool("generate-default-marker-options", false, "When running migrate-legacy-media, generate default classification marker_options for users in the organisation scope")
 	timezone := flag.String("timezone", "", "Timezone")
 	mode := flag.String("mode", "dry-run", "Mode")
@@ -113,6 +115,14 @@ func main() {
 	collections := flag.String("collections", "", "Comma separated list of collections to migrate (default all)")
 	indexVersion := flag.String("index-version", "", "Path to the indexes specification file")
 	domains := flag.String("domains", "", "Comma separated list of compatibility domains (default: media,analysis,users,devices,groups,sites,settings)")
+	collection := flag.String("collection", "", "Single registered collection to migrate")
+	allCollections := flag.Bool("all", false, "Process every ready migration adapter")
+	adapterVersion := flag.String("adapter-version", "", "Exact organisations-backfill adapter version")
+	documentId := flag.String("document-id", "", "Single document ObjectID for diagnosis")
+	resume := flag.Bool("resume", false, "Resume the matching migration checkpoint")
+	restart := flag.Bool("restart", false, "Restart the matching migration checkpoint")
+	stopOnConflict := flag.Bool("stop-on-conflict", false, "Stop after the first tenant conflict")
+	reportFile := flag.String("report-file", "", "Optional path for the JSON migration report")
 
 	flag.Parse()
 
@@ -162,6 +172,40 @@ func main() {
 			*batchSize,
 			*batchDelay,
 		)
+	case "organisations-backfill":
+		backfillBatchSize := *batchSize
+		if !actions.WasFlagPassed("batch-size") {
+			backfillBatchSize = 500
+		}
+		err := actions.OrganisationsBackfill(actions.OrganisationsBackfillConfig{
+			Mode:                       *mode,
+			MongoDBURI:                 *mongodbURI,
+			MongoDBHost:                *mongodbHost,
+			MongoDBPort:                *mongodbPort,
+			MongoDBSourceDatabase:      *mongodbSourceDatabase,
+			MongoDBDestinationDatabase: *mongodbDestinationDatabase,
+			MongoDBDatabaseCredentials: *mongodbDatabaseCredentials,
+			MongoDBUsername:            *mongodbUsername,
+			MongoDBPassword:            *mongodbPassword,
+			MigrationVersion:           *migrationVersion,
+			AdapterVersion:             *adapterVersion,
+			Collection:                 *collection,
+			AllCollections:             *allCollections,
+			BatchSize:                  backfillBatchSize,
+			MigrationTimeoutMinutes:    *migrationTimeoutMinutes,
+			OrganisationID:             *organisationId,
+			DocumentID:                 *documentId,
+			Resume:                     *resume,
+			Restart:                    *restart,
+			CheckMigrationIndexes:      *checkMigrationIndexes,
+			ApplyMigrationIndexes:      *applyMigrationIndexes,
+			StopOnConflict:             *stopOnConflict,
+			ReportFile:                 *reportFile,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "organisations-backfill: %v\n", err)
+			os.Exit(actions.OrganisationsBackfillExitCode(err))
+		}
 	case "migrate-legacy-media":
 		fmt.Printf("Running legacy media migration (%s)...\n", *mode)
 		actions.MigrateLegacyMedia(*mode,


### PR DESCRIPTION
## Description

## Motivation

The Phase 4 organisation migration requires confidence that ownership data across collections is structurally valid before any backfill writes are allowed. Until now, there was no dedicated preflight tool to audit canonical organisation references, detect incompatible BSON shapes, or verify index readiness across collections.

This change introduces `organisations-backfill`, a read-only preflight action that validates migration readiness and produces structured reports for operational review. It allows us to identify invalid `organisationId` values, missing canonical ownership fields, incomplete legacy coverage, and index gaps before enabling live migration behaviour.

## Why this improves the project

The new preflight workflow reduces migration risk by making ownership inconsistencies visible early and enforcing strict safety guarantees before writes are introduced. It also establishes a clear adapter model for supported collections while explicitly blocking unverified domains until their persistence contracts are audited.

Key improvements include:

- Adds a deterministic, report-driven preflight for organisation ownership migration readiness.
- Detects invalid BSON types and malformed ObjectID references that would otherwise break migration assumptions.
- Verifies index coverage and legacy ownership candidate availability across supported collections.
- Prevents unsafe execution paths by explicitly disabling live writes, checkpoint resume, scoped resolution, and index creation until reconciliation logic is implemented.
- Documents the Phase 3 bootstrap flow and the new Phase 4 preflight workflow in the README for safer operational rollout.
- Adds validation and adapter-selection test coverage to ensure migration guardrails remain enforced.
- Updates ARM CI runners to use the supported hosted Ubuntu ARM environment for more stable PR builds.

This lays the foundation for safe, checkpointed organisation ownership backfills while keeping the current implementation intentionally non-destructive.