### PR TITLE
fix(projects): accept lazily-minted default projects

### DIFF
--- a/actions/projects-bootstrap-data.go
+++ b/actions/projects-bootstrap-data.go
@@ -56,7 +56,14 @@ func projectsBootstrapProjectDocument(organisationID, ownerID primitive.ObjectID
 // projectsBootstrapMissingProjectFields reports only absent fields. A populated
 // business field is never replaced: the migration fills gaps, it does not
 // rewrite tenant data.
-func projectsBootstrapMissingProjectFields(document bson.Raw, organisationID, ownerID primitive.ObjectID, createdAt time.Time) bson.M {
+//
+// audit.createdBy and audit.updatedBy are deliberately absent from the
+// candidates. models.Audit marks them omitempty and Hub API's
+// ensureDefaultProject sets neither, so a lazily-minted default has no such
+// keys. Patching them in would attribute creation to an owner who did not
+// create the document. Documents this tool inserts carry both; existing
+// documents keep whatever shape they already have.
+func projectsBootstrapMissingProjectFields(document bson.Raw, organisationID primitive.ObjectID, createdAt time.Time) bson.M {
 	if existingCreatedAt, state := organisationsBootstrapTime(document, "audit", "createdAt"); state == organisationsBootstrapFieldValue {
 		createdAt = existingCreatedAt
 	}
@@ -65,9 +72,7 @@ func projectsBootstrapMissingProjectFields(document bson.Raw, organisationID, ow
 		"name":             projectsBootstrapDefaultName,
 		"slug":             projectsBootstrapDefaultSlug,
 		"isActive":         true,
-		"audit.createdBy":  ownerID.Hex(),
 		"audit.createdAt":  createdAt,
-		"audit.updatedBy":  ownerID.Hex(),
 		"audit.updatedAt":  createdAt,
 		"audit.lastAction": projectsBootstrapLastAction,
 	}
@@ -87,12 +92,17 @@ func projectsBootstrapMissingProjectFields(document bson.Raw, organisationID, ow
 	return missing
 }
 
+// projectsBootstrapProjectFieldsValid reports whether a stored default project
+// carries every field this migration depends on.
+//
+// audit.createdBy and audit.updatedBy are not required: Hub API's
+// ensureDefaultProject omits them, and demanding them here would report every
+// lazily-minted default as incomplete — failing `verify` for any organisation
+// that saw a metadata read, and blocking that master's sub-users stage.
 func projectsBootstrapProjectFieldsValid(document bson.Raw) bool {
 	for _, path := range [][]string{
 		{"name"},
 		{"slug"},
-		{"audit", "createdBy"},
-		{"audit", "updatedBy"},
 		{"audit", "lastAction"},
 	} {
 		if _, state := organisationsBootstrapString(document, path...); state != organisationsBootstrapFieldValue {
@@ -217,6 +227,9 @@ func (r *projectsBootstrapRunner) ensureDefaultProject(ctx context.Context, orga
 // requires exactly one match, so a second document would break every metadata
 // read. This tool never deletes or folds it — an operator must decide.
 func (r *projectsBootstrapRunner) inspectLegacyDefaultProjects(ctx context.Context, organisationID, actorID primitive.ObjectID) (int64, error) {
+	if seen, ok := r.legacyDefaultsSeen[organisationID]; ok {
+		return seen, nil
+	}
 	cursor, err := r.database.Collection(projectsBootstrapCollection).Find(ctx, bson.M{
 		"organisationId": organisationID,
 		"slug":           projectsBootstrapDefaultSlug,
@@ -239,7 +252,14 @@ func (r *projectsBootstrapRunner) inspectLegacyDefaultProjects(ctx context.Conte
 		r.report.Projects.Conflicted++
 		r.addConflict("default-project-conflict", actorID.Hex(), legacy.ID.Hex(), "a default project exists outside the deterministic identity and must be resolved by an operator")
 	}
-	return found, cursor.Err()
+	if err := cursor.Err(); err != nil {
+		return found, err
+	}
+	if r.legacyDefaultsSeen == nil {
+		r.legacyDefaultsSeen = map[primitive.ObjectID]int64{}
+	}
+	r.legacyDefaultsSeen[organisationID] = found
+	return found, nil
 }
 
 func (r *projectsBootstrapRunner) createDefaultProject(ctx context.Context, organisationID, ownerID, actorID primitive.ObjectID, createdAt time.Time) (bool, bool, error) {
@@ -311,7 +331,7 @@ func (r *projectsBootstrapRunner) completeDefaultProject(ctx context.Context, st
 		return false, false, nil
 	}
 
-	missing := projectsBootstrapMissingProjectFields(stored, organisationID, ownerID, createdAt)
+	missing := projectsBootstrapMissingProjectFields(stored, organisationID, createdAt)
 	if len(missing) == 0 && projectsBootstrapDefaultProjectValid(stored, organisationID) && projectsBootstrapProjectFieldsValid(stored) {
 		r.report.Projects.AlreadyPresent++
 		return true, false, nil
@@ -621,6 +641,7 @@ func (r *projectsBootstrapRunner) processSubUser(ctx context.Context, user proje
 		return nil
 	}
 	if selectionChanged {
+		r.report.Users.SelectionsPlanned++
 		if r.config.Mode == "live" {
 			r.report.SubUsers.Updated++
 			r.report.Users.SubUsersUpdated++

--- a/actions/projects-bootstrap.go
+++ b/actions/projects-bootstrap.go
@@ -80,7 +80,10 @@ type projectsBootstrapReport struct {
 	Indexes          projectsBootstrapIndexStatus        `json:"indexes"`
 	Checkpoint       projectsBootstrapCheckpoint         `json:"checkpoint"`
 	Conflicts        []projectsBootstrapConflict         `json:"conflicts"`
-	Warnings         []projectsBootstrapWarning          `json:"warnings"`
+	// Warnings keeps the report shape aligned with the organisations bootstrap
+	// so operator tooling can parse both. It is always empty here: every
+	// projects bootstrap finding is blocking, so nothing produces a warning.
+	Warnings []projectsBootstrapWarning `json:"warnings"`
 }
 
 type projectsBootstrapMasterCounts struct {
@@ -100,6 +103,7 @@ type projectsBootstrapSubUserCounts struct {
 }
 
 type projectsBootstrapUserCounts struct {
+	SelectionsPlanned    int64 `json:"selectionsPlanned"`
 	MastersUpdated       int64 `json:"mastersUpdated"`
 	SubUsersUpdated      int64 `json:"subUsersUpdated"`
 	SelectionsPreserved  int64 `json:"selectionsPreserved"`
@@ -172,6 +176,10 @@ type projectsBootstrapRunner struct {
 	checkpointLeaseOwner  string
 	checkpointLeaseExpiry time.Time
 	checkpointLastMaster  primitive.ObjectID
+	// legacyDefaultsSeen memoizes the per-organisation legacy default scan so a
+	// shared organisation is inspected, counted, and reported once per run
+	// rather than once per principal that resolves to it.
+	legacyDefaultsSeen map[primitive.ObjectID]int64
 }
 
 type projectsBootstrapError struct {
@@ -436,17 +444,6 @@ func (r *projectsBootstrapRunner) addConflict(code, masterID, documentID, messag
 	}
 }
 
-func (r *projectsBootstrapRunner) addWarning(code, masterID, documentID, message string) {
-	if len(r.report.Warnings) < 100 {
-		r.report.Warnings = append(r.report.Warnings, projectsBootstrapWarning{
-			Code:       code,
-			MasterID:   masterID,
-			DocumentID: documentID,
-			Message:    message,
-		})
-	}
-}
-
 func (r *projectsBootstrapRunner) interrupted() bool {
 	if r.stopRequested == nil {
 		return false
@@ -640,27 +637,6 @@ func (r *projectsBootstrapRunner) masterFilter(ctx context.Context) (bson.M, err
 	return filter, nil
 }
 
-func (r *projectsBootstrapRunner) scopedMasterID(ctx context.Context) (primitive.ObjectID, bool, error) {
-	if r.config.OrganisationID != "" {
-		id, _ := primitive.ObjectIDFromHex(r.config.OrganisationID)
-		return id, true, nil
-	}
-	if r.config.Username == "" {
-		return primitive.NilObjectID, false, nil
-	}
-	filter, err := r.masterFilter(ctx)
-	if err != nil {
-		return primitive.NilObjectID, false, err
-	}
-	var document struct {
-		ID primitive.ObjectID `bson:"_id"`
-	}
-	if err := r.database.Collection("users").FindOne(ctx, filter).Decode(&document); err != nil {
-		return primitive.NilObjectID, false, err
-	}
-	return document.ID, true, nil
-}
-
 func (r *projectsBootstrapRunner) runOwners(ctx context.Context) error {
 	filter, err := r.masterFilter(ctx)
 	if err != nil {
@@ -740,6 +716,11 @@ func (r *projectsBootstrapRunner) processOwner(ctx context.Context, user project
 	if err != nil {
 		return err
 	}
+	for _, organisationID := range targets {
+		if organisationID != user.ID {
+			r.report.Organisations.SecondaryOwned++
+		}
+	}
 	if user.SelectionState != organisationsBootstrapFieldValue {
 		r.addConflict("organisation-bootstrap-incomplete", masterID, masterID, "master has no canonical organisationId")
 		r.report.Masters.Conflicted++
@@ -776,8 +757,14 @@ func (r *projectsBootstrapRunner) processOwner(ctx context.Context, user project
 		r.report.Verification.Failed++
 		return nil
 	}
-	if selectionChanged && r.config.Mode == "live" {
-		r.report.Users.MastersUpdated++
+	// SelectionsPlanned counts in both modes so the dry-run gate report shows
+	// the volume of users.projectId writes a live run would perform;
+	// MastersUpdated stays an applied-write counter.
+	if selectionChanged {
+		r.report.Users.SelectionsPlanned++
+		if r.config.Mode == "live" {
+			r.report.Users.MastersUpdated++
+		}
 	}
 	if projectChanged || selectionChanged {
 		r.report.Masters.Planned++
@@ -799,7 +786,8 @@ func targetIndex(targets []primitive.ObjectID, id primitive.ObjectID) (int, bool
 
 // ownedOrganisations returns the canonical primary organisation plus every
 // secondary organisation owned by the principal, sorted for deterministic
-// write order.
+// write order. It reports no counters: the sub-users gate calls it too, and
+// counting here would double-count every master.
 func (r *projectsBootstrapRunner) ownedOrganisations(ctx context.Context, ownerID primitive.ObjectID) ([]primitive.ObjectID, error) {
 	owned := map[primitive.ObjectID]struct{}{ownerID: {}}
 	cursor, err := r.database.Collection("organisation").Find(ctx, bson.M{"ownerId": ownerID}, options.Find().SetProjection(bson.M{"_id": 1}))
@@ -813,9 +801,6 @@ func (r *projectsBootstrapRunner) ownedOrganisations(ctx context.Context, ownerI
 		}
 		if err := cursor.Decode(&organisation); err != nil {
 			return nil, err
-		}
-		if organisation.ID != ownerID {
-			r.report.Organisations.SecondaryOwned++
 		}
 		owned[organisation.ID] = struct{}{}
 	}

--- a/actions/projects-bootstrap_test.go
+++ b/actions/projects-bootstrap_test.go
@@ -131,10 +131,6 @@ func TestProjectsBootstrapEveryConflictBlocksLiveWrites(t *testing.T) {
 	if runner.blockingConflictCount != 1 || !runner.hasConflict {
 		t.Fatalf("blocking conflicts = %d, hasConflict = %v", runner.blockingConflictCount, runner.hasConflict)
 	}
-	runner.addWarning("informational", "", "", "not blocking")
-	if runner.blockingConflictCount != 1 {
-		t.Fatalf("warnings must not block: %d", runner.blockingConflictCount)
-	}
 }
 
 func TestProjectsBootstrapInterrupted(t *testing.T) {
@@ -332,9 +328,44 @@ func TestProjectsBootstrapProjectDocumentIsTheReservedDefault(t *testing.T) {
 	}
 }
 
+// A default project minted lazily by Hub API's ensureDefaultProject carries no
+// audit.createdBy/updatedBy: models.Audit marks both omitempty and Hub API sets
+// neither. Such a document must read as complete, or `verify` fails for every
+// organisation that saw a metadata read and the sub-users stage blocks.
+func TestProjectsBootstrapAcceptsLazilyMintedDefaultProject(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	mintedAt := time.Date(2026, time.August, 19, 0, 0, 0, 0, time.UTC)
+	raw, err := bson.Marshal(bson.M{
+		"_id":            organisationID,
+		"organisationId": organisationID,
+		"name":           "Default",
+		"slug":           "default",
+		"isActive":       true,
+		"audit": bson.M{
+			"createdAt":  mintedAt,
+			"updatedAt":  mintedAt,
+			"lastAction": "project.default.created",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !projectsBootstrapDefaultProjectValid(raw, organisationID) {
+		t.Fatal("a lazily-minted default must satisfy the Hub API identity contract")
+	}
+	if !projectsBootstrapExistingProjectTypesValid(raw) {
+		t.Fatal("a lazily-minted default must satisfy project type validation")
+	}
+	if !projectsBootstrapProjectFieldsValid(raw) {
+		t.Fatal("a lazily-minted default must read as complete")
+	}
+	if missing := projectsBootstrapMissingProjectFields(raw, organisationID, mintedAt); len(missing) != 0 {
+		t.Fatalf("missing fields = %v, want none — the migration must not attribute creation to the owner", missing)
+	}
+}
+
 func TestProjectsBootstrapMissingProjectFieldsPreservesExistingValues(t *testing.T) {
 	organisationID := primitive.NewObjectID()
-	ownerID := primitive.NewObjectID()
 	existingCreatedAt := time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
 	raw, err := bson.Marshal(bson.M{
 		"_id":            organisationID,
@@ -353,7 +384,7 @@ func TestProjectsBootstrapMissingProjectFieldsPreservesExistingValues(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	missing := projectsBootstrapMissingProjectFields(raw, organisationID, ownerID, time.Now())
+	missing := projectsBootstrapMissingProjectFields(raw, organisationID, time.Now())
 	if len(missing) != 0 {
 		t.Fatalf("missing fields = %v, want none — populated tenant values must never be rewritten", missing)
 	}
@@ -361,7 +392,6 @@ func TestProjectsBootstrapMissingProjectFieldsPreservesExistingValues(t *testing
 
 func TestProjectsBootstrapMissingProjectFieldsAdoptsExistingCreatedAt(t *testing.T) {
 	organisationID := primitive.NewObjectID()
-	ownerID := primitive.NewObjectID()
 	existingCreatedAt := time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
 	raw, err := bson.Marshal(bson.M{
 		"audit": bson.M{"createdAt": existingCreatedAt},
@@ -369,7 +399,7 @@ func TestProjectsBootstrapMissingProjectFieldsAdoptsExistingCreatedAt(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	missing := projectsBootstrapMissingProjectFields(raw, organisationID, ownerID, time.Now())
+	missing := projectsBootstrapMissingProjectFields(raw, organisationID, time.Now())
 	updatedAt, ok := missing["audit.updatedAt"].(time.Time)
 	if !ok || !updatedAt.Equal(existingCreatedAt) {
 		t.Fatalf("audit.updatedAt = %v, want the existing createdAt %v", missing["audit.updatedAt"], existingCreatedAt)
@@ -512,10 +542,9 @@ func TestProjectsBootstrapReportOmitsTenantSecrets(t *testing.T) {
 	runner := projectsBootstrapRunner{report: &report}
 	for index := 0; index < 150; index++ {
 		runner.addConflict("default-project-conflict", primitive.NewObjectID().Hex(), primitive.NewObjectID().Hex(), "legacy default")
-		runner.addWarning("informational", "", "", "noted")
 	}
-	if len(report.Conflicts) != 100 || len(report.Warnings) != 100 {
-		t.Fatalf("report entries = (%d, %d), want capped at 100", len(report.Conflicts), len(report.Warnings))
+	if len(report.Conflicts) != 100 {
+		t.Fatalf("report entries = %d, want capped at 100", len(report.Conflicts))
 	}
 	if runner.conflictCount != 150 {
 		t.Fatalf("conflict count = %d, want every conflict counted even when not listed", runner.conflictCount)


### PR DESCRIPTION
## Description

This change fixes the projects bootstrap flow to correctly accept default projects that were lazily minted by the Hub API.

Previously, the bootstrap validation logic treated `audit.createdBy` and `audit.updatedBy` as required fields. However, lazily-created default projects intentionally omit those fields because `models.Audit` marks them as `omitempty` and the Hub API never sets them. As a result, valid default projects were incorrectly reported as incomplete, causing `verify` runs to fail and blocking downstream sub-user processing.

The bootstrap migration now:
- Accepts lazily-minted default projects as valid.
- Stops backfilling missing audit ownership fields onto existing documents, avoiding incorrect attribution of project creation.
- Preserves the original shape of tenant data instead of rewriting documents unnecessarily.

The PR also improves operational behavior and reporting by:
- Memoizing legacy default-project scans to avoid repeated work for shared organisations.
- Tracking planned project-selection updates consistently in dry-run and live modes.
- Correcting secondary-organisation accounting to avoid double-counting.
- Removing unused warning paths so reports better reflect that all findings are blocking conditions.

Additional tests cover the lazily-minted project case and ensure existing tenant values remain untouched.