### PR TITLE
fix(build): raise the builder image to Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM mcr.microsoft.com/devcontainers/go:1.24-bookworm AS builder
+# The builder's Go must be at least the `go` directive in go.mod. It is not
+# merely a version-skew preference: GOSUMDB is off below, so when GOTOOLCHAIN
+# has to fetch a newer toolchain it cannot verify the download and the build
+# fails outright ("checksum database disabled by GOSUMDB=off"). Keep this image
+# ahead of go.mod, or the next directive bump breaks the image build again.
+FROM mcr.microsoft.com/devcontainers/go:1.25-bookworm AS builder
 
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/go


### PR DESCRIPTION
## Description

This change updates the builder image from Go 1.24 to Go 1.25 to keep the container toolchain aligned with the `go` directive in `go.mod`.

The build currently runs with `GOSUMDB=off`, which means automatic toolchain downloads triggered by `GOTOOLCHAIN` cannot be verified. When the `go.mod` version exceeds the builder image version, the build fails outright instead of transparently upgrading the toolchain. Raising the base image prevents these failures and restores predictable container builds.

The added documentation also clarifies why the builder version must stay ahead of the `go.mod` directive, reducing the risk of future regressions when the Go version is bumped again.