### PR TITLE
Add subscription ownership audit adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ are implemented.
 
 ### Organisation ownership backfill
 
-This action currently implements the read-only Phase 4 preflight. It inventories
-canonical tenant presence, BSON type and ObjectID-hex validity, legacy candidate
-coverage, and current indexes for the registered `sites`, `groups`, `devices`,
-and `alerts` adapters. Live writes, scoped tenant resolution, checkpoint resume,
-and index creation deliberately remain disabled until their compare-and-set and
-reconciliation paths are implemented.
+This action currently implements the read-only Phase 3e/Phase 4 preflight. It
+inventories canonical tenant presence, BSON types, legacy candidate coverage,
+and current indexes for registered adapters. The `subscriptions` adapter also
+resolves canonical-missing rows through persisted user/master identity, reports
+bounded ownership conflicts and proposed writes, inventories observed document
+shapes, and verifies required index key order. Live writes, checkpoint writes,
+resume/restart, and index creation remain disabled until Phase 4.
 
 ```sh
 go run . -action organisations-backfill \
@@ -103,6 +104,22 @@ go run . -action organisations-backfill \
 Use `-all` instead of `-collection` to inspect every ready adapter. The command
 exits `0` when preflight passes, `2` for invalid canonical tenant data, `1` for
 operational failures, and `64` for unsafe or invalid arguments.
+
+Subscriptions support an organisation-scoped read-only canary. The scope
+includes canonical rows for the organisation and canonical-missing rows whose
+legacy payer resolves to that organisation; it does not assume
+`user_id == organisation_id`.
+
+```sh
+go run . -action organisations-backfill \
+         -mode dry-run \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collection subscriptions \
+         -adapter-version v1 \
+         -organisation-id <organisation-object-id> \
+         -report-file organisations-backfill-subscriptions.json
+```
 
 ### Vault to Hub Migration
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ go run . -action organisations-backfill \
          -report-file organisations-backfill-subscriptions.json
 ```
 
+The subscription rollout index contracts are versioned in
+`indexes/migration-hub-subscription-ownership-21-08-2026.txt`. Audit them before
+the backfill with:
+
+```sh
+go run . -action check-indexes \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collections subscriptions \
+         -mode dry-run \
+         -index-version migration-hub-subscription-ownership-21-08-2026
+```
+
 ### Vault to Hub Migration
 
 This tool migrates data from a Vault database to a Hub database.

--- a/actions/check-indexes.go
+++ b/actions/check-indexes.go
@@ -55,15 +55,15 @@ func CheckIndexes(
 		if mongoURI == "" {
 			mongoURI = DefaultMongoURI
 		}
-		fmt.Printf("[info] using flag -mongodb-uri=%s\n", mongoURI)
+		fmt.Printf("[info] using flag -mongodb-uri=%s\n", redactMongoURI(mongoURI))
 	} else {
 		in := PromptString(fmt.Sprintf("MongoDB URI (-mongodb-uri, default %s): ", DefaultMongoURI))
 		if strings.TrimSpace(in) == "" {
 			mongoURI = DefaultMongoURI
-			fmt.Printf("[info] using default -mongodb-uri=%s\n", mongoURI)
+			fmt.Printf("[info] using default -mongodb-uri=%s\n", redactMongoURI(mongoURI))
 		} else {
 			mongoURI = in
-			fmt.Printf("[info] using input -mongodb-uri=%s\n", mongoURI)
+			fmt.Printf("[info] using input -mongodb-uri=%s\n", redactMongoURI(mongoURI))
 		}
 	}
 
