### PR TITLE
fix(tenant): scope subscription readers

### DIFF
--- a/actions/reprocess-media.go
+++ b/actions/reprocess-media.go
@@ -390,7 +390,7 @@ func loadMonitorContext(client *mongo.Client, dbName, userId string) (pipeline.U
 	if user.Id.IsZero() == false {
 		subUserID = user.Id.Hex()
 	}
-	err := db.Collection("subscriptions").FindOne(ctx, bson.M{"user_id": subUserID}).Decode(&subscription)
+	err := db.Collection("subscriptions").FindOne(ctx, database.SubscriptionOwnershipFilter(user)).Decode(&subscription)
 	if err != nil && err != mongo.ErrNoDocuments {
 		return user, subscription, plans, err
 	}

--- a/actions/vault-to-hub-migration.go
+++ b/actions/vault-to-hub-migration.go
@@ -156,7 +156,11 @@ func VaultToHubMigration(mode string,
 		if pipelineUser.Username == "" {
 			log.Println("Warning: unable to load pipeline user for analysis-only events")
 		}
-		pipelineSubscription = database.GetActiveSubscriptionFromMongodb(client, mongodbDestinationDatabase, pipelineUser)
+		subscriptionUser := pipelineUser
+		if subscriptionUser.Id.IsZero() {
+			subscriptionUser.Id = user.Id
+		}
+		pipelineSubscription = database.GetActiveSubscriptionFromMongodb(client, mongodbDestinationDatabase, subscriptionUser)
 		pipelinePlans = database.GetPlansFromMongodb(client, mongodbDestinationDatabase, pipelineUser)
 	}
 	time.Sleep(time.Second * 2)

--- a/actions/vault-to-hub-migration.go
+++ b/actions/vault-to-hub-migration.go
@@ -156,7 +156,7 @@ func VaultToHubMigration(mode string,
 		if pipelineUser.Username == "" {
 			log.Println("Warning: unable to load pipeline user for analysis-only events")
 		}
-		pipelineSubscription = database.GetActiveSubscriptionFromMongodb(client, mongodbDestinationDatabase, user.Id.Hex())
+		pipelineSubscription = database.GetActiveSubscriptionFromMongodb(client, mongodbDestinationDatabase, pipelineUser)
 		pipelinePlans = database.GetPlansFromMongodb(client, mongodbDestinationDatabase, pipelineUser)
 	}
 	time.Sleep(time.Second * 2)

--- a/database/hub.go
+++ b/database/hub.go
@@ -86,21 +86,50 @@ func GetPipelineUserFromMongodb(client *mongo.Client, DatabaseName string, usern
 	return user
 }
 
-func GetActiveSubscriptionFromMongodb(client *mongo.Client, DatabaseName string, userId string) models.Subscription {
+func SubscriptionOwnershipFilter(user models.User) bson.M {
+	legacyOwnerID := strings.TrimSpace(user.MasterAccount)
+	if legacyOwnerID == "" && !user.Id.IsZero() {
+		legacyOwnerID = user.Id.Hex()
+	}
+
+	organisationID := user.OrganisationId
+	if organisationID.IsZero() && legacyOwnerID != "" {
+		organisationID, _ = primitive.ObjectIDFromHex(legacyOwnerID)
+	}
+
+	canonical := bson.M{"organisation_id": organisationID}
+	legacy := bson.M{
+		"organisation_id": bson.M{"$exists": false},
+		"user_id":         legacyOwnerID,
+	}
+	switch {
+	case !organisationID.IsZero() && legacyOwnerID != "":
+		return bson.M{"$or": bson.A{canonical, legacy}}
+	case !organisationID.IsZero():
+		return canonical
+	default:
+		return legacy
+	}
+}
+
+func activeSubscriptionFilter(user models.User, now time.Time) bson.M {
+	return bson.M{"$and": bson.A{
+		SubscriptionOwnershipFilter(user),
+		bson.M{"$or": bson.A{
+			bson.M{"ends_at": bson.M{"$gt": now}},
+			bson.M{"ends_at": nil},
+		}},
+	}}
+}
+
+func GetActiveSubscriptionFromMongodb(client *mongo.Client, DatabaseName string, user models.User) models.Subscription {
 	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT)
 	defer cancel()
 	db := client.Database(DatabaseName)
 	subscriptionCollection := db.Collection("subscriptions")
 
 	var subscription models.Subscription
-	now := time.Now()
-	match := bson.M{
-		"user_id": userId,
-		"$or": []bson.M{
-			{"ends_at": bson.M{"$gt": now}},
-			{"ends_at": nil},
-		},
-	}
+	match := activeSubscriptionFilter(user, time.Now())
 	err := subscriptionCollection.FindOne(ctx, match).Decode(&subscription)
 	if err != nil {
 		log.Println(err)

--- a/database/hub_test.go
+++ b/database/hub_test.go
@@ -1,0 +1,106 @@
+package database
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/uug-ai/models/pkg/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestSubscriptionOwnershipFilterCanonicalPrecedence(t *testing.T) {
+	actorID := primitive.NewObjectID()
+	legacyOwnerID := primitive.NewObjectID()
+	organisationID := primitive.NewObjectID()
+	user := models.User{
+		Id:             actorID,
+		OrganisationId: organisationID,
+		MasterAccount:  legacyOwnerID.Hex(),
+	}
+
+	want := bson.M{"$or": bson.A{
+		bson.M{"organisation_id": organisationID},
+		bson.M{
+			"organisation_id": bson.M{"$exists": false},
+			"user_id":         legacyOwnerID.Hex(),
+		},
+	}}
+	if got := SubscriptionOwnershipFilter(user); !reflect.DeepEqual(got, want) {
+		t.Fatalf("SubscriptionOwnershipFilter() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSubscriptionOwnershipFilterDerivesOrganisationFromStableLegacyOwner(t *testing.T) {
+	actorID := primitive.NewObjectID()
+	legacyOwnerID := primitive.NewObjectID()
+
+	tests := []struct {
+		name string
+		user models.User
+	}{
+		{
+			name: "sub-user uses master identity",
+			user: models.User{Id: actorID, MasterAccount: legacyOwnerID.Hex()},
+		},
+		{
+			name: "master uses account identity",
+			user: models.User{Id: legacyOwnerID},
+		},
+	}
+
+	want := bson.M{"$or": bson.A{
+		bson.M{"organisation_id": legacyOwnerID},
+		bson.M{
+			"organisation_id": bson.M{"$exists": false},
+			"user_id":         legacyOwnerID.Hex(),
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := SubscriptionOwnershipFilter(test.user); !reflect.DeepEqual(got, want) {
+				t.Fatalf("SubscriptionOwnershipFilter() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestSubscriptionOwnershipFilterDoesNotWidenStaleLegacyOwnership(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	legacyOwnerID := primitive.NewObjectID()
+	user := models.User{OrganisationId: organisationID, MasterAccount: legacyOwnerID.Hex()}
+
+	filter := SubscriptionOwnershipFilter(user)
+	legacyBranch := filter["$or"].(bson.A)[1].(bson.M)
+	wantGuard := bson.M{"$exists": false}
+	if got := legacyBranch["organisation_id"]; !reflect.DeepEqual(got, wantGuard) {
+		t.Fatalf("legacy organisation_id guard = %#v, want %#v", got, wantGuard)
+	}
+	if got := legacyBranch["user_id"]; got != legacyOwnerID.Hex() {
+		t.Fatalf("legacy user_id = %#v, want %q", got, legacyOwnerID.Hex())
+	}
+}
+
+func TestActiveSubscriptionFilterPreservesEndsAtPredicate(t *testing.T) {
+	now := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	organisationID := primitive.NewObjectID()
+	user := models.User{Id: organisationID, OrganisationId: organisationID}
+
+	want := bson.M{"$and": bson.A{
+		bson.M{"$or": bson.A{
+			bson.M{"organisation_id": organisationID},
+			bson.M{
+				"organisation_id": bson.M{"$exists": false},
+				"user_id":         organisationID.Hex(),
+			},
+		}},
+		bson.M{"$or": bson.A{
+			bson.M{"ends_at": bson.M{"$gt": now}},
+			bson.M{"ends_at": nil},
+		}},
+	}}
+	if got := activeSubscriptionFilter(user, now); !reflect.DeepEqual(got, want) {
+		t.Fatalf("activeSubscriptionFilter() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

This change fixes subscription lookups for tenant-scoped users by moving ownership resolution away from direct `user_id` matching and toward a canonical organisation-aware filter.

Previously, subscription reads could incorrectly scope access when operating under sub-users, migrated accounts, or mixed legacy/canonical tenancy models. The logic relied on raw user identifiers, which made subscription resolution fragile during tenant transitions and could cause readers to miss valid subscriptions or resolve the wrong ownership context.

This PR introduces a shared `SubscriptionOwnershipFilter` that:
- Resolves subscriptions using `organisation_id` as the canonical ownership model.
- Preserves backward compatibility with legacy `user_id`-based subscriptions.
- Prevents stale legacy ownership records from widening access unintentionally.
- Centralises subscription scoping logic so all readers behave consistently.

`GetActiveSubscriptionFromMongodb` now accepts a full `User` model instead of a plain user ID, allowing ownership resolution to account for tenant relationships and master/sub-user mappings. The migration and media reprocessing flows were updated to use the new logic, ensuring subscription access remains correct during analysis-only events and tenant-aware processing.

Comprehensive tests were added to validate canonical precedence, legacy fallback behaviour, tenant derivation, and active subscription filtering semantics. This improves confidence in multi-tenant subscription isolation while maintaining compatibility with existing subscription records.