### PR TITLE
feat(check-indexes): support partialFilterExpression and declare slug + membership indexes

### DIFF
--- a/actions/check-indexes.go
+++ b/actions/check-indexes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -18,6 +19,18 @@ type IndexSpec struct {
 	Name   string
 	Key    bson.D
 	Unique bool
+	// PartialFilterExpression restricts which documents the index covers. It is
+	// nil for the ordinary full index that every other entry in the indexes
+	// files describes.
+	//
+	// A unique index needs this whenever the indexed field is optional. Mongo
+	// treats an absent field as null for a plain unique index, so the first
+	// document without the field indexes as null and the second collides — the
+	// build fails outright on any collection that already holds two of them.
+	// The organisation slug is exactly that case: the field is `omitempty`, so
+	// most organisations have no slug key at all, and the uniqueness has to
+	// apply only to the ones that do.
+	PartialFilterExpression bson.M
 }
 
 const (
@@ -208,9 +221,10 @@ func CheckIndexes(
 		fmt.Println("")
 		fmt.Printf(">> Collection: %s\n", collName)
 		fmt.Println("")
-		fmt.Println("  +------------------------------+----------------------------------------------------+---------+")
-		fmt.Println("  | Name                         | Key                                                | Unique  |")
-		fmt.Println("  +------------------------------+----------------------------------------------------+---------+")
+		border := "  +------------------------------+----------------------------------------------------+---------+------------------------------------------+"
+		fmt.Println(border)
+		fmt.Printf("  | %-28s | %-50s | %-7s | %-40s |\n", "Name", "Key", "Unique", "Partial")
+		fmt.Println(border)
 		for _, m := range misses {
 			name := m.Name
 			key := normalizeKey(m.Key)
@@ -218,9 +232,9 @@ func CheckIndexes(
 			if m.Unique {
 				unique = "true"
 			}
-			fmt.Printf("  | %-28s | %-50s | %-7s |\n", name, key, unique)
+			fmt.Printf("  | %-28s | %-50s | %-7s | %-40s |\n", name, key, unique, describePartialFilter(m.PartialFilterExpression))
 		}
-		fmt.Println("  +------------------------------+----------------------------------------------------+---------+")
+		fmt.Println(border)
 	}
 
 	fmt.Printf("\n[summary] missing_total=%d mode=%s\n", missingTotal, mode)
@@ -238,6 +252,9 @@ func CheckIndexes(
 			opts := options.Index().SetName(m.spec.Name)
 			if m.spec.Unique {
 				opts.SetUnique(true)
+			}
+			if len(m.spec.PartialFilterExpression) > 0 {
+				opts.SetPartialFilterExpression(m.spec.PartialFilterExpression)
 			}
 			_, err := db.Collection(m.coll).Indexes().CreateOne(ctx, mongo.IndexModel{
 				Keys:    m.spec.Key,
@@ -354,6 +371,36 @@ func normalizeKey(d bson.D) string {
 	return sb.String()
 }
 
+// describePartialFilter renders a partial filter expression for the missing-index
+// table. Keys are sorted so the same filter always prints the same way.
+func describePartialFilter(m bson.M) string {
+	if len(m) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString("{")
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(k)
+		sb.WriteString(": ")
+		if nested, ok := m[k].(bson.M); ok {
+			sb.WriteString(describePartialFilter(nested))
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("%v", m[k]))
+	}
+	sb.WriteString("}")
+	return sb.String()
+}
+
 func loadCanonicalIndexSpecsFromFile(path string) (map[string][]IndexSpec, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -428,9 +475,10 @@ func parseIndexArrayBlock(lines []string) []IndexSpec {
 			continue
 		}
 		specs = append(specs, IndexSpec{
-			Name:   name,
-			Key:    key,
-			Unique: extractUnique(p),
+			Name:                    name,
+			Key:                     key,
+			Unique:                  extractUnique(p),
+			PartialFilterExpression: parseFilterDoc(extractPartialFilterExpression(p)),
 		})
 	}
 	return specs
@@ -485,29 +533,64 @@ func extractName(obj string) string {
 }
 
 func extractKeyDoc(obj string) string {
-	start := strings.Index(obj, "key:")
+	return extractBraceDoc(obj, "key:")
+}
+
+// extractPartialFilterExpression returns the raw `partialFilterExpression: {...}`
+// document from an index object, or "" when the index has none. Both the
+// mongosh dump spelling and the shorthand used when hand-writing an indexes
+// file are accepted.
+func extractPartialFilterExpression(obj string) string {
+	for _, label := range []string{"partialFilterExpression:", "partialFilter:"} {
+		if doc := extractBraceDoc(obj, label); doc != "" {
+			return doc
+		}
+	}
+	return ""
+}
+
+// extractBraceDoc returns the balanced `{...}` document that follows label in
+// obj, or "" when label is absent or is not followed by one. Quoted braces are
+// not counted, so a filter such as { name: '{literal}' } stays balanced.
+func extractBraceDoc(obj string, label string) string {
+	start := strings.Index(obj, label)
 	if start == -1 {
 		return ""
 	}
-	s := strings.TrimSpace(obj[start+4:])
+	s := strings.TrimSpace(obj[start+len(label):])
 	if !strings.HasPrefix(s, "{") {
 		return ""
 	}
-	depth := 0
-	var b strings.Builder
+	var (
+		b       strings.Builder
+		inQuote rune
+		depth   int
+	)
 	for _, r := range s {
-		if r == '{' {
-			depth++
-		}
 		b.WriteRune(r)
-		if r == '}' {
-			depth--
-			if depth == 0 {
-				break
+		switch r {
+		case '\'', '"':
+			if inQuote == 0 {
+				inQuote = r
+			} else if inQuote == r {
+				inQuote = 0
+			}
+		case '{':
+			if inQuote == 0 {
+				depth++
+			}
+		case '}':
+			if inQuote == 0 {
+				depth--
+				if depth == 0 {
+					return b.String()
+				}
 			}
 		}
 	}
-	return b.String()
+	// Unbalanced: the object was truncated. Treat it as absent rather than
+	// creating an index with a half-read filter.
+	return ""
 }
 
 func extractUnique(obj string) bool {
@@ -515,15 +598,67 @@ func extractUnique(obj string) bool {
 	return strings.Contains(obj, "unique: true")
 }
 
-func parseKeyFields(doc string) bson.D {
+// parseFilterDoc parses a partialFilterExpression document into bson.M.
+//
+// This is deliberately not parseKeyFields: a key document maps every value to a
+// sort direction, coercing anything unrecognized toward int32(1), whereas a
+// filter carries booleans, strings and nested operator documents that have to
+// survive intact. `{ slug: { $exists: true, $type: 'string' } }` would come out
+// of parseKeyFields as slug:1.
+func parseFilterDoc(doc string) bson.M {
 	doc = strings.TrimSpace(doc)
-	doc = strings.TrimPrefix(doc, "{")
-	doc = strings.TrimSuffix(doc, "}")
-	doc = strings.TrimSpace(doc)
-	if doc == "" {
-		return bson.D{}
+	if !strings.HasPrefix(doc, "{") || !strings.HasSuffix(doc, "}") {
+		return nil
+	}
+	inner := strings.TrimSpace(doc[1 : len(doc)-1])
+	if inner == "" {
+		return bson.M{}
 	}
 
+	out := bson.M{}
+	for _, field := range splitTopLevelFields(inner) {
+		kv := strings.SplitN(field, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(strings.Trim(strings.TrimSpace(kv[0]), "'\""))
+		if key == "" {
+			continue
+		}
+		out[key] = parseFilterValue(strings.TrimSpace(kv[1]))
+	}
+	return out
+}
+
+// parseFilterValue converts a single filter value literal into the Go type the
+// driver should send: a nested document, a bool, an int32, or a string.
+func parseFilterValue(val string) interface{} {
+	val = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(val), ","))
+	switch {
+	case val == "":
+		return ""
+	case strings.HasPrefix(val, "{"):
+		if nested := parseFilterDoc(val); nested != nil {
+			return nested
+		}
+		return val
+	case val == "true":
+		return true
+	case val == "false":
+		return false
+	case strings.HasPrefix(val, "'"), strings.HasPrefix(val, "\""):
+		return strings.Trim(val, "'\"")
+	}
+	if i, err := parseInt(unwrapNumericConstructor(val)); err == nil {
+		return int32(i)
+	}
+	return strings.Trim(val, "'\"")
+}
+
+// splitTopLevelFields splits a comma-separated document body on the commas that
+// sit outside quotes and outside any nested {} or []. Both parseKeyFields and
+// parseFilterDoc need this, and they must agree on it.
+func splitTopLevelFields(body string) []string {
 	var (
 		parts   []string
 		cur     strings.Builder
@@ -531,7 +666,7 @@ func parseKeyFields(doc string) bson.D {
 		depth   int
 	)
 
-	for _, r := range doc {
+	for _, r := range body {
 		switch r {
 		case '\'', '"':
 			if inQuote == 0 {
@@ -552,8 +687,7 @@ func parseKeyFields(doc string) bson.D {
 			cur.WriteRune(r)
 		case ',':
 			if inQuote == 0 && depth == 0 {
-				segment := strings.TrimSpace(cur.String())
-				if segment != "" {
+				if segment := strings.TrimSpace(cur.String()); segment != "" {
 					parts = append(parts, segment)
 				}
 				cur.Reset()
@@ -567,6 +701,19 @@ func parseKeyFields(doc string) bson.D {
 	if tail := strings.TrimSpace(cur.String()); tail != "" {
 		parts = append(parts, tail)
 	}
+	return parts
+}
+
+func parseKeyFields(doc string) bson.D {
+	doc = strings.TrimSpace(doc)
+	doc = strings.TrimPrefix(doc, "{")
+	doc = strings.TrimSuffix(doc, "}")
+	doc = strings.TrimSpace(doc)
+	if doc == "" {
+		return bson.D{}
+	}
+
+	parts := splitTopLevelFields(doc)
 
 	out := make(bson.D, 0, len(parts))
 	for _, p := range parts {

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -1,0 +1,220 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// The parser had no tests before partialFilterExpression support was added. The
+// first group pins the behaviour that existed then, so the shared
+// splitTopLevelFields extraction cannot change how ordinary index files parse.
+
+func TestParseKeyFieldsSingleAndCompound(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+		want bson.D
+	}{
+		{
+			name: "single ascending",
+			doc:  "{ _id: 1 }",
+			want: bson.D{{Key: "_id", Value: int32(1)}},
+		},
+		{
+			name: "compound mixed direction",
+			doc:  "{ organisationId: 1, createdAt: -1 }",
+			want: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "createdAt", Value: int32(-1)}},
+		},
+		{
+			name: "quoted keys",
+			doc:  "{ 'alert_master_user': 1, \"timestamp\": -1 }",
+			want: bson.D{{Key: "alert_master_user", Value: int32(1)}, {Key: "timestamp", Value: int32(-1)}},
+		},
+		{
+			name: "text plugin value is kept as a string",
+			doc:  "{ description: 'text' }",
+			want: bson.D{{Key: "description", Value: "text"}},
+		},
+		{
+			name: "numeric constructor is unwrapped",
+			doc:  "{ createdAt: NumberLong('-1') }",
+			want: bson.D{{Key: "createdAt", Value: int32(-1)}},
+		},
+		{
+			name: "empty document",
+			doc:  "{}",
+			want: bson.D{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseKeyFields(tc.doc)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseKeyFields(%q) = %#v, want %#v", tc.doc, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractUnique(t *testing.T) {
+	if extractUnique("{ v: 2, key: { slug: 1 }, name: 'slug_1', unique: true }") != true {
+		t.Fatal("unique: true not detected")
+	}
+	if extractUnique("{ v: 2, key: { slug: 1 }, name: 'slug_1' }") != false {
+		t.Fatal("absent unique reported as true")
+	}
+}
+
+func TestExtractKeyDocStopsAtBalancedBrace(t *testing.T) {
+	obj := "{ v: 2, key: { organisationId: 1, slug: 1 }, name: 'organisationId_1_slug_1' }"
+	if got, want := extractKeyDoc(obj), "{ organisationId: 1, slug: 1 }"; got != want {
+		t.Fatalf("extractKeyDoc = %q, want %q", got, want)
+	}
+}
+
+// Partial filter expressions.
+
+func TestExtractPartialFilterExpression(t *testing.T) {
+	obj := "{ v: 2, key: { slug: 1 }, name: 'slug_1', unique: true, " +
+		"partialFilterExpression: { slug: { $exists: true, $type: 'string' } } }"
+
+	got := extractPartialFilterExpression(obj)
+	want := "{ slug: { $exists: true, $type: 'string' } }"
+	if got != want {
+		t.Fatalf("extractPartialFilterExpression = %q, want %q", got, want)
+	}
+
+	if extractPartialFilterExpression("{ v: 2, key: { slug: 1 }, name: 'slug_1' }") != "" {
+		t.Fatal("absent partialFilterExpression reported as present")
+	}
+}
+
+func TestParseFilterDocPreservesTypes(t *testing.T) {
+	// The organisation slug filter is the reason this parser exists:
+	// parseKeyFields would flatten the nested operator document to slug:1.
+	got := parseFilterDoc("{ slug: { $exists: true, $type: 'string' } }")
+	want := bson.M{"slug": bson.M{"$exists": true, "$type": "string"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseFilterDoc = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFilterDocValueTypes(t *testing.T) {
+	got := parseFilterDoc("{ enabled: false, retries: 3, state: 'active', nested: { $gt: 0 } }")
+	want := bson.M{
+		"enabled": false,
+		"retries": int32(3),
+		"state":   "active",
+		"nested":  bson.M{"$gt": int32(0)},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseFilterDoc = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFilterDocRejectsNonDocument(t *testing.T) {
+	if got := parseFilterDoc(""); got != nil {
+		t.Fatalf("parseFilterDoc(\"\") = %#v, want nil", got)
+	}
+	if got := parseFilterDoc("{ slug: 1"); got != nil {
+		t.Fatalf("unbalanced document parsed as %#v, want nil", got)
+	}
+}
+
+func TestParseIndexArrayBlockCarriesPartialFilter(t *testing.T) {
+	block := []string{
+		"[",
+		"{ v: 2, key: { _id: 1 }, name: '_id_' },",
+		"{ v: 2, key: { slug: 1 }, name: 'slug_1', unique: true, partialFilterExpression: { slug: { $exists: true, $type: 'string' } } }",
+		"]",
+	}
+
+	specs := parseIndexArrayBlock(block)
+	if len(specs) != 2 {
+		t.Fatalf("parsed %d specs, want 2", len(specs))
+	}
+
+	if specs[0].PartialFilterExpression != nil {
+		t.Fatalf("_id_ carries a partial filter: %#v", specs[0].PartialFilterExpression)
+	}
+
+	slugSpec := specs[1]
+	if slugSpec.Name != "slug_1" || !slugSpec.Unique {
+		t.Fatalf("slug spec = %+v, want name slug_1 and unique", slugSpec)
+	}
+	want := bson.M{"slug": bson.M{"$exists": true, "$type": "string"}}
+	if !reflect.DeepEqual(slugSpec.PartialFilterExpression, want) {
+		t.Fatalf("slug partial filter = %#v, want %#v", slugSpec.PartialFilterExpression, want)
+	}
+}
+
+// The shipped indexes file is the contract the checker actually applies, so it
+// is asserted directly rather than through a fixture.
+
+func TestShippedIndexFileDeclaresSlugIndexes(t *testing.T) {
+	path := filepath.Join("..", "indexes", "hub-20-08-2026.txt")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("indexes file missing: %v", err)
+	}
+
+	canonical, err := loadCanonicalIndexSpecsFromFile(path)
+	if err != nil {
+		t.Fatalf("loadCanonicalIndexSpecsFromFile: %v", err)
+	}
+
+	slugFilter := bson.M{"slug": bson.M{"$exists": true, "$type": "string"}}
+
+	// organisation {slug: 1}: the partial filter is mandatory here. Organisation
+	// slugs are omitempty, so a plain unique index fails to build the moment two
+	// organisations have no slug key.
+	orgSpec := findSpecByKey(t, canonical["organisation"], "slug:1")
+	if !orgSpec.Unique {
+		t.Fatal("organisation slug index is not unique")
+	}
+	if !reflect.DeepEqual(orgSpec.PartialFilterExpression, slugFilter) {
+		t.Fatalf("organisation slug partial filter = %#v, want %#v", orgSpec.PartialFilterExpression, slugFilter)
+	}
+
+	// project {organisationId: 1, slug: 1}: matches ensureProjectIndexes exactly.
+	// A plain unique index on the same keys is a different index, and Mongo
+	// rejects the second definition with IndexOptionsConflict.
+	projSpec := findSpecByKey(t, canonical["project"], "organisationId:1.slug:1")
+	if !projSpec.Unique {
+		t.Fatal("project slug index is not unique")
+	}
+	if !reflect.DeepEqual(projSpec.PartialFilterExpression, slugFilter) {
+		t.Fatalf("project slug partial filter = %#v, want %#v", projSpec.PartialFilterExpression, slugFilter)
+	}
+
+	// The listing index the bootstrap preflight also requires.
+	findSpecByKey(t, canonical["project"], "organisationId:1")
+}
+
+func findSpecByKey(t *testing.T, specs []IndexSpec, normalized string) IndexSpec {
+	t.Helper()
+	for _, s := range specs {
+		if normalizeKey(s.Key) == normalized {
+			return s
+		}
+	}
+	t.Fatalf("no index with key %q among %d specs", normalized, len(specs))
+	return IndexSpec{}
+}
+
+func TestDescribePartialFilterIsStable(t *testing.T) {
+	filter := bson.M{"slug": bson.M{"$type": "string", "$exists": true}}
+	want := "{slug: {$exists: true, $type: string}}"
+	for i := 0; i < 8; i++ {
+		if got := describePartialFilter(filter); got != want {
+			t.Fatalf("describePartialFilter = %q, want %q", got, want)
+		}
+	}
+	if got := describePartialFilter(nil); got != "-" {
+		t.Fatalf("describePartialFilter(nil) = %q, want %q", got, "-")
+	}
+}

--- a/indexes/hub-20-08-2026.txt
+++ b/indexes/hub-20-08-2026.txt
@@ -1,0 +1,243 @@
+alerts
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { master_user_id: 1, enabled: 1 }, name: 'master_user_id_1_enabled_1' }
+]
+analysis
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { userid: 1, key: 1 }, name: 'userid_1_key_1' },
+  { v: 2, key: { userid: 1, start: 1 }, name: 'userid_1_start_1' },
+  { v: 2, key: { start: 1 }, name: 'start_1' },
+  { v: 2, key: { userid: 1, deviceid: 1, timestamp: 1, favourite: 1, 'data.classify.properties': 1 }, name: 'userid_1_deviceid_1_timestamp_1_favourite_1_data.classify.properties_1' },
+  { v: 2, key: { user_id: 1, key: 1 }, name: 'user_id_1_key_1' }
+]
+cache
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+case_attachments
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { task_id: 1, created_at: 1 }, name: 'task_id_1_created_at_1' },
+  { v: 2, key: { organisation_id: 1, _id: 1 }, name: 'organisation_id_1__id_1' },
+  { v: 2, key: { task_id: 1, organisation_id: 1, created_at: 1 }, name: 'case_attachments_task_org_created' }
+]
+case_media
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { task_id: 1, role: 1, created_at: 1 }, name: 'task_id_1_role_1_created_at_1' },
+  { v: 2, key: { organisation_id: 1, status: 1 }, name: 'organisation_id_1_status_1' },
+  { v: 2, key: { source_media_id: 1 }, name: 'source_media_id_1' },
+  { v: 2, key: { task_id: 1, parent_id: 1, action: 1, edit_type: 1, version: 1 }, name: 'case_media_edit_version_unique' },
+  { v: 2, key: { task_id: 1, organisation_id: 1, role: 1, created_at: 1 }, name: 'case_media_task_org_role_created' },
+  { v: 2, key: { task_id: 1, parent_id: 1, action: 1, role: 1, version: -1 }, name: 'case_media_next_version_desc' }
+]
+case_shares
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { task_id: 1, user_id: 1, created_at: -1 }, name: 'task_id_1_user_id_1_created_at_-1' },
+  { v: 2, key: { token: 1 }, name: 'token_1' },
+  { v: 2, key: { token: 1, is_active: 1 }, name: 'token_1_is_active_1' }
+]
+category_options
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+comments
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+counting
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1, timestamp: 1 }, name: 'user_id_1_timestamp_1' },
+  { v: 2, key: { timestamp: 1 }, name: 'timestamp_1' }
+]
+detections
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1, 'source.runId': 1 }, name: 'key_1_source.runId_1', unique: true }
+]
+devices
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1, user_id: 1 }, name: 'key_1_user_id_1' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' }
+]
+event_option_ranges
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, createdAt: 1 }, name: 'organisationId_1_createdAt_1' },
+  { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' }
+]
+event_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, updatedAt: 1 }, name: 'organisationId_1_updatedAt_1' },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+groups
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' }
+]
+heatmap
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1, timestamp: 1 }, name: 'user_id_1_timestamp_1' },
+  { v: 2, key: { timestamp: 1 }, name: 'timestamp_1' }
+]
+io
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+labels
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { is_private: 1, owner_id: 1 }, name: 'is_private_1_owner_id_1' }
+]
+marker_category_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, updatedAt: 1 }, name: 'organisationId_1_updatedAt_1' },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+marker_event_option_ranges
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+marker_event_options
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+marker_option_ranges
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, createdAt: 1 }, name: 'organisationId_1_createdAt_1' },
+  { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' },
+  { v: 2, key: { organisationId: 1, start: 1, deviceKey: 1, end: 1 }, name: 'organisationId_1_start_1_deviceKey_1_end_1' },
+  { v: 2, key: { organisationId: 1, start: 1, deviceId: 1, end: 1 }, name: 'organisationId_1_start_1_deviceId_1_end_1' },
+  { v: 2, key: { organisationId: 1, deviceId: 1, start: 1, end: 1 }, name: 'org_device_start_end' },
+  { v: 2, key: { organisationId: 1, deviceKey: 1, start: 1, end: 1 }, name: 'org_deviceKey_start_end' }
+]
+marker_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, updatedAt: 1 }, name: 'organisationId_1_updatedAt_1' },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+marker_tag_option_ranges
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+marker_tag_options
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+markers
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1 }, name: 'organisationId_1' },
+  { v: 2, key: { organisationId: 1, startTimestamp: 1 }, name: 'organisationId_1_startTimestamp_1' },
+  { v: 2, key: { startTimestamp: 1 }, name: 'startTimestamp_1' },
+  { v: 2, key: { organisationId: 1, deviceId: 1, name: 1, startTimestamp: 1 }, name: 'organisationId_1_deviceId_1_name_1_startTimestamp_1' }
+]
+media
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, deviceId: 1, startTimestamp: -1, _id: -1 }, name: 'org_device_start_id' },
+  { v: 2, key: { organisationId: 1, startTimestamp: -1, _id: -1 }, name: 'org_start_id' },
+  { v: 2, key: { organisationId: 1, videoFile: 1 }, name: 'organisationId_1_videoFile_1' },
+  { v: 2, key: { deviceId: 1, endTimestamp: 1, startTimestamp: 1 }, name: 'deviceId_1_endTimestamp_1_startTimestamp_1' },
+  { v: 2, key: { organisationId: 1, startTimestamp: 1 }, name: 'organisationId_1_startTimestamp_1' },
+  { v: 2, key: { start: 1 }, name: 'start_1' },
+  { v: 2, key: { organisationId: 1, start: 1 }, name: 'organisationId_1_start_1' },
+  { v: 2, key: { organisationId: 1, startTimestamp: 1, endTimestamp: 1, deviceKey: 1 }, name: 'organisationId_1_startTimestamp_1_endTimestamp_1_deviceKey_1' },
+  { v: 2, key: { organisationId: 1, markerNames: 1 }, name: 'organisationId_1_markerNames_1' },
+  { v: 2, key: { organisationId: 1, tagNames: 1 }, name: 'organisationId_1_tagNames_1' },
+  { v: 2, key: { organisationId: 1, eventNames: 1 }, name: 'organisationId_1_eventNames_1' },
+  { v: 2, key: { startTimestamp: 1 }, name: 'startTimestamp_1' },
+  { v: 2, key: { organisationId: 1, star: 1, startTimestamp: -1, _id: -1 }, name: 'media_org_star_start_id' }
+]
+notifications
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' },
+  { v: 2, key: { user: 1 }, name: 'user_1' },
+  { v: 2, key: { userid: 1, timestamp: 1 }, name: 'userid_1_timestamp_1' },
+  { v: 2, key: { alert_master_user: 1, media_key: 1 }, name: 'alert_master_user_1_media_key_1' },
+  { v: 2, key: { userid: 1, media_key: 1 }, name: 'userid_1_media_key_1' },
+  { v: 2, key: { timestamp: 1 }, name: 'timestamp_1' },
+  { v: 2, key: { alert_master_user: 1, timestamp: -1 }, name: 'alert_master_user_1_timestamp_-1' },
+  { v: 2, key: { userid: 1 }, name: 'userid_1' }
+]
+organisation
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { ownerId: 1 }, name: 'ownerId_1' },
+  { v: 2, key: { slug: 1 }, name: 'slug_1', unique: true, partialFilterExpression: { slug: { $exists: true, $type: 'string' } } }
+]
+organisation_users
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+project
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1 }, name: 'organisationId_1' },
+  { v: 2, key: { organisationId: 1, slug: 1 }, name: 'organisationId_1_slug_1', unique: true, partialFilterExpression: { slug: { $exists: true, $type: 'string' } } }
+]
+queues
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+roles
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+settings
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1 }, name: 'key_1' }
+]
+sequences
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1, start: 1, end: 1, 'images.instanceName': 1 }, name: 'user_id_1_start_1_end_1_images.instanceName_1' },
+  { v: 2, key: { user_id: 1, 'images.key': 1 }, name: 'user_id_1_images.key_1' },
+  { v: 2, key: { user_id: 1, end: 1, start: -1, devices: 1 }, name: 'user_id_1_end_1_start_-1_devices_1' },
+  { v: 2, key: { start: 1 }, name: 'start_1' },
+  { v: 2, key: { user_id: 1, start: 1 }, name: 'user_id_1_start_1' }
+]
+sites
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' },
+  { v: 2, key: { devices: 1 }, name: 'devices_1' }
+]
+subscriptions
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' },
+  { v: 2, key: { user_id: 1, updated_at: -1, created_at: -1, _id: -1 }, name: 'user_id_1_updated_at_-1_created_at_-1__id_-1' }
+]
+subscriptions_items
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+tag_option_ranges
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, createdAt: 1 }, name: 'organisationId_1_createdAt_1' },
+  { v: 2, key: { createdAt: 1 }, name: 'createdAt_1' }
+]
+tag_options
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { organisationId: 1, updatedAt: 1 }, name: 'organisationId_1_updatedAt_1' },
+  { v: 2, key: { updatedAt: 1 }, name: 'updatedAt_1' }
+]
+tasks
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+tokens
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+users
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { 'devices.key': 1, amazon_access_key_id: 1 }, name: 'devices.key_1_amazon_access_key_id_1' },
+  { v: 2, key: { username: 1, amazon_access_key_id: 1 }, name: 'username_1_amazon_access_key_id_1' },
+  { v: 2, key: { amazon_access_key_id: 1, username: 1 }, name: 'amazon_access_key_id_1_username_1' },
+  { v: 2, key: { user_id: 1 }, name: 'user_id_1' },
+  { v: 2, key: { reachedLimit: 1 }, name: 'reachedLimit_1' },
+  { v: 2, key: { role: 1 }, name: 'role_1' },
+  { v: 2, key: { email: 1 }, name: 'email_1' },
+  { v: 2, key: { 'cleanup.next_scan_at': 1 }, name: 'cleanup.next_scan_at_1' },
+  { v: 2, key: { 'cleanup.next_scan_at': 1, _id: 1 }, name: 'cleanup.next_scan_at_1__id_1' },
+  { v: 2, key: { username: 1 }, name: 'username_1' }
+]
+videowalls
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+workflow_runs
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { key: 1, organisationId: 1 }, name: 'key_1_organisationId_1' }
+]
+workflows
+[ { v: 2, key: { _id: 1 }, name: '_id_' } ]