@@ -277,6 +277,16 @@ func CheckIndexes(
 
 // Helpers
 
+func redactMongoURI(uri string) string {
+	uri = strings.TrimSpace(uri)
+	for _, scheme := range []string{"mongodb+srv://", "mongodb://"} {
+		if strings.HasPrefix(uri, scheme) {
+			return scheme + "<redacted>"
+		}
+	}
+	return "<redacted>"
+}
+
 func parseCSV(s string) []string {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -293,7 +303,7 @@ func parseCSV(s string) []string {
 	return out
 }
 
-// listIndexKeys returns a set keyed by normalized key spec like "name:1.user_id:1"
+// listIndexKeys returns a set keyed by ordered key spec like "name:1.user_id:1".
 func listIndexKeys(ctx context.Context, coll *mongo.Collection) (map[string]struct{}, error) {
 	cur, err := coll.Indexes().List(ctx)
 	if err != nil {
@@ -303,61 +313,31 @@ func listIndexKeys(ctx context.Context, coll *mongo.Collection) (map[string]stru
 
 	out := make(map[string]struct{})
 	for cur.Next(ctx) {
-		var doc bson.M
-		if err := cur.Decode(&doc); err != nil {
+		var doc struct {
+			Key bson.D `bson:"key"`
+		}
+		if err := cur.Decode(&doc); err != nil || len(doc.Key) == 0 {
 			continue
 		}
-		// doc["key"] is a document of fields
-		keyDoc, _ := doc["key"].(bson.M)
-		if keyDoc == nil {
-			// try bson.D
-			if d, ok := doc["key"].(bson.D); ok {
-				out[normalizeKey(d)] = struct{}{}
-				continue
-			}
-			continue
-		}
-		// Convert bson.M to bson.D (stable order)
-		var d bson.D
-		for k, v := range keyDoc {
-			// try to preserve natural ordering isn't possible with map; normalize handles reordering
-			d = append(d, bson.E{Key: k, Value: v})
-		}
-		out[normalizeKey(d)] = struct{}{}
+		out[normalizeKey(doc.Key)] = struct{}{}
 	}
-	return out, nil
+	return out, cur.Err()
 }
 
-// normalizeKey builds a stable string like "field1:1.field2:-1"
+// normalizeKey builds an order-preserving string like "field1:1.field2:-1".
+// Compound index order changes which query prefixes the index can support.
 func normalizeKey(d bson.D) string {
 	if len(d) == 0 {
 		return ""
 	}
-	// Sort by field name for stable comparison
-	type kv struct {
-		k string
-		v interface{}
-	}
-	arr := make([]kv, 0, len(d))
-	for _, e := range d {
-		arr = append(arr, kv{k: e.Key, v: e.Value})
-	}
-	// simple bubble (len small) or use map then sort
-	for i := 0; i < len(arr); i++ {
-		for j := i + 1; j < len(arr); j++ {
-			if arr[j].k < arr[i].k {
-				arr[i], arr[j] = arr[j], arr[i]
-			}
-		}
-	}
 	var sb strings.Builder
-	for i, e := range arr {
+	for i, e := range d {
 		if i > 0 {
 			sb.WriteString(".")
 		}
-		sb.WriteString(e.k)
+		sb.WriteString(e.Key)
 		sb.WriteString(":")
-		switch v := e.v.(type) {
+		switch v := e.Value.(type) {
 		case int32:
 			sb.WriteString(fmt.Sprintf("%d", v))
 		case int64:
@@ -378,24 +358,24 @@ func describePartialFilter(m bson.M) string {
 		return "-"
 	}
 	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+	for key := range m {
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
 	var sb strings.Builder
 	sb.WriteString("{")
-	for i, k := range keys {
+	for i, key := range keys {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
-		sb.WriteString(k)
+		sb.WriteString(key)
 		sb.WriteString(": ")
-		if nested, ok := m[k].(bson.M); ok {
+		if nested, ok := m[key].(bson.M); ok {
 			sb.WriteString(describePartialFilter(nested))
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("%v", m[k]))
+		sb.WriteString(fmt.Sprintf("%v", m[key]))
 	}
 	sb.WriteString("}")
 	return sb.String()

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -61,12 +61,36 @@ func TestParseKeyFieldsSingleAndCompound(t *testing.T) {
 	}
 }
 
+func TestNormalizeKeyPreservesCompoundOrder(t *testing.T) {
+	forward := bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}}
+	reverse := bson.D{{Key: "ends_at", Value: int32(1)}, {Key: "organisation_id", Value: int32(1)}}
+	if got, want := normalizeKey(forward), "organisation_id:1.ends_at:1"; got != want {
+		t.Fatalf("normalizeKey(forward) = %q, want %q", got, want)
+	}
+	if normalizeKey(forward) == normalizeKey(reverse) {
+		t.Fatal("reverse-order compound index normalized as the required index")
+	}
+}
+
 func TestExtractUnique(t *testing.T) {
 	if extractUnique("{ v: 2, key: { slug: 1 }, name: 'slug_1', unique: true }") != true {
 		t.Fatal("unique: true not detected")
 	}
 	if extractUnique("{ v: 2, key: { slug: 1 }, name: 'slug_1' }") != false {
 		t.Fatal("absent unique reported as true")
+	}
+}
+
+func TestRedactMongoURI(t *testing.T) {
+	tests := map[string]string{
+		"mongodb+srv://user:secret@example.mongodb.net/?retryWrites=true": "mongodb+srv://<redacted>",
+		"mongodb://user:secret@localhost:27017/database":                  "mongodb://<redacted>",
+		"not-a-mongodb-uri": "<redacted>",
+	}
+	for input, want := range tests {
+		if got := redactMongoURI(input); got != want {
+			t.Errorf("redactMongoURI(%q) = %q, want %q", input, got, want)
+		}
 	}
 }
 
@@ -193,6 +217,37 @@ func TestShippedIndexFileDeclaresSlugIndexes(t *testing.T) {
 
 	// The listing index the bootstrap preflight also requires.
 	findSpecByKey(t, canonical["project"], "organisationId:1")
+}
+
+func TestSubscriptionOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
+	path := filepath.Join("..", "indexes", "migration-hub-subscription-ownership-21-08-2026.txt")
+	canonical, err := loadCanonicalIndexSpecsFromFile(path)
+	if err != nil {
+		t.Fatalf("loadCanonicalIndexSpecsFromFile: %v", err)
+	}
+
+	want := []IndexSpec{
+		{
+			Name: "organisation_id_1_ends_at_1",
+			Key:  bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}},
+		},
+		{
+			Name: "user_id_1_ends_at_1",
+			Key:  bson.D{{Key: "user_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}},
+		},
+		{
+			Name: "organisation_id_1_updated_at_-1_created_at_-1__id_-1",
+			Key: bson.D{
+				{Key: "organisation_id", Value: int32(1)},
+				{Key: "updated_at", Value: int32(-1)},
+				{Key: "created_at", Value: int32(-1)},
+				{Key: "_id", Value: int32(-1)},
+			},
+		},
+	}
+	if got := canonical["subscriptions"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("subscription ownership indexes = %#v, want %#v", got, want)
+	}
 }
 
 func findSpecByKey(t *testing.T, specs []IndexSpec, normalized string) IndexSpec {

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -1,0 +1,611 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const organisationsBackfillSubscriptionConflictLimit = 100
+
+type organisationsBackfillSubscriptionResolution struct {
+	Scanned             int64                                       `json:"scanned"`
+	CanonicalValid      int64                                       `json:"canonicalValid"`
+	CanonicalMissing    int64                                       `json:"canonicalMissing"`
+	Resolved            int64                                       `json:"resolved"`
+	ZeroCandidate       int64                                       `json:"zeroCandidate"`
+	Conflicts           int64                                       `json:"conflicts"`
+	InvalidLegacy       int64                                       `json:"invalidLegacy"`
+	OrphanUsers         int64                                       `json:"orphanUsers"`
+	OrphanOrganisations int64                                       `json:"orphanOrganisations"`
+	ProposedWrites      int64                                       `json:"proposedWrites"`
+	ObservedFieldTypes  map[string]map[string]int64                 `json:"observedFieldTypes"`
+	ObservedShapes      map[string]int64                            `json:"observedShapes"`
+	ConflictEntries     []organisationsBackfillSubscriptionConflict `json:"conflictEntries"`
+}
+
+type organisationsBackfillSubscriptionConflict struct {
+	Code                  string   `json:"code"`
+	DocumentID            string   `json:"documentId"`
+	CanonicalOrganisation string   `json:"canonicalOrganisation,omitempty"`
+	LegacyUser            string   `json:"legacyUser,omitempty"`
+	ResolvedOrganisations []string `json:"resolvedOrganisations,omitempty"`
+	Message               string   `json:"message"`
+}
+
+type organisationsBackfillIndexContract struct {
+	Name      string                          `json:"name"`
+	Keys      []organisationsBackfillIndexKey `json:"keys"`
+	Status    string                          `json:"status"`
+	IndexName string                          `json:"indexName,omitempty"`
+}
+
+type organisationsBackfillIndexKey struct {
+	Field     string `json:"field"`
+	Direction int32  `json:"direction"`
+}
+
+type organisationsBackfillSubscriptionOutcome struct {
+	documentID         string
+	canonicalID        primitive.ObjectID
+	canonicalValid     bool
+	canonicalMissing   bool
+	canonicalWrong     bool
+	legacyUserID       primitive.ObjectID
+	legacyPresent      bool
+	invalidLegacy      bool
+	resolvedID         primitive.ObjectID
+	resolved           bool
+	zeroCandidate      bool
+	orphanUser         bool
+	orphanOrganisation bool
+	proposedWrite      bool
+	conflicts          []organisationsBackfillSubscriptionConflict
+}
+
+type organisationsBackfillUserResolution struct {
+	organisationID primitive.ObjectID
+	code           string
+	message        string
+}
+
+func inspectOrganisationsBackfillSubscriptions(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillSubscriptionDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+
+	legacyUserIDs := make(map[primitive.ObjectID]struct{})
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if id, state := organisationsBackfillSubscriptionCanonicalOrganisation(document); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		}
+		if id, state := organisationsBackfillSubscriptionLegacyUser(document); state == organisationsBootstrapFieldValue {
+			legacyUserIDs[id] = struct{}{}
+		}
+	}
+
+	users, err := findOrganisationsBackfillUsers(ctx, database.Collection("users"), legacyUserIDs)
+	if err != nil {
+		return report, err
+	}
+	for _, user := range users {
+		resolved := resolveOrganisationsBackfillUser(user)
+		if resolved.code == "" {
+			organisationIDs[resolved.organisationID] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillSubscriptionResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	if !scopeID.IsZero() && !organisations[scopeID] {
+		resolution.OrphanOrganisations++
+		resolution.Conflicts++
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillSubscriptionConflict{
+			Code:                  "scope-organisation-not-found",
+			CanonicalOrganisation: scopeID.Hex(),
+			ResolvedOrganisations: []string{scopeID.Hex()},
+			Message:               "requested organisation does not exist",
+		})
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillSubscription(document, users, organisations)
+		if !organisationsBackfillSubscriptionInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillSubscriptionDocument(&resolution, document)
+		addOrganisationsBackfillSubscriptionOutcome(&resolution, outcome)
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillScopedInventory(&report, outcome)
+		}
+	}
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		first := resolution.ConflictEntries[left]
+		second := resolution.ConflictEntries[right]
+		if first.DocumentID != second.DocumentID {
+			return first.DocumentID < second.DocumentID
+		}
+		if first.Code != second.Code {
+			return first.Code < second.Code
+		}
+		return first.Message < second.Message
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillSubscriptionConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillSubscriptionConflictLimit]
+	}
+	report.Resolution = &resolution
+
+	contracts, err := inspectOrganisationsBackfillSubscriptionIndexes(ctx, database.Collection(adapter.Collection))
+	if err != nil {
+		return report, err
+	}
+	report.IndexContracts = contracts
+	return report, nil
+}
+
+func observeOrganisationsBackfillSubscriptionDocument(report *organisationsBackfillSubscriptionResolution, document bson.Raw) {
+	elements, err := document.Elements()
+	if err != nil {
+		return
+	}
+	shape := make([]string, 0, len(elements))
+	for _, element := range elements {
+		field := element.Key()
+		typeName := element.Value().Type.String()
+		if report.ObservedFieldTypes[field] == nil {
+			report.ObservedFieldTypes[field] = make(map[string]int64)
+		}
+		report.ObservedFieldTypes[field][typeName]++
+		shape = append(shape, field+":"+typeName)
+	}
+	sort.Strings(shape)
+	report.ObservedShapes[strings.Join(shape, ",")]++
+}
+
+func findOrganisationsBackfillSubscriptionDocuments(
+	ctx context.Context,
+	collection *mongo.Collection,
+	config OrganisationsBackfillConfig,
+) ([]bson.Raw, error) {
+	filter := bson.M{}
+	if config.DocumentID != "" {
+		id, _ := primitive.ObjectIDFromHex(config.DocumentID)
+		filter["_id"] = id
+	}
+	cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}).SetBatchSize(int32(config.BatchSize)))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	documents := []bson.Raw{}
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return nil, err
+		}
+		documents = append(documents, document)
+	}
+	return documents, cursor.Err()
+}
+
+func findOrganisationsBackfillUsers(
+	ctx context.Context,
+	collection *mongo.Collection,
+	ids map[primitive.ObjectID]struct{},
+) (map[primitive.ObjectID]bson.Raw, error) {
+	users := make(map[primitive.ObjectID]bson.Raw, len(ids))
+	if len(ids) == 0 {
+		return users, nil
+	}
+	cursor, err := collection.Find(ctx, bson.M{"_id": bson.M{"$in": sortedOrganisationsBackfillObjectIDs(ids)}}, options.Find().SetProjection(bson.M{
+		"_id": 1, "organisationId": 1, "user_id": 1,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return nil, err
+		}
+		id, state := organisationsBootstrapObjectID(document, "_id")
+		if state == organisationsBootstrapFieldValue {
+			users[id] = document
+		}
+	}
+	return users, cursor.Err()
+}
+
+func findOrganisationsBackfillOrganisations(
+	ctx context.Context,
+	collection *mongo.Collection,
+	ids map[primitive.ObjectID]struct{},
+) (map[primitive.ObjectID]bool, error) {
+	organisations := make(map[primitive.ObjectID]bool, len(ids))
+	if len(ids) == 0 {
+		return organisations, nil
+	}
+	cursor, err := collection.Find(ctx, bson.M{"_id": bson.M{"$in": sortedOrganisationsBackfillObjectIDs(ids)}}, options.Find().SetProjection(bson.M{"_id": 1}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return nil, err
+		}
+		id, state := organisationsBootstrapObjectID(document, "_id")
+		if state == organisationsBootstrapFieldValue {
+			organisations[id] = true
+		}
+	}
+	return organisations, cursor.Err()
+}
+
+func sortedOrganisationsBackfillObjectIDs(ids map[primitive.ObjectID]struct{}) []primitive.ObjectID {
+	result := make([]primitive.ObjectID, 0, len(ids))
+	for id := range ids {
+		result = append(result, id)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left].Hex() < result[right].Hex() })
+	return result
+}
+
+func resolveOrganisationsBackfillSubscription(
+	document bson.Raw,
+	users map[primitive.ObjectID]bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+) (outcome organisationsBackfillSubscriptionOutcome) {
+	outcome.documentID = organisationsBackfillSubscriptionDocumentID(document)
+	defer outcome.enrichConflicts()
+	legacyUserID, legacyState := organisationsBackfillSubscriptionLegacyUser(document)
+	if legacyState != organisationsBootstrapFieldEmpty {
+		outcome.legacyPresent = true
+	}
+	if legacyState == organisationsBootstrapFieldValue {
+		outcome.legacyUserID = legacyUserID
+	} else if legacyState == organisationsBootstrapFieldWrong {
+		outcome.invalidLegacy = true
+		outcome.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
+	}
+
+	var canonicalState organisationsBootstrapFieldState
+	outcome.canonicalID, canonicalState = organisationsBackfillSubscriptionCanonicalOrganisation(document)
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		outcome.canonicalValid = true
+		if !organisations[outcome.canonicalID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		// Once canonical ownership exists, user_id is payer/creator provenance.
+		// It may legitimately identify a user whose primary organisation differs
+		// from this subscription's organisation, so it must not be reinterpreted
+		// as a competing tenant candidate.
+		return outcome
+	case organisationsBootstrapFieldEmpty:
+		outcome.canonicalMissing = true
+	default:
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisation_id must be a non-zero BSON ObjectID or null")
+	}
+
+	if legacyState == organisationsBootstrapFieldEmpty {
+		if outcome.canonicalMissing {
+			outcome.zeroCandidate = true
+			outcome.addConflict("zero-candidate", "subscription has neither canonical organisation_id nor legacy user_id")
+		}
+		return outcome
+	}
+	if legacyState == organisationsBootstrapFieldWrong {
+		return outcome
+	}
+	user, exists := users[legacyUserID]
+	if !exists {
+		outcome.orphanUser = true
+		outcome.addConflict("orphan-user", "legacy user_id does not resolve to a user")
+		return outcome
+	}
+	userResolution := resolveOrganisationsBackfillUser(user)
+	if userResolution.code != "" {
+		outcome.addConflict(userResolution.code, userResolution.message)
+		return outcome
+	}
+	outcome.resolvedID = userResolution.organisationID
+	if !organisations[outcome.resolvedID] {
+		outcome.orphanOrganisation = true
+		outcome.addConflict("orphan-organisation", "organisation resolved from legacy user does not exist")
+		return outcome
+	}
+	outcome.resolved = true
+	if outcome.canonicalMissing {
+		outcome.proposedWrite = true
+	}
+	return outcome
+}
+
+func resolveOrganisationsBackfillUser(user bson.Raw) organisationsBackfillUserResolution {
+	userID, userIDState := organisationsBootstrapObjectID(user, "_id")
+	if userIDState != organisationsBootstrapFieldValue {
+		return organisationsBackfillUserResolution{code: "invalid-user-identity", message: "persisted user _id must be a non-zero BSON ObjectID"}
+	}
+	// users.organisationId is mutable active-selection state and is not evidence
+	// of which organisation owned a historical legacy subscription. The stable
+	// legacy master relationship, or the master's own deterministic primary
+	// organisation identity, is the only safe fallback for canonical-missing rows.
+	parentID, parentState := organisationsBackfillSubscriptionLegacyField(user, "user_id")
+	if parentState == organisationsBootstrapFieldValue {
+		return organisationsBackfillUserResolution{organisationID: parentID}
+	}
+	if parentState == organisationsBootstrapFieldWrong {
+		return organisationsBackfillUserResolution{code: "invalid-user-parent", message: "persisted users.user_id must contain an ObjectID hex string"}
+	}
+	return organisationsBackfillUserResolution{organisationID: userID}
+}
+
+func organisationsBackfillSubscriptionLegacyUser(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	return organisationsBackfillSubscriptionLegacyField(document, "user_id")
+}
+
+func organisationsBackfillSubscriptionCanonicalOrganisation(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	value := document.Lookup("organisation_id")
+	switch value.Type {
+	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
+		return primitive.NilObjectID, organisationsBootstrapFieldEmpty
+	case bsontype.ObjectID:
+		id := value.ObjectID()
+		if id.IsZero() {
+			return primitive.NilObjectID, organisationsBootstrapFieldWrong
+		}
+		return id, organisationsBootstrapFieldValue
+	default:
+		return primitive.NilObjectID, organisationsBootstrapFieldWrong
+	}
+}
+
+func organisationsBackfillSubscriptionLegacyField(document bson.Raw, field string) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	value := document.Lookup(field)
+	switch value.Type {
+	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
+		return primitive.NilObjectID, organisationsBootstrapFieldEmpty
+	case bsontype.String:
+		text := value.StringValue()
+		if text == "" {
+			return primitive.NilObjectID, organisationsBootstrapFieldEmpty
+		}
+		id, err := primitive.ObjectIDFromHex(text)
+		if err != nil || id.IsZero() {
+			return primitive.NilObjectID, organisationsBootstrapFieldWrong
+		}
+		return id, organisationsBootstrapFieldValue
+	default:
+		return primitive.NilObjectID, organisationsBootstrapFieldWrong
+	}
+}
+
+func organisationsBackfillSubscriptionDocumentID(document bson.Raw) string {
+	value := document.Lookup("_id")
+	if value.Type == bsontype.ObjectID {
+		return value.ObjectID().Hex()
+	}
+	if value.Type == bsontype.String {
+		return value.StringValue()
+	}
+	return fmt.Sprintf("<%s>", value.Type)
+}
+
+func (outcome *organisationsBackfillSubscriptionOutcome) addConflict(code, message string) {
+	outcome.conflicts = append(outcome.conflicts, organisationsBackfillSubscriptionConflict{
+		Code:       code,
+		DocumentID: outcome.documentID,
+		Message:    message,
+	})
+}
+
+func (outcome *organisationsBackfillSubscriptionOutcome) enrichConflicts() {
+	resolved := map[string]struct{}{}
+	if outcome.canonicalValid {
+		resolved[outcome.canonicalID.Hex()] = struct{}{}
+	}
+	if !outcome.resolvedID.IsZero() {
+		resolved[outcome.resolvedID.Hex()] = struct{}{}
+	}
+	resolvedOrganisations := make([]string, 0, len(resolved))
+	for id := range resolved {
+		resolvedOrganisations = append(resolvedOrganisations, id)
+	}
+	sort.Strings(resolvedOrganisations)
+	for index := range outcome.conflicts {
+		if outcome.canonicalValid {
+			outcome.conflicts[index].CanonicalOrganisation = outcome.canonicalID.Hex()
+		}
+		if !outcome.legacyUserID.IsZero() {
+			outcome.conflicts[index].LegacyUser = outcome.legacyUserID.Hex()
+		}
+		outcome.conflicts[index].ResolvedOrganisations = append([]string(nil), resolvedOrganisations...)
+	}
+}
+
+func organisationsBackfillSubscriptionInScope(outcome organisationsBackfillSubscriptionOutcome, scopeID primitive.ObjectID) bool {
+	if scopeID.IsZero() {
+		return true
+	}
+	if outcome.canonicalValid {
+		return outcome.canonicalID == scopeID
+	}
+	return (outcome.canonicalMissing || outcome.canonicalWrong) && outcome.resolvedID == scopeID
+}
+
+func addOrganisationsBackfillSubscriptionOutcome(
+	report *organisationsBackfillSubscriptionResolution,
+	outcome organisationsBackfillSubscriptionOutcome,
+) {
+	report.Scanned++
+	if outcome.canonicalValid {
+		report.CanonicalValid++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.resolved {
+		report.Resolved++
+	}
+	if outcome.zeroCandidate {
+		report.ZeroCandidate++
+	}
+	if outcome.invalidLegacy {
+		report.InvalidLegacy++
+	}
+	if outcome.orphanUser {
+		report.OrphanUsers++
+	}
+	if outcome.orphanOrganisation {
+		report.OrphanOrganisations++
+	}
+	if outcome.proposedWrite {
+		report.ProposedWrites++
+	}
+	report.Conflicts += int64(len(outcome.conflicts))
+	report.ConflictEntries = append(report.ConflictEntries, outcome.conflicts...)
+}
+
+func resetOrganisationsBackfillScopedInventory(report *organisationsBackfillCollection) {
+	report.Total = 0
+	report.CanonicalPresent = 0
+	report.CanonicalMissing = 0
+	report.CanonicalWrongType = 0
+	report.CanonicalInvalidHex = 0
+	for candidate := range report.LegacyCandidateCount {
+		report.LegacyCandidateCount[candidate] = 0
+	}
+}
+
+func addOrganisationsBackfillScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillSubscriptionOutcome) {
+	report.Total++
+	if outcome.canonicalValid {
+		report.CanonicalPresent++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.canonicalWrong {
+		report.CanonicalWrongType++
+	}
+	if outcome.legacyPresent {
+		report.LegacyCandidateCount["user_id"]++
+	}
+}
+
+func inspectOrganisationsBackfillSubscriptionIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	type indexDocument struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	indexes := []indexDocument{}
+	for cursor.Next(ctx) {
+		var index indexDocument
+		if err := cursor.Decode(&index); err != nil {
+			return nil, err
+		}
+		indexes = append(indexes, index)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(indexes, func(left, right int) bool { return indexes[left].Name < indexes[right].Name })
+
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-active-lookup", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-rollback", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("cleanup", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "updated_at", Value: int32(-1)}, {Key: "created_at", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}
+
+func organisationsBackfillNewIndexContract(name string, keys bson.D) organisationsBackfillIndexContract {
+	contract := organisationsBackfillIndexContract{Name: name}
+	for _, key := range keys {
+		contract.Keys = append(contract.Keys, organisationsBackfillIndexKey{Field: key.Key, Direction: organisationsBackfillIndexDirection(key.Value)})
+	}
+	return contract
+}
+
+func organisationsBackfillOrderedIndexCoverage(actual bson.D, required []organisationsBackfillIndexKey) string {
+	if len(actual) < len(required) {
+		return "missing"
+	}
+	for index, key := range required {
+		if actual[index].Key != key.Field || organisationsBackfillIndexDirection(actual[index].Value) != key.Direction {
+			return "missing"
+		}
+	}
+	if len(actual) == len(required) {
+		return "exact"
+	}
+	return "prefix"
+}
+
+func organisationsBackfillIndexDirection(value any) int32 {
+	switch direction := value.(type) {
+	case int:
+		return int32(direction)
+	case int32:
+		return direction
+	case int64:
+		return int32(direction)
+	case float64:
+		return int32(direction)
+	default:
+		return 0
+	}
+}

--- a/actions/organisations-backfill-subscriptions_mongo_test.go
+++ b/actions/organisations-backfill-subscriptions_mongo_test.go
@@ -1,0 +1,101 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillSubscriptionsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy sub-user subscription", func(mt *mtest.T) {
+		subscriptionID := primitive.NewObjectID()
+		userID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		subscriptionsNamespace := mt.DB.Name() + ".subscriptions"
+		usersNamespace := mt.DB.Name() + ".users"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, subscriptionsNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: subscriptionID},
+				{Key: "user_id", Value: userID.Hex()},
+			}),
+			mtest.CreateCursorResponse(0, usersNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: userID},
+				{Key: "user_id", Value: organisationID.Hex()},
+			}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, subscriptionsNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "canonical_active"}, {Key: "key", Value: bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}}}},
+				bson.D{{Key: "name", Value: "legacy_rollback_extended"}, {Key: "key", Value: bson.D{{Key: "user_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}, {Key: "_id", Value: int32(-1)}}}},
+				bson.D{{Key: "name", Value: "cleanup"}, {Key: "key", Value: bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "updated_at", Value: int32(-1)}, {Key: "created_at", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillSubscriptions(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["subscriptions"],
+			OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"user_id": 1}},
+		)
+		if err != nil {
+			t.Fatalf("inspectOrganisationsBackfillSubscriptions() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Scanned != 1 || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 || report.Resolution.Conflicts != 0 {
+			t.Fatalf("resolution = %+v", report.Resolution)
+		}
+		statuses := map[string]string{}
+		for _, contract := range report.IndexContracts {
+			statuses[contract.Name] = contract.Status
+		}
+		if statuses["canonical-active-lookup"] != "exact" || statuses["legacy-rollback"] != "prefix" || statuses["cleanup"] != "exact" {
+			t.Fatalf("index statuses = %+v", statuses)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				t.Fatalf("subscription dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}
+
+func TestInspectOrganisationsBackfillSubscriptionsRejectsMissingScopeOrganisation(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("missing scoped organisation", func(mt *mtest.T) {
+		organisationID := primitive.NewObjectID()
+		subscriptionsNamespace := mt.DB.Name() + ".subscriptions"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, subscriptionsNamespace, mtest.FirstBatch),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch),
+			mtest.CreateCursorResponse(0, subscriptionsNamespace, mtest.FirstBatch),
+		)
+
+		report, err := inspectOrganisationsBackfillSubscriptions(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["subscriptions"],
+			OrganisationsBackfillConfig{BatchSize: 500, OrganisationID: organisationID.Hex()},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"user_id": 0}},
+		)
+		if err != nil {
+			t.Fatalf("inspectOrganisationsBackfillSubscriptions() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Conflicts != 1 || report.Resolution.OrphanOrganisations != 1 {
+			t.Fatalf("resolution = %+v", report.Resolution)
+		}
+		entry := report.Resolution.ConflictEntries[0]
+		if entry.Code != "scope-organisation-not-found" || entry.CanonicalOrganisation != organisationID.Hex() {
+			t.Fatalf("scope conflict = %+v", entry)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				t.Fatalf("subscription dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-subscriptions_test.go
+++ b/actions/organisations-backfill-subscriptions_test.go
@@ -1,0 +1,302 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillSubscription(t *testing.T) {
+	organisationA := primitive.NewObjectID()
+	organisationB := primitive.NewObjectID()
+	legacyParent := primitive.NewObjectID()
+	userID := primitive.NewObjectID()
+	documentID := primitive.NewObjectID()
+
+	tests := []struct {
+		name          string
+		document      bson.D
+		users         map[primitive.ObjectID]bson.Raw
+		organisations map[primitive.ObjectID]bool
+		check         func(*testing.T, organisationsBackfillSubscriptionOutcome)
+	}{
+		{
+			name: "canonical ownership ignores payer organisation",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisation_id", Value: organisationA},
+				{Key: "user_id", Value: userID.Hex()},
+			},
+			users: map[primitive.ObjectID]bson.Raw{
+				userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "organisationId", Value: organisationB}}),
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true, organisationB: true},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.canonicalValid || outcome.resolved || len(outcome.conflicts) != 0 || outcome.proposedWrite {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "canonical ownership wins over stale legacy payer",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisation_id", Value: organisationA},
+				{Key: "user_id", Value: userID.Hex()},
+			},
+			users: map[primitive.ObjectID]bson.Raw{
+				userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "organisationId", Value: organisationB}}),
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true, organisationB: true},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.canonicalValid || outcome.resolved || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "canonical missing resolves own id despite active selection",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: userID.Hex()}},
+			users: map[primitive.ObjectID]bson.Raw{
+				userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "organisationId", Value: organisationB}}),
+			},
+			organisations: map[primitive.ObjectID]bool{userID: true, organisationB: true},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.canonicalMissing || outcome.resolvedID != userID || !outcome.resolved || !outcome.proposedWrite {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "canonical missing resolves legacy parent",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: userID.Hex()}},
+			users: map[primitive.ObjectID]bson.Raw{
+				userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "user_id", Value: legacyParent.Hex()}}),
+			},
+			organisations: map[primitive.ObjectID]bool{legacyParent: true},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if outcome.resolvedID != legacyParent || !outcome.resolved || !outcome.proposedWrite {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "canonical missing resolves own id for master",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: userID.Hex()}},
+			users: map[primitive.ObjectID]bson.Raw{
+				userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}}),
+			},
+			organisations: map[primitive.ObjectID]bool{userID: true},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if outcome.resolvedID != userID || !outcome.resolved || !outcome.proposedWrite {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:          "zero canonical object id is invalid",
+			document:      bson.D{{Key: "_id", Value: documentID}, {Key: "organisation_id", Value: primitive.NilObjectID}},
+			organisations: map[primitive.ObjectID]bool{},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if outcome.canonicalValid || outcome.canonicalMissing || !outcome.canonicalWrong || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-canonical-organisation" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:          "invalid legacy user id",
+			document:      bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: "invalid"}},
+			organisations: map[primitive.ObjectID]bool{},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.invalidLegacy || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-legacy-user-id" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:          "orphan user",
+			document:      bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: userID.Hex()}},
+			users:         map[primitive.ObjectID]bson.Raw{},
+			organisations: map[primitive.ObjectID]bool{},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.orphanUser || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-user" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "orphan organisation",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: userID.Hex()}},
+			users: map[primitive.ObjectID]bson.Raw{
+				userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "organisationId", Value: organisationB}}),
+			},
+			organisations: map[primitive.ObjectID]bool{},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.orphanOrganisation || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-organisation" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:          "no candidate",
+			document:      bson.D{{Key: "_id", Value: documentID}},
+			organisations: map[primitive.ObjectID]bool{},
+			check: func(t *testing.T, outcome organisationsBackfillSubscriptionOutcome) {
+				if !outcome.canonicalMissing || !outcome.zeroCandidate || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "zero-candidate" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outcome := resolveOrganisationsBackfillSubscription(
+				organisationsBackfillTestRaw(t, test.document),
+				test.users,
+				test.organisations,
+			)
+			test.check(t, outcome)
+		})
+	}
+}
+
+func TestOrganisationsBackfillSubscriptionScopeUsesResolvedUserOrganisation(t *testing.T) {
+	requestedOrganisation := primitive.NewObjectID()
+	otherOrganisation := primitive.NewObjectID()
+	subUserID := primitive.NewObjectID()
+	otherUserID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{requestedOrganisation: true, otherOrganisation: true}
+	users := map[primitive.ObjectID]bson.Raw{
+		subUserID:   organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: subUserID}, {Key: "user_id", Value: requestedOrganisation.Hex()}}),
+		otherUserID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: otherUserID}, {Key: "user_id", Value: requestedOrganisation.Hex()}}),
+	}
+	documents := []bson.Raw{
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "user_id", Value: subUserID.Hex()}}),
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "organisation_id", Value: requestedOrganisation}}),
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "organisation_id", Value: otherOrganisation}, {Key: "user_id", Value: otherUserID.Hex()}}),
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "organisation_id", Value: otherOrganisation}}),
+	}
+
+	report := organisationsBackfillSubscriptionResolution{}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillSubscription(document, users, organisations)
+		if organisationsBackfillSubscriptionInScope(outcome, requestedOrganisation) {
+			addOrganisationsBackfillSubscriptionOutcome(&report, outcome)
+		}
+	}
+
+	if subUserID == requestedOrganisation {
+		t.Fatal("test requires the legacy user and organisation IDs to differ")
+	}
+	if report.Scanned != 2 || report.CanonicalValid != 1 || report.CanonicalMissing != 1 || report.Resolved != 1 || report.ProposedWrites != 1 || report.Conflicts != 0 {
+		t.Fatalf("scoped report = %+v", report)
+	}
+}
+
+func TestOrganisationsBackfillSubscriptionScopeIncludesMissingRequestedOrganisation(t *testing.T) {
+	requestedOrganisation := primitive.NewObjectID()
+	userID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "user_id", Value: userID.Hex()}})
+	users := map[primitive.ObjectID]bson.Raw{
+		userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "user_id", Value: requestedOrganisation.Hex()}}),
+	}
+
+	outcome := resolveOrganisationsBackfillSubscription(document, users, map[primitive.ObjectID]bool{})
+	if !organisationsBackfillSubscriptionInScope(outcome, requestedOrganisation) {
+		t.Fatal("scoped selection excluded a relevant missing organisation")
+	}
+	if !outcome.orphanOrganisation || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-organisation" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestOrganisationsBackfillSubscriptionScopeIncludesWrongCanonicalTypeResolvedToScope(t *testing.T) {
+	requestedOrganisation := primitive.NewObjectID()
+	userID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisation_id", Value: requestedOrganisation.Hex()},
+		{Key: "user_id", Value: userID.Hex()},
+	})
+	users := map[primitive.ObjectID]bson.Raw{
+		userID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: userID}, {Key: "user_id", Value: requestedOrganisation.Hex()}}),
+	}
+	outcome := resolveOrganisationsBackfillSubscription(document, users, map[primitive.ObjectID]bool{requestedOrganisation: true})
+	if !organisationsBackfillSubscriptionInScope(outcome, requestedOrganisation) {
+		t.Fatal("scoped selection excluded a wrong-type canonical conflict resolved to the requested organisation")
+	}
+	if !outcome.canonicalWrong || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-canonical-organisation" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestCanonicalSubscriptionReportsMalformedPayerWithoutReinterpretingOwnership(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisation_id", Value: organisationID},
+		{Key: "user_id", Value: "invalid"},
+	})
+	outcome := resolveOrganisationsBackfillSubscription(document, nil, map[primitive.ObjectID]bool{organisationID: true})
+	if !outcome.canonicalValid || outcome.resolved || !outcome.invalidLegacy {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-legacy-user-id" {
+		t.Fatalf("conflicts = %+v", outcome.conflicts)
+	}
+}
+
+func TestOrganisationsBackfillOrderedIndexCoverage(t *testing.T) {
+	required := []organisationsBackfillIndexKey{
+		{Field: "organisation_id", Direction: 1},
+		{Field: "ends_at", Direction: 1},
+	}
+	tests := []struct {
+		name string
+		key  bson.D
+		want string
+	}{
+		{name: "exact", key: bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int64(1)}}, want: "exact"},
+		{name: "covered prefix", key: bson.D{{Key: "organisation_id", Value: 1}, {Key: "ends_at", Value: 1}, {Key: "_id", Value: -1}}, want: "prefix"},
+		{name: "shorter index", key: bson.D{{Key: "organisation_id", Value: 1}}, want: "missing"},
+		{name: "wrong order", key: bson.D{{Key: "ends_at", Value: 1}, {Key: "organisation_id", Value: 1}}, want: "missing"},
+		{name: "wrong direction", key: bson.D{{Key: "organisation_id", Value: 1}, {Key: "ends_at", Value: -1}}, want: "missing"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := organisationsBackfillOrderedIndexCoverage(test.key, required); got != test.want {
+				t.Fatalf("organisationsBackfillOrderedIndexCoverage() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestObserveOrganisationsBackfillSubscriptionDocumentRecordsTypesAndShape(t *testing.T) {
+	report := organisationsBackfillSubscriptionResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisation_id", Value: primitive.NewObjectID()},
+		{Key: "user_id", Value: primitive.NewObjectID().Hex()},
+	})
+	observeOrganisationsBackfillSubscriptionDocument(&report, document)
+	if report.ObservedFieldTypes["organisation_id"]["objectID"] != 1 || report.ObservedFieldTypes["user_id"]["string"] != 1 {
+		t.Fatalf("observed field types = %#v", report.ObservedFieldTypes)
+	}
+	if len(report.ObservedShapes) != 1 {
+		t.Fatalf("observed shapes = %#v", report.ObservedShapes)
+	}
+}
+
+func organisationsBackfillTestRaw(t *testing.T, document bson.D) bson.Raw {
+	t.Helper()
+	raw, err := bson.Marshal(document)
+	if err != nil {
+		t.Fatalf("bson.Marshal() error = %v", err)
+	}
+	return raw
+}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	organisationsBackfillAdapterVersion  = "v1"
-	organisationsBackfillExitOperational = 1
-	organisationsBackfillExitData        = 2
-	organisationsBackfillExitUsage       = 64
+	organisationsBackfillAdapterVersion       = "v1"
+	organisationsBackfillExitOperational      = 1
+	organisationsBackfillExitData             = 2
+	organisationsBackfillExitUsage            = 64
+	organisationsBackfillResolverSubscription = "subscription-user"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -51,11 +52,14 @@ type OrganisationsBackfillConfig struct {
 }
 
 type organisationsBackfillAdapter struct {
-	Collection       string
-	TargetField      string
-	TargetBSONType   string
-	LegacyCandidates []string
-	PreservedFields  []string
+	Collection            string
+	TargetField           string
+	TargetBSONType        string
+	LegacyCandidates      []string
+	PreservedFields       []string
+	ResolverKind          string
+	MinimumWriterVersions []string
+	MinimumReaderVersions []string
 }
 
 type organisationsBackfillReport struct {
@@ -64,25 +68,35 @@ type organisationsBackfillReport struct {
 	MigrationVersion int                                        `json:"migrationVersion"`
 	AdapterVersion   string                                     `json:"adapterVersion"`
 	BatchSize        int                                        `json:"batchSize"`
+	Scope            *organisationsBackfillScope                `json:"scope,omitempty"`
 	StartedAt        string                                     `json:"startedAt"`
 	CompletedAt      string                                     `json:"completedAt"`
 	PreflightStatus  string                                     `json:"preflightStatus"`
 	Collections      map[string]organisationsBackfillCollection `json:"collections"`
 }
 
+type organisationsBackfillScope struct {
+	OrganisationID string `json:"organisationId"`
+}
+
 type organisationsBackfillCollection struct {
-	TargetField          string           `json:"targetField"`
-	TargetBSONType       string           `json:"targetBsonType"`
-	LegacyCandidates     []string         `json:"legacyCandidates"`
-	PreservedFields      []string         `json:"preservedFields"`
-	Total                int64            `json:"total"`
-	CanonicalPresent     int64            `json:"canonicalPresent"`
-	CanonicalMissing     int64            `json:"canonicalMissing"`
-	CanonicalWrongType   int64            `json:"canonicalWrongType"`
-	CanonicalInvalidHex  int64            `json:"canonicalInvalidHex"`
-	LegacyCandidateCount map[string]int64 `json:"legacyCandidateCount"`
-	Indexes              []string         `json:"indexes"`
-	TargetIndexCovered   bool             `json:"targetIndexCovered"`
+	TargetField           string                                       `json:"targetField"`
+	TargetBSONType        string                                       `json:"targetBsonType"`
+	LegacyCandidates      []string                                     `json:"legacyCandidates"`
+	PreservedFields       []string                                     `json:"preservedFields"`
+	ResolverKind          string                                       `json:"resolverKind,omitempty"`
+	MinimumWriterVersions []string                                     `json:"minimumWriterVersions,omitempty"`
+	MinimumReaderVersions []string                                     `json:"minimumReaderVersions,omitempty"`
+	Total                 int64                                        `json:"total"`
+	CanonicalPresent      int64                                        `json:"canonicalPresent"`
+	CanonicalMissing      int64                                        `json:"canonicalMissing"`
+	CanonicalWrongType    int64                                        `json:"canonicalWrongType"`
+	CanonicalInvalidHex   int64                                        `json:"canonicalInvalidHex"`
+	LegacyCandidateCount  map[string]int64                             `json:"legacyCandidateCount"`
+	Indexes               []string                                     `json:"indexes"`
+	TargetIndexCovered    bool                                         `json:"targetIndexCovered"`
+	IndexContracts        []organisationsBackfillIndexContract         `json:"indexContracts,omitempty"`
+	Resolution            *organisationsBackfillSubscriptionResolution `json:"resolution,omitempty"`
 }
 
 type organisationsBackfillError struct {
@@ -162,14 +176,18 @@ func OrganisationsBackfill(config OrganisationsBackfillConfig) error {
 		PreflightStatus:  "passed",
 		Collections:      make(map[string]organisationsBackfillCollection, len(adapters)),
 	}
+	if config.OrganisationID != "" {
+		report.Scope = &organisationsBackfillScope{OrganisationID: config.OrganisationID}
+	}
 
 	hasDataConflict := false
 	for _, adapter := range adapters {
-		collectionReport, err := inspectOrganisationsBackfillCollection(ctx, hubDB.Collection(adapter.Collection), adapter, config.DocumentID)
+		collectionReport, err := inspectOrganisationsBackfillAdapter(ctx, hubDB, adapter, config)
 		if err != nil {
 			return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: fmt.Errorf("inspect %s: %w", adapter.Collection, err)}
 		}
-		if collectionReport.CanonicalWrongType > 0 || collectionReport.CanonicalInvalidHex > 0 {
+		if collectionReport.CanonicalWrongType > 0 || collectionReport.CanonicalInvalidHex > 0 ||
+			(collectionReport.Resolution != nil && collectionReport.Resolution.Conflicts > 0) {
 			hasDataConflict = true
 			report.PreflightStatus = "blocked"
 		}
@@ -184,9 +202,25 @@ func OrganisationsBackfill(config OrganisationsBackfillConfig) error {
 		return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: err}
 	}
 	if hasDataConflict {
-		return &organisationsBackfillError{code: organisationsBackfillExitData, err: errors.New("preflight found canonical tenant values with invalid BSON type or ObjectID hex")}
+		return &organisationsBackfillError{code: organisationsBackfillExitData, err: errors.New("preflight found invalid or conflicting tenant ownership")}
 	}
 	return nil
+}
+
+func inspectOrganisationsBackfillAdapter(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+) (organisationsBackfillCollection, error) {
+	report, err := inspectOrganisationsBackfillCollection(ctx, database.Collection(adapter.Collection), adapter, config.DocumentID)
+	if err != nil {
+		return report, err
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverSubscription {
+		return inspectOrganisationsBackfillSubscriptions(ctx, database, adapter, config, report)
+	}
+	return report, nil
 }
 
 func normalizeOrganisationsBackfillConfig(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
@@ -257,7 +291,13 @@ func validateOrganisationsBackfillConfig(config OrganisationsBackfillConfig) ([]
 		if _, err := primitive.ObjectIDFromHex(config.OrganisationID); err != nil {
 			return nil, fmt.Errorf("invalid organisation-id: %w", err)
 		}
-		return nil, errors.New("organisation-scoped resolution is disabled until collection resolvers are implemented")
+		if config.AllCollections || config.Collection == "" {
+			return nil, errors.New("organisation-id requires exactly one -collection")
+		}
+		adapter, ok := organisationsBackfillAdapters()[config.Collection]
+		if !ok || adapter.ResolverKind == "" {
+			return nil, fmt.Errorf("organisation-scoped resolution is not implemented for collection %q", config.Collection)
+		}
 	}
 	if config.DocumentID != "" {
 		if config.AllCollections || config.Collection == "" {
@@ -323,6 +363,16 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			LegacyCandidates: []string{"user_id"},
 			PreservedFields:  []string{"created_by", "updated_by"},
 		},
+		"subscriptions": {
+			Collection:            "subscriptions",
+			TargetField:           "organisation_id",
+			TargetBSONType:        "objectId",
+			LegacyCandidates:      []string{"user_id"},
+			PreservedFields:       []string{"user_id"},
+			ResolverKind:          organisationsBackfillResolverSubscription,
+			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
+			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-monitor:v1.3.14", "hub-cleanup:v1.4.19", "cli:v1.2.23"},
+		},
 	}
 }
 
@@ -356,33 +406,44 @@ func inspectOrganisationsBackfillCollection(
 	}
 
 	report := organisationsBackfillCollection{
-		TargetField:          adapter.TargetField,
-		TargetBSONType:       adapter.TargetBSONType,
-		LegacyCandidates:     append([]string(nil), adapter.LegacyCandidates...),
-		PreservedFields:      append([]string(nil), adapter.PreservedFields...),
-		LegacyCandidateCount: make(map[string]int64, len(adapter.LegacyCandidates)),
+		TargetField:           adapter.TargetField,
+		TargetBSONType:        adapter.TargetBSONType,
+		LegacyCandidates:      append([]string(nil), adapter.LegacyCandidates...),
+		PreservedFields:       append([]string(nil), adapter.PreservedFields...),
+		ResolverKind:          adapter.ResolverKind,
+		MinimumWriterVersions: append([]string(nil), adapter.MinimumWriterVersions...),
+		MinimumReaderVersions: append([]string(nil), adapter.MinimumReaderVersions...),
+		LegacyCandidateCount:  make(map[string]int64, len(adapter.LegacyCandidates)),
 	}
 
+	canonicalMissing := bson.A{
+		bson.M{adapter.TargetField: bson.M{"$exists": false}},
+		bson.M{adapter.TargetField: nil},
+	}
+	if adapter.TargetBSONType == "string" {
+		canonicalMissing = append(canonicalMissing, bson.M{adapter.TargetField: ""})
+	}
 	counts := []struct {
 		target *int64
 		filter bson.M
 	}{
 		{&report.Total, baseFilter},
 		{&report.CanonicalPresent, combineOrganisationsBackfillFilters(baseFilter, bson.M{adapter.TargetField: bson.M{"$type": adapter.TargetBSONType, "$ne": ""}})},
-		{&report.CanonicalMissing, combineOrganisationsBackfillFilters(baseFilter, bson.M{"$or": bson.A{
-			bson.M{adapter.TargetField: bson.M{"$exists": false}},
-			bson.M{adapter.TargetField: nil},
-			bson.M{adapter.TargetField: ""},
-		}})},
+		{&report.CanonicalMissing, combineOrganisationsBackfillFilters(baseFilter, bson.M{"$or": canonicalMissing})},
 		{&report.CanonicalWrongType, combineOrganisationsBackfillFilters(baseFilter, bson.M{
 			adapter.TargetField: bson.M{"$exists": true, "$ne": nil},
 			"$expr":             bson.M{"$ne": bson.A{bson.M{"$type": "$" + adapter.TargetField}, adapter.TargetBSONType}},
 		})},
-		{&report.CanonicalInvalidHex, combineOrganisationsBackfillFilters(baseFilter, bson.M{adapter.TargetField: bson.M{
+	}
+	if adapter.TargetBSONType == "string" {
+		counts = append(counts, struct {
+			target *int64
+			filter bson.M
+		}{&report.CanonicalInvalidHex, combineOrganisationsBackfillFilters(baseFilter, bson.M{adapter.TargetField: bson.M{
 			"$type": adapter.TargetBSONType,
 			"$ne":   "",
 			"$not":  primitive.Regex{Pattern: "^[0-9a-fA-F]{24}$"},
-		}})},
+		}})})
 	}
 	for _, count := range counts {
 		value, err := collection.CountDocuments(ctx, count.filter)

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -75,12 +75,29 @@ func TestValidateOrganisationsBackfillConfig(t *testing.T) {
 			wantError: "invalid document-id",
 		},
 		{
-			name: "rejects scoped run before resolvers exist",
+			name: "accepts scoped subscriptions",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.Collection = "subscriptions"
+				config.OrganisationID = "507f1f77bcf86cd799439011"
+				return config
+			},
+		},
+		{
+			name: "rejects scoped sites",
 			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
 				config.OrganisationID = "507f1f77bcf86cd799439011"
 				return config
 			},
-			wantError: "scoped resolution is disabled",
+			wantError: "not implemented",
+		},
+		{
+			name: "rejects invalid scope",
+			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
+				config.Collection = "subscriptions"
+				config.OrganisationID = "invalid"
+				return config
+			},
+			wantError: "invalid organisation-id",
 		},
 		{
 			name: "reports blocked adapter",
@@ -113,7 +130,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "sites"}
+	want := []string{"alerts", "devices", "groups", "sites", "subscriptions"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -121,6 +138,13 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 		if adapters[index].Collection != want[index] {
 			t.Errorf("adapters[%d].Collection = %q, want %q", index, adapters[index].Collection, want[index])
 		}
+	}
+}
+
+func TestSubscriptionsAdapterDeclaresDeploymentPrerequisites(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["subscriptions"]
+	if len(adapter.MinimumWriterVersions) == 0 || len(adapter.MinimumReaderVersions) != 4 {
+		t.Fatalf("subscription deployment prerequisites = writers %#v readers %#v", adapter.MinimumWriterVersions, adapter.MinimumReaderVersions)
 	}
 }
 

