### PR TITLE
refactor(seed): write seeded markers through the ingest writer

### DIFF
--- a/actions/seed-database.go
+++ b/actions/seed-database.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/uug-ai/cli/database"
-	"github.com/uug-ai/markers/pkg/markers"
+	"github.com/uug-ai/ingest/pkg/markers"
 	"github.com/uug-ai/models/pkg/models"
 	"github.com/uug-ai/trace/pkg/opentelemetry"
 	"go.mongodb.org/mongo-driver/bson"
@@ -493,6 +493,10 @@ func RunSeedDatabase(cfg SeedDatabaseConfig) error {
 			DeviceId:       deviceID,
 			GroupId:        "",
 			OrganisationId: userHex,
+			// The seeded organisation id is a deterministic ObjectID, so the
+			// owning project is derived from it with the same pure helper the
+			// rest of the platform uses instead of being hand-computed here.
+			ProjectId:      resolveSeedProjectId(userHex),
 			StartTimestamp: markerStart,
 			EndTimestamp:   markerEnd,
 			Name:           markerName,

--- a/actions/seed-markers.go
+++ b/actions/seed-markers.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gosuri/uiprogress"
-	"github.com/uug-ai/markers/pkg/markers"
+	"github.com/uug-ai/ingest/pkg/markers"
 	"github.com/uug-ai/models/pkg/models"
 	"github.com/uug-ai/trace/pkg/opentelemetry"
 
@@ -204,6 +204,20 @@ func RunSeedMarkers(cfg SeedMarkersConfig) error {
 		organisationId = userObjectID.Hex()
 	}
 
+	// Resolve the project that owns every seeded marker. The value is derived,
+	// never looked up: models.ResolveProjectId is a pure function of the
+	// organisation id, so the seeder stamps exactly what the services reading
+	// these markers compute for themselves. Hand-rolling the default here would
+	// let the seeder drift from the platform the moment the rollout changes.
+	//
+	// A non-ObjectID organisation yields no project rather than a fabricated
+	// one — the same choice the shared writer makes — because a made-up project
+	// hides the marker from every project-scoped read.
+	projectId := resolveSeedProjectId(organisationId)
+	if projectId == nil {
+		fmt.Printf("[warn] organisation %q is not an ObjectID: seeding markers without a project\n", organisationId)
+	}
+
 	// Align the marker package with user-provided database/collection names.
 	markers.DatabaseName = cfg.DBName
 	markers.MARKERS_COLLECTION = cfg.MarkerColl
@@ -376,9 +390,9 @@ func RunSeedMarkers(cfg SeedMarkersConfig) error {
 
 		var batch []markerInsertTask
 		if cfg.LinkMedia {
-			batch = generateBatchMarkersFromMedia(current, organisationId, &mediaItems, groupIds)
+			batch = generateBatchMarkersFromMedia(current, organisationId, projectId, &mediaItems, groupIds)
 		} else {
-			base := generateBatchMarkers(current, cfg.Days, organisationId, deviceKeys, groupIds)
+			base := generateBatchMarkers(current, cfg.Days, organisationId, projectId, deviceKeys, groupIds)
 			batch = make([]markerInsertTask, 0, len(base))
 			for _, marker := range base {
 				batch = append(batch, markerInsertTask{Marker: marker})
@@ -411,7 +425,22 @@ func RunSeedMarkers(cfg SeedMarkersConfig) error {
 	return nil
 }
 
-func generateBatchMarkersFromMedia(batchSize int, organisationId string, mediaItems *[]mediaCandidate, groupIds []string) []markerInsertTask {
+// resolveSeedProjectId returns the project every seeded resource of an
+// organisation belongs to during the hidden single-project rollout, or nil when
+// the organisation id is not an ObjectID and no project can be derived from it.
+//
+// It defers to models.ResolveProjectId rather than reimplementing the default,
+// so seeded data lands in the same project the rest of the platform computes.
+func resolveSeedProjectId(organisationId string) *primitive.ObjectID {
+	organisationObjectId, err := primitive.ObjectIDFromHex(organisationId)
+	if err != nil {
+		return nil
+	}
+	projectId := models.ResolveProjectId(organisationObjectId, nil)
+	return &projectId
+}
+
+func generateBatchMarkersFromMedia(batchSize int, organisationId string, projectId *primitive.ObjectID, mediaItems *[]mediaCandidate, groupIds []string) []markerInsertTask {
 	if batchSize > len(*mediaItems) {
 		batchSize = len(*mediaItems)
 	}
@@ -509,6 +538,7 @@ func generateBatchMarkersFromMedia(batchSize int, organisationId string, mediaIt
 			SiteId:         randomSiteId(),
 			GroupId:        groupId,
 			OrganisationId: organisationId,
+			ProjectId:      projectId,
 			StartTimestamp: start,
 			EndTimestamp:   end,
 			Duration:       duration,
@@ -538,7 +568,7 @@ func popRandomMedia(mediaItems *[]mediaCandidate) mediaCandidate {
 	return selected
 }
 
-func generateBatchMarkers(batchSize int, days int, organisationId string, deviceKeys []string, groupIds []string) []models.Marker {
+func generateBatchMarkers(batchSize int, days int, organisationId string, projectId *primitive.ObjectID, deviceKeys []string, groupIds []string) []models.Marker {
 	tagNames := []string{
 		"vehicle", "license plate", "security", "entrance", "exit", "parking-lot",
 		"lobby-area", "staff", "visitor", "delivery", "motion", "sound", "door", "window",
@@ -650,6 +680,7 @@ func generateBatchMarkers(batchSize int, days int, organisationId string, device
 			SiteId:         randomSiteId(),
 			GroupId:        groupId,
 			OrganisationId: organisationId,
+			ProjectId:      projectId,
 			StartTimestamp: start,
 			EndTimestamp:   end,
 			Duration:       duration,

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.12.0
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/rabbitmq/amqp091-go v1.10.0
-	github.com/uug-ai/markers v1.2.4
-	github.com/uug-ai/models v1.7.17
+	github.com/uug-ai/ingest v1.0.8
+	github.com/uug-ai/models v1.7.19
 	github.com/uug-ai/trace v1.1.0
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.51.0
@@ -30,7 +30,7 @@ require (
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
@@ -46,7 +46,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -322,10 +322,10 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
-github.com/uug-ai/markers v1.2.4 h1:TKpTlHOz7mSKKWhVrsFZLaDaesMTvoFEu9Rkiw8ax8k=
-github.com/uug-ai/markers v1.2.4/go.mod h1:WvDWCIP8RB3fqybWbQuKJoQ26YrcJQA6IGwLqw3cfTE=
-github.com/uug-ai/models v1.7.17 h1:kmQhxmQB8GZorbn6GinIw++bBgvnLNnV46LAz+1StLY=
-github.com/uug-ai/models v1.7.17/go.mod h1:Ts/6PtFhsFOkZQRuC/tntFBG8Fl1BGICC6dmubXULbk=
+github.com/uug-ai/ingest v1.0.8 h1:99r1dYOrdgVTDop5Ot43vN/ZN+e1hDQJ+MT9nZGzzt4=
+github.com/uug-ai/ingest v1.0.8/go.mod h1:hg1eySY4vUkO4k5PYk0m7iz3dOJcsAMLdf1iE7PbpeM=
+github.com/uug-ai/models v1.7.19 h1:GUb3ZqjxpYWGEGScIkKm/SuKlRndGOH6DcE3QYUXUQE=
+github.com/uug-ai/models v1.7.19/go.mod h1:Ts/6PtFhsFOkZQRuC/tntFBG8Fl1BGICC6dmubXULbk=
 github.com/uug-ai/trace v1.1.0 h1:JNLfwrs8A23LDHR+JXpDszI+O423k78B8nq9GeAgzSs=
 github.com/uug-ai/trace v1.1.0/go.mod h1:V1uDCf2a5QhF2/bwymmh6xabUJ41KY8M079oWT1xyfE=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -393,8 +393,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.32.0 h1:jsCblLleRMDrxMN29H3z/k1KliIvpLgCkE6R8FXXNgY=
 golang.org/x/oauth2 v0.32.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Description

This refactor moves seeded marker writes onto the shared ingest writer path so seeded data is produced the same way as runtime marker ingestion. That removes duplicated marker-writing logic and keeps the seeding flow aligned with the platform’s canonical ingest behaviour.

The change also ensures seeded markers are assigned the correct `ProjectId` using `models.ResolveProjectId` instead of locally reimplementing the mapping logic. This prevents the seeder from drifting from the rollout logic used elsewhere in the platform and guarantees seeded markers remain visible to project-scoped reads and services.

By deriving project ownership consistently and routing writes through the ingest package, seeded environments now more accurately reflect production behaviour, reducing inconsistencies between test data and real ingested data.