--- a/indexes/hub-20-08-2026.txt
+++ b/indexes/hub-20-08-2026.txt
@@ -163,7 +163,11 @@ organisation
   { v: 2, key: { slug: 1 }, name: 'slug_1', unique: true, partialFilterExpression: { slug: { $exists: true, $type: 'string' } } }
 ]
 organisation_users
-[ { v: 2, key: { _id: 1 }, name: '_id_' } ]
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { userId: 1, organisationId: 1 }, name: 'userId_1_organisationId_1', unique: true },
+  { v: 2, key: { organisationId: 1, status: 1 }, name: 'organisationId_1_status_1' }
+]
 project
 [
   { v: 2, key: { _id: 1 }, name: '_id_' },


### PR DESCRIPTION
## Description

Adds support for `partialFilterExpression` in the index checker and aligns the canonical index definitions with the indexes required by the application bootstrap.

This change fixes an important gap in how indexes are declared and validated. MongoDB treats missing values as `null` in unique indexes, which makes plain unique indexes invalid for optional fields such as organisation and project slugs. By supporting partial filter expressions, the checker can now correctly model indexes that only apply when a field exists, preventing index build failures and avoiding `IndexOptionsConflict` errors caused by mismatched definitions.

The PR also introduces canonical slug and membership indexes in the shipped index definitions, ensuring CI and deployment environments validate the same index configuration the application expects at runtime.

To make the new behaviour reliable, the parser has been extended to handle nested filter documents, quoted values, and balanced brace extraction safely. A comprehensive test suite was added to lock down parsing behaviour and prevent regressions in both existing index handling and the new partial-filter support.

Overall, this improves consistency between runtime and declared indexes, makes index validation more accurate, and reduces the risk of production failures caused by incorrect MongoDB index definitions.