--- a/indexes/migration-hub-subscription-ownership-21-08-2026.txt
+++ b/indexes/migration-hub-subscription-ownership-21-08-2026.txt
@@ -1,0 +1,6 @@
+subscriptions
+[
+  { v: 2, key: { organisation_id: 1, ends_at: 1 }, name: 'organisation_id_1_ends_at_1' },
+  { v: 2, key: { user_id: 1, ends_at: 1 }, name: 'user_id_1_ends_at_1' },
+  { v: 2, key: { organisation_id: 1, updated_at: -1, created_at: -1, _id: -1 }, name: 'organisation_id_1_updated_at_-1_created_at_-1__id_-1' }
+]


### PR DESCRIPTION
## Description

Adds a dedicated subscription ownership audit adapter to the organisation backfill workflow, enabling safe preflight validation of subscription tenancy before any migration or write phase is introduced.

The new adapter focuses on one of the highest-risk migration paths: subscriptions that are missing canonical `organisation_id` ownership. It resolves ownership through persisted user/master identity relationships, detects orphaned or conflicting records, inventories observed document shapes and BSON field types, and reports proposed writes without mutating data. This improves migration confidence by surfacing data quality issues early and making rollout impact measurable.

The change also introduces organisation-scoped canary support for subscriptions, allowing targeted validation of a single organisation before broader rollout. This reduces operational risk and provides a controlled path for phased adoption.

Index validation was strengthened to preserve compound index key order during comparison. Previously, indexes were normalized in a way that could treat differently ordered compound indexes as equivalent, even though order changes query coverage and performance characteristics. The new ordered comparison ensures migration index contracts are validated accurately.

Additional improvements include:
- Versioned subscription ownership index contracts and automated verification tests.
- Redaction of MongoDB URIs in logs to avoid leaking credentials in CI or operator output.
- Expanded README guidance for subscription ownership audits and index verification workflows.

Overall, this change improves migration safety, observability, and operational readiness for rolling out canonical organisation ownership to subscriptions.