### PR TITLE
Add alert ownership audit adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ go run . -action check-indexes \
          -index-version migration-hub-subscription-ownership-21-08-2026
 ```
 
+Alerts use canonical `organisationId`, then `master_user_id`, then `user_id`
+only when every higher-precedence field is absent. Their read-only resolver and
+index contracts can be audited with:
+
+```sh
+go run . -action organisations-backfill \
+         -mode dry-run \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collection alerts \
+         -adapter-version v1 \
+         -report-file organisations-backfill-alerts.json
+
+go run . -action check-indexes \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collections alerts \
+         -mode dry-run \
+         -index-version migration-hub-alert-ownership-21-08-2026
+```
+
 ### Vault to Hub Migration
 
 This tool migrates data from a Vault database to a Hub database.

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -228,6 +228,10 @@ func TestSubscriptionOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
 
 	want := []IndexSpec{
 		{
+			Name: "ends_at_1",
+			Key:  bson.D{{Key: "ends_at", Value: int32(1)}},
+		},
+		{
 			Name: "organisation_id_1_ends_at_1",
 			Key:  bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}},
 		},

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -250,6 +250,23 @@ func TestSubscriptionOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
 	}
 }
 
+func TestAlertOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
+	path := filepath.Join("..", "indexes", "migration-hub-alert-ownership-21-08-2026.txt")
+	canonical, err := loadCanonicalIndexSpecsFromFile(path)
+	if err != nil {
+		t.Fatalf("loadCanonicalIndexSpecsFromFile: %v", err)
+	}
+
+	want := []IndexSpec{
+		{Name: "organisationId_1_enabled_1", Key: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
+		{Name: "master_user_id_1_enabled_1", Key: bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
+		{Name: "user_id_1_enabled_1", Key: bson.D{{Key: "user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
+	}
+	if got := canonical["alerts"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("alert ownership indexes = %#v, want %#v", got, want)
+	}
+}
+
 func findSpecByKey(t *testing.T, specs []IndexSpec, normalized string) IndexSpec {
 	t.Helper()
 	for _, s := range specs {

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -258,9 +258,10 @@ func TestAlertOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
 	}
 
 	want := []IndexSpec{
-		{Name: "organisationId_1_enabled_1", Key: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
+		{Name: "organisationId_1_projectId_1_enabled_1", Key: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
+		{Name: "master_user_id_1_projectId_1_enabled_1", Key: bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
+		{Name: "user_id_1_projectId_1_enabled_1", Key: bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
 		{Name: "master_user_id_1_enabled_1", Key: bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
-		{Name: "user_id_1_enabled_1", Key: bson.D{{Key: "user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}},
 	}
 	if got := canonical["alerts"]; !reflect.DeepEqual(got, want) {
 		t.Fatalf("alert ownership indexes = %#v, want %#v", got, want)

--- a/actions/organisations-backfill-alerts.go
+++ b/actions/organisations-backfill-alerts.go
@@ -8,6 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type organisationsBackfillAlertOutcome struct {
@@ -55,7 +56,11 @@ func inspectOrganisationsBackfillAlerts(
 
 	legacyUserIDs := make(map[primitive.ObjectID]struct{})
 	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
 	for _, document := range documents {
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
 		canonicalID, canonicalState, _ := organisationsBackfillAlertCanonicalOrganisation(document)
 		if canonicalState == organisationsBootstrapFieldValue {
 			organisationIDs[canonicalID] = struct{}{}
@@ -96,6 +101,10 @@ func inspectOrganisationsBackfillAlerts(
 	if err != nil {
 		return report, err
 	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
 
 	resolution := organisationsBackfillResolution{
 		ObservedFieldTypes: make(map[string]map[string]int64),
@@ -115,7 +124,7 @@ func inspectOrganisationsBackfillAlerts(
 		})
 	}
 	for _, document := range documents {
-		outcome := resolveOrganisationsBackfillAlert(document, users, organisations)
+		outcome := resolveOrganisationsBackfillAlert(document, users, organisations, projects)
 		if !organisationsBackfillAlertInScope(outcome, scopeID) {
 			continue
 		}
@@ -150,10 +159,11 @@ func resolveOrganisationsBackfillAlert(
 	document bson.Raw,
 	users map[primitive.ObjectID]bson.Raw,
 	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
 ) (outcome organisationsBackfillAlertOutcome) {
 	outcome.documentID = organisationsBackfillDocumentID(document)
 	defer outcome.enrichConflicts()
-	defer outcome.resolveDefaultProject()
+	defer outcome.resolveProject(projects)
 	masterID, masterState := organisationsBackfillStringObjectIDField(document, "master_user_id")
 	if masterState != organisationsBootstrapFieldEmpty {
 		outcome.legacyMasterPresent = true
@@ -168,10 +178,11 @@ func resolveOrganisationsBackfillAlert(
 	if userState == organisationsBootstrapFieldValue {
 		outcome.legacyUserID = userID
 	}
-	_, projectState := organisationsBootstrapObjectID(document, "projectId")
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
 	switch projectState {
 	case organisationsBootstrapFieldValue:
 		outcome.projectPresent = true
+		outcome.resolvedProjectID = projectID
 	case organisationsBootstrapFieldEmpty:
 		outcome.projectMissing = true
 	default:
@@ -266,8 +277,8 @@ func resolveOrganisationsBackfillAlert(
 	return outcome
 }
 
-func (outcome *organisationsBackfillAlertOutcome) resolveDefaultProject() {
-	if !outcome.projectMissing || outcome.projectWrong || len(outcome.conflicts) > 0 {
+func (outcome *organisationsBackfillAlertOutcome) resolveProject(projects map[primitive.ObjectID]primitive.ObjectID) {
+	if outcome.projectWrong || len(outcome.conflicts) > 0 {
 		return
 	}
 	organisationID := outcome.resolvedID
@@ -277,9 +288,57 @@ func (outcome *organisationsBackfillAlertOutcome) resolveDefaultProject() {
 	if organisationID.IsZero() {
 		return
 	}
+	if outcome.projectPresent {
+		if outcome.resolvedProjectID == organisationID {
+			outcome.projectResolved = true
+			return
+		}
+		projectOrganisationID, exists := projects[outcome.resolvedProjectID]
+		if !exists {
+			outcome.addConflict("orphan-project", "projectId does not resolve to a project")
+			return
+		}
+		if projectOrganisationID != organisationID {
+			outcome.addConflict("project-organisation-mismatch", "projectId belongs to a different organisation")
+			return
+		}
+		outcome.projectResolved = true
+		return
+	}
+	if !outcome.projectMissing {
+		return
+	}
 	outcome.resolvedProjectID = organisationID
 	outcome.projectResolved = true
 	outcome.proposedProjectWrite = true
+}
+
+func findOrganisationsBackfillProjects(
+	ctx context.Context,
+	collection *mongo.Collection,
+	ids map[primitive.ObjectID]struct{},
+) (map[primitive.ObjectID]primitive.ObjectID, error) {
+	projects := make(map[primitive.ObjectID]primitive.ObjectID, len(ids))
+	if len(ids) == 0 {
+		return projects, nil
+	}
+	cursor, err := collection.Find(ctx, bson.M{"_id": bson.M{"$in": sortedOrganisationsBackfillObjectIDs(ids)}}, options.Find().SetProjection(bson.M{"_id": 1, "organisationId": 1}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return nil, err
+		}
+		projectID, projectState := organisationsBootstrapObjectID(document, "_id")
+		organisationID, organisationState := organisationsBootstrapObjectID(document, "organisationId")
+		if projectState == organisationsBootstrapFieldValue && organisationState == organisationsBootstrapFieldValue {
+			projects[projectID] = organisationID
+		}
+	}
+	return projects, cursor.Err()
 }
 
 func organisationsBackfillAlertCanonicalOrganisation(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState, bool) {

--- a/actions/organisations-backfill-alerts.go
+++ b/actions/organisations-backfill-alerts.go
@@ -16,6 +16,9 @@ type organisationsBackfillAlertOutcome struct {
 	canonicalValid      bool
 	canonicalMissing    bool
 	canonicalWrong      bool
+	projectPresent      bool
+	projectMissing      bool
+	projectWrong        bool
 	legacyMasterID      primitive.ObjectID
 	legacyMasterPresent bool
 	legacyUserID        primitive.ObjectID
@@ -160,6 +163,16 @@ func resolveOrganisationsBackfillAlert(
 	}
 	if userState == organisationsBootstrapFieldValue {
 		outcome.legacyUserID = userID
+	}
+	_, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		outcome.projectPresent = true
+	case organisationsBootstrapFieldEmpty:
+		outcome.projectMissing = true
+	default:
+		outcome.projectWrong = true
+		outcome.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
 	}
 
 	canonicalID, canonicalState, canonicalWrongType := organisationsBackfillAlertCanonicalOrganisation(document)
@@ -353,6 +366,15 @@ func addOrganisationsBackfillAlertScopedInventory(report *organisationsBackfillC
 	if outcome.canonicalWrong {
 		report.CanonicalWrongType++
 	}
+	if outcome.projectPresent {
+		report.ProjectPresent++
+	}
+	if outcome.projectMissing {
+		report.ProjectMissing++
+	}
+	if outcome.projectWrong {
+		report.ProjectWrongType++
+	}
 	if outcome.legacyMasterPresent {
 		report.LegacyCandidateCount["master_user_id"]++
 	}
@@ -375,9 +397,10 @@ func inspectOrganisationsBackfillAlertIndexes(ctx context.Context, collection *m
 		return nil, err
 	}
 	contracts := []organisationsBackfillIndexContract{
-		organisationsBackfillNewIndexContract("canonical-enabled-lookup", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("canonical-project-enabled-lookup", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-master-project-lookup", bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-creator-project-lookup", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
 		organisationsBackfillNewIndexContract("legacy-master-rollback", bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
-		organisationsBackfillNewIndexContract("legacy-creator-rollback", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
 	}
 	for index := range contracts {
 		contracts[index].Status = "missing"

--- a/actions/organisations-backfill-alerts.go
+++ b/actions/organisations-backfill-alerts.go
@@ -1,0 +1,396 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type organisationsBackfillAlertOutcome struct {
+	documentID          string
+	canonicalID         primitive.ObjectID
+	canonicalValid      bool
+	canonicalMissing    bool
+	canonicalWrong      bool
+	legacyMasterID      primitive.ObjectID
+	legacyMasterPresent bool
+	legacyUserID        primitive.ObjectID
+	legacyUserPresent   bool
+	invalidLegacy       bool
+	resolvedID          primitive.ObjectID
+	resolved            bool
+	zeroCandidate       bool
+	multipleCandidates  bool
+	orphanUser          bool
+	orphanOrganisation  bool
+	proposedWrite       bool
+	conflicts           []organisationsBackfillConflict
+}
+
+func inspectOrganisationsBackfillAlerts(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+
+	legacyUserIDs := make(map[primitive.ObjectID]struct{})
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		canonicalID, canonicalState, _ := organisationsBackfillAlertCanonicalOrganisation(document)
+		if canonicalState == organisationsBootstrapFieldValue {
+			organisationIDs[canonicalID] = struct{}{}
+			continue
+		}
+		if canonicalState == organisationsBootstrapFieldWrong {
+			continue
+		}
+		masterID, masterState := organisationsBackfillStringObjectIDField(document, "master_user_id")
+		if masterState == organisationsBootstrapFieldValue {
+			organisationIDs[masterID] = struct{}{}
+			continue
+		}
+		if masterState == organisationsBootstrapFieldWrong {
+			continue
+		}
+		userID, userState := organisationsBackfillStringObjectIDField(document, "user_id")
+		if userState == organisationsBootstrapFieldValue {
+			legacyUserIDs[userID] = struct{}{}
+			organisationIDs[userID] = struct{}{}
+		}
+	}
+
+	users, err := findOrganisationsBackfillUsers(ctx, database.Collection("users"), legacyUserIDs)
+	if err != nil {
+		return report, err
+	}
+	for _, user := range users {
+		resolved := resolveOrganisationsBackfillUser(user)
+		if resolved.code == "" {
+			organisationIDs[resolved.organisationID] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	if !scopeID.IsZero() && !organisations[scopeID] {
+		resolution.OrphanOrganisations++
+		resolution.Conflicts++
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
+			Code:                  "scope-organisation-not-found",
+			CanonicalOrganisation: scopeID.Hex(),
+			ResolvedOrganisations: []string{scopeID.Hex()},
+			Message:               "requested organisation does not exist",
+		})
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillAlert(document, users, organisations)
+		if !organisationsBackfillAlertInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillAlertOutcome(&resolution, outcome)
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillAlertScopedInventory(&report, outcome)
+		}
+	}
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		first := resolution.ConflictEntries[left]
+		second := resolution.ConflictEntries[right]
+		if first.DocumentID != second.DocumentID {
+			return first.DocumentID < second.DocumentID
+		}
+		return first.Code < second.Code
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+	report.Resolution = &resolution
+
+	contracts, err := inspectOrganisationsBackfillAlertIndexes(ctx, database.Collection(adapter.Collection))
+	if err != nil {
+		return report, err
+	}
+	report.IndexContracts = contracts
+	return report, nil
+}
+
+func resolveOrganisationsBackfillAlert(
+	document bson.Raw,
+	users map[primitive.ObjectID]bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+) (outcome organisationsBackfillAlertOutcome) {
+	outcome.documentID = organisationsBackfillDocumentID(document)
+	defer outcome.enrichConflicts()
+	masterID, masterState := organisationsBackfillStringObjectIDField(document, "master_user_id")
+	if masterState != organisationsBootstrapFieldEmpty {
+		outcome.legacyMasterPresent = true
+	}
+	if masterState == organisationsBootstrapFieldValue {
+		outcome.legacyMasterID = masterID
+	}
+	userID, userState := organisationsBackfillStringObjectIDField(document, "user_id")
+	if userState != organisationsBootstrapFieldEmpty {
+		outcome.legacyUserPresent = true
+	}
+	if userState == organisationsBootstrapFieldValue {
+		outcome.legacyUserID = userID
+	}
+
+	canonicalID, canonicalState, canonicalWrongType := organisationsBackfillAlertCanonicalOrganisation(document)
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		outcome.canonicalID = canonicalID
+		outcome.canonicalValid = !canonicalWrongType
+		outcome.canonicalWrong = canonicalWrongType
+		if canonicalWrongType {
+			outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		}
+		if !organisations[canonicalID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		outcome.canonicalMissing = true
+	}
+
+	switch masterState {
+	case organisationsBootstrapFieldValue:
+		outcome.resolvedID = masterID
+		if !organisations[masterID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "master_user_id organisation does not exist")
+			return outcome
+		}
+		outcome.resolved = true
+		outcome.proposedWrite = true
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		outcome.invalidLegacy = true
+		outcome.addConflict("invalid-legacy-master-id", "master_user_id must contain an ObjectID hex string")
+		return outcome
+	}
+
+	switch userState {
+	case organisationsBootstrapFieldEmpty:
+		outcome.zeroCandidate = true
+		outcome.addConflict("zero-candidate", "alert has no canonical organisationId, master_user_id, or user_id")
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		outcome.invalidLegacy = true
+		outcome.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
+		return outcome
+	}
+	candidates := make(map[primitive.ObjectID]struct{})
+	if organisations[userID] {
+		candidates[userID] = struct{}{}
+	}
+	user, userExists := users[userID]
+	if userExists {
+		userResolution := resolveOrganisationsBackfillUser(user)
+		if userResolution.code != "" {
+			outcome.addConflict(userResolution.code, userResolution.message)
+			return outcome
+		}
+		if !organisations[userResolution.organisationID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "organisation resolved from legacy creator does not exist")
+			return outcome
+		}
+		candidates[userResolution.organisationID] = struct{}{}
+	} else if len(candidates) == 0 {
+		outcome.orphanUser = true
+		outcome.addConflict("orphan-user", "legacy user_id resolves to neither an organisation nor a user")
+		return outcome
+	}
+
+	resolved := sortedOrganisationsBackfillObjectIDs(candidates)
+	if len(resolved) > 1 {
+		outcome.multipleCandidates = true
+		outcome.addConflict("multiple-candidates", "legacy user_id resolves to multiple organisations")
+		for _, id := range resolved {
+			outcome.conflicts[len(outcome.conflicts)-1].ResolvedOrganisations = append(outcome.conflicts[len(outcome.conflicts)-1].ResolvedOrganisations, id.Hex())
+		}
+		return outcome
+	}
+	outcome.resolvedID = resolved[0]
+	outcome.resolved = true
+	outcome.proposedWrite = true
+	return outcome
+}
+
+func organisationsBackfillAlertCanonicalOrganisation(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState, bool) {
+	value := document.Lookup("organisationId")
+	if value.Type == bsontype.ObjectID {
+		id := value.ObjectID()
+		if id.IsZero() {
+			return primitive.NilObjectID, organisationsBootstrapFieldWrong, true
+		}
+		return id, organisationsBootstrapFieldValue, true
+	}
+	id, state := organisationsBackfillStringObjectIDField(document, "organisationId")
+	return id, state, false
+}
+
+func (outcome *organisationsBackfillAlertOutcome) addConflict(code, message string) {
+	outcome.conflicts = append(outcome.conflicts, organisationsBackfillConflict{
+		Code:       code,
+		DocumentID: outcome.documentID,
+		Message:    message,
+	})
+}
+
+func (outcome *organisationsBackfillAlertOutcome) enrichConflicts() {
+	resolved := make(map[string]struct{})
+	if !outcome.canonicalID.IsZero() {
+		resolved[outcome.canonicalID.Hex()] = struct{}{}
+	}
+	if !outcome.resolvedID.IsZero() {
+		resolved[outcome.resolvedID.Hex()] = struct{}{}
+	}
+	resolvedOrganisations := make([]string, 0, len(resolved))
+	for id := range resolved {
+		resolvedOrganisations = append(resolvedOrganisations, id)
+	}
+	sort.Strings(resolvedOrganisations)
+	for index := range outcome.conflicts {
+		if !outcome.canonicalID.IsZero() {
+			outcome.conflicts[index].CanonicalOrganisation = outcome.canonicalID.Hex()
+		}
+		if !outcome.legacyMasterID.IsZero() {
+			outcome.conflicts[index].LegacyMaster = outcome.legacyMasterID.Hex()
+		}
+		if !outcome.legacyUserID.IsZero() {
+			outcome.conflicts[index].LegacyUser = outcome.legacyUserID.Hex()
+		}
+		if len(outcome.conflicts[index].ResolvedOrganisations) == 0 {
+			outcome.conflicts[index].ResolvedOrganisations = append([]string(nil), resolvedOrganisations...)
+		}
+	}
+}
+
+func organisationsBackfillAlertInScope(outcome organisationsBackfillAlertOutcome, scopeID primitive.ObjectID) bool {
+	if scopeID.IsZero() {
+		return true
+	}
+	if !outcome.canonicalID.IsZero() {
+		return outcome.canonicalID == scopeID
+	}
+	return outcome.resolvedID == scopeID
+}
+
+func addOrganisationsBackfillAlertOutcome(report *organisationsBackfillResolution, outcome organisationsBackfillAlertOutcome) {
+	report.Scanned++
+	if outcome.canonicalValid {
+		report.CanonicalValid++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.resolved {
+		report.Resolved++
+	}
+	if outcome.zeroCandidate {
+		report.ZeroCandidate++
+	}
+	if outcome.multipleCandidates {
+		report.MultipleCandidates++
+	}
+	if outcome.invalidLegacy {
+		report.InvalidLegacy++
+	}
+	if outcome.orphanUser {
+		report.OrphanUsers++
+	}
+	if outcome.orphanOrganisation {
+		report.OrphanOrganisations++
+	}
+	if outcome.proposedWrite {
+		report.ProposedWrites++
+	}
+	report.Conflicts += int64(len(outcome.conflicts))
+	report.ConflictEntries = append(report.ConflictEntries, outcome.conflicts...)
+}
+
+func addOrganisationsBackfillAlertScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillAlertOutcome) {
+	report.Total++
+	if outcome.canonicalValid {
+		report.CanonicalPresent++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.canonicalWrong {
+		report.CanonicalWrongType++
+	}
+	if outcome.legacyMasterPresent {
+		report.LegacyCandidateCount["master_user_id"]++
+	}
+	if outcome.legacyUserPresent {
+		report.LegacyCandidateCount["user_id"]++
+	}
+}
+
+func inspectOrganisationsBackfillAlertIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-enabled-lookup", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-master-rollback", bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-creator-rollback", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-alerts.go
+++ b/actions/organisations-backfill-alerts.go
@@ -11,27 +11,30 @@ import (
 )
 
 type organisationsBackfillAlertOutcome struct {
-	documentID          string
-	canonicalID         primitive.ObjectID
-	canonicalValid      bool
-	canonicalMissing    bool
-	canonicalWrong      bool
-	projectPresent      bool
-	projectMissing      bool
-	projectWrong        bool
-	legacyMasterID      primitive.ObjectID
-	legacyMasterPresent bool
-	legacyUserID        primitive.ObjectID
-	legacyUserPresent   bool
-	invalidLegacy       bool
-	resolvedID          primitive.ObjectID
-	resolved            bool
-	zeroCandidate       bool
-	multipleCandidates  bool
-	orphanUser          bool
-	orphanOrganisation  bool
-	proposedWrite       bool
-	conflicts           []organisationsBackfillConflict
+	documentID           string
+	canonicalID          primitive.ObjectID
+	canonicalValid       bool
+	canonicalMissing     bool
+	canonicalWrong       bool
+	projectPresent       bool
+	projectMissing       bool
+	projectWrong         bool
+	resolvedProjectID    primitive.ObjectID
+	projectResolved      bool
+	proposedProjectWrite bool
+	legacyMasterID       primitive.ObjectID
+	legacyMasterPresent  bool
+	legacyUserID         primitive.ObjectID
+	legacyUserPresent    bool
+	invalidLegacy        bool
+	resolvedID           primitive.ObjectID
+	resolved             bool
+	zeroCandidate        bool
+	multipleCandidates   bool
+	orphanUser           bool
+	orphanOrganisation   bool
+	proposedWrite        bool
+	conflicts            []organisationsBackfillConflict
 }
 
 func inspectOrganisationsBackfillAlerts(
@@ -150,6 +153,7 @@ func resolveOrganisationsBackfillAlert(
 ) (outcome organisationsBackfillAlertOutcome) {
 	outcome.documentID = organisationsBackfillDocumentID(document)
 	defer outcome.enrichConflicts()
+	defer outcome.resolveDefaultProject()
 	masterID, masterState := organisationsBackfillStringObjectIDField(document, "master_user_id")
 	if masterState != organisationsBootstrapFieldEmpty {
 		outcome.legacyMasterPresent = true
@@ -262,6 +266,22 @@ func resolveOrganisationsBackfillAlert(
 	return outcome
 }
 
+func (outcome *organisationsBackfillAlertOutcome) resolveDefaultProject() {
+	if !outcome.projectMissing || outcome.projectWrong || len(outcome.conflicts) > 0 {
+		return
+	}
+	organisationID := outcome.resolvedID
+	if outcome.canonicalValid {
+		organisationID = outcome.canonicalID
+	}
+	if organisationID.IsZero() {
+		return
+	}
+	outcome.resolvedProjectID = organisationID
+	outcome.projectResolved = true
+	outcome.proposedProjectWrite = true
+}
+
 func organisationsBackfillAlertCanonicalOrganisation(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState, bool) {
 	value := document.Lookup("organisationId")
 	if value.Type == bsontype.ObjectID {
@@ -350,6 +370,12 @@ func addOrganisationsBackfillAlertOutcome(report *organisationsBackfillResolutio
 	}
 	if outcome.proposedWrite {
 		report.ProposedWrites++
+	}
+	if outcome.projectResolved {
+		report.ProjectResolved++
+	}
+	if outcome.proposedProjectWrite {
+		report.ProposedProjectWrites++
 	}
 	report.Conflicts += int64(len(outcome.conflicts))
 	report.ConflictEntries = append(report.ConflictEntries, outcome.conflicts...)

--- a/actions/organisations-backfill-alerts_mongo_test.go
+++ b/actions/organisations-backfill-alerts_mongo_test.go
@@ -1,0 +1,54 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillAlertsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy master alert", func(mt *mtest.T) {
+		alertID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		alertsNamespace := mt.DB.Name() + ".alerts"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, alertsNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: alertID},
+				{Key: "master_user_id", Value: organisationID.Hex()},
+				{Key: "user_id", Value: primitive.NewObjectID().Hex()},
+				{Key: "enabled", Value: true},
+			}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, alertsNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "master_user_id_1_enabled_1"}, {Key: "key", Value: bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillAlerts(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["alerts"],
+			OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"master_user_id": 1, "user_id": 1}},
+		)
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillAlerts() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 3 || report.IndexContracts[1].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("alert dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-alerts_mongo_test.go
+++ b/actions/organisations-backfill-alerts_mongo_test.go
@@ -42,7 +42,7 @@ func TestInspectOrganisationsBackfillAlertsIsReadOnly(t *testing.T) {
 		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 || report.Resolution.Conflicts != 0 {
 			mt.Fatalf("resolution = %+v", report.Resolution)
 		}
-		if len(report.IndexContracts) != 3 || report.IndexContracts[1].Status != "exact" {
+		if len(report.IndexContracts) != 4 || report.IndexContracts[3].Status != "exact" {
 			mt.Fatalf("index contracts = %+v", report.IndexContracts)
 		}
 		for _, event := range mt.GetAllStartedEvents() {

--- a/actions/organisations-backfill-alerts_mongo_test.go
+++ b/actions/organisations-backfill-alerts_mongo_test.go
@@ -39,7 +39,8 @@ func TestInspectOrganisationsBackfillAlertsIsReadOnly(t *testing.T) {
 		if err != nil {
 			mt.Fatalf("inspectOrganisationsBackfillAlerts() error = %v", err)
 		}
-		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 || report.Resolution.Conflicts != 0 {
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 ||
+			report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
 			mt.Fatalf("resolution = %+v", report.Resolution)
 		}
 		if len(report.IndexContracts) != 4 || report.IndexContracts[3].Status != "exact" {

--- a/actions/organisations-backfill-alerts_test.go
+++ b/actions/organisations-backfill-alerts_test.go
@@ -55,7 +55,22 @@ func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
 			organisations: map[primitive.ObjectID]bool{organisationA: true},
 			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
 				if !outcome.resolved || outcome.resolvedID != organisationA || !outcome.proposedWrite ||
-					!outcome.legacyMasterPresent || !outcome.legacyUserPresent || !outcome.projectMissing || len(outcome.conflicts) != 0 {
+					!outcome.legacyMasterPresent || !outcome.legacyUserPresent || !outcome.projectMissing ||
+					!outcome.projectResolved || outcome.resolvedProjectID != organisationA || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "existing project is preserved",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "master_user_id", Value: organisationA.Hex()},
+				{Key: "projectId", Value: organisationB},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.resolved || !outcome.projectPresent || outcome.projectResolved || outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
 					t.Fatalf("outcome = %+v", outcome)
 				}
 			},

--- a/actions/organisations-backfill-alerts_test.go
+++ b/actions/organisations-backfill-alerts_test.go
@@ -18,6 +18,7 @@ func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
 		document      bson.D
 		users         map[primitive.ObjectID]bson.Raw
 		organisations map[primitive.ObjectID]bool
+		projects      map[primitive.ObjectID]primitive.ObjectID
 		check         func(*testing.T, organisationsBackfillAlertOutcome)
 	}{
 		{
@@ -62,7 +63,36 @@ func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
 			},
 		},
 		{
-			name: "existing project is preserved",
+			name: "existing project in organisation is preserved",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "master_user_id", Value: organisationA.Hex()},
+				{Key: "projectId", Value: organisationB},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			projects:      map[primitive.ObjectID]primitive.ObjectID{organisationB: organisationA},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.resolved || !outcome.projectPresent || !outcome.projectResolved || outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "explicit deterministic default needs no project document",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "master_user_id", Value: organisationA.Hex()},
+				{Key: "projectId", Value: organisationA},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.projectResolved || outcome.resolvedProjectID != organisationA || outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "orphan non-default project conflicts",
 			document: bson.D{
 				{Key: "_id", Value: documentID},
 				{Key: "master_user_id", Value: organisationA.Hex()},
@@ -70,7 +100,22 @@ func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
 			},
 			organisations: map[primitive.ObjectID]bool{organisationA: true},
 			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
-				if !outcome.resolved || !outcome.projectPresent || outcome.projectResolved || outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+				if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-project" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "cross-organisation project conflicts",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "master_user_id", Value: organisationA.Hex()},
+				{Key: "projectId", Value: organisationB},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			projects:      map[primitive.ObjectID]primitive.ObjectID{organisationB: primitive.NewObjectID()},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "project-organisation-mismatch" {
 					t.Fatalf("outcome = %+v", outcome)
 				}
 			},
@@ -135,10 +180,14 @@ func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
 			if test.organisations == nil {
 				test.organisations = map[primitive.ObjectID]bool{}
 			}
+			if test.projects == nil {
+				test.projects = map[primitive.ObjectID]primitive.ObjectID{}
+			}
 			outcome := resolveOrganisationsBackfillAlert(
 				organisationsBackfillTestRaw(t, test.document),
 				test.users,
 				test.organisations,
+				test.projects,
 			)
 			test.check(t, outcome)
 		})

--- a/actions/organisations-backfill-alerts_test.go
+++ b/actions/organisations-backfill-alerts_test.go
@@ -1,0 +1,141 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
+	organisationA := primitive.NewObjectID()
+	organisationB := primitive.NewObjectID()
+	creatorID := primitive.NewObjectID()
+	documentID := primitive.NewObjectID()
+
+	tests := []struct {
+		name          string
+		document      bson.D
+		users         map[primitive.ObjectID]bson.Raw
+		organisations map[primitive.ObjectID]bool
+		check         func(*testing.T, organisationsBackfillAlertOutcome)
+	}{
+		{
+			name: "canonical ownership ignores lower precedence fields",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationA.Hex()},
+				{Key: "master_user_id", Value: organisationB.Hex()},
+				{Key: "user_id", Value: creatorID.Hex()},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true, organisationB: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.canonicalValid || outcome.resolved || outcome.proposedWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:          "object id canonical value is authoritative but wrong type",
+			document:      bson.D{{Key: "_id", Value: documentID}, {Key: "organisationId", Value: organisationA}},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.canonicalWrong || outcome.canonicalValid || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-canonical-organisation" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "master tenant wins over creator",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "master_user_id", Value: organisationA.Hex()},
+				{Key: "user_id", Value: creatorID.Hex()},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || !outcome.proposedWrite ||
+					!outcome.legacyMasterPresent || !outcome.legacyUserPresent || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:          "oldest user field can directly name tenant",
+			document:      bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: organisationA.Hex()}},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "creator resolves through stable parent",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: creatorID.Hex()}},
+			users: map[primitive.ObjectID]bson.Raw{
+				creatorID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: creatorID}, {Key: "user_id", Value: organisationA.Hex()}}),
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "creator with direct and parent tenants is ambiguous",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: creatorID.Hex()}},
+			users: map[primitive.ObjectID]bson.Raw{
+				creatorID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: creatorID}, {Key: "user_id", Value: organisationB.Hex()}}),
+			},
+			organisations: map[primitive.ObjectID]bool{creatorID: true, organisationB: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.multipleCandidates || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "multiple-candidates" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "invalid master blocks creator fallback",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "master_user_id", Value: "invalid"},
+				{Key: "user_id", Value: organisationA.Hex()},
+			},
+			organisations: map[primitive.ObjectID]bool{organisationA: true},
+			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
+				if !outcome.invalidLegacy || outcome.resolved || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-legacy-master-id" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.users == nil {
+				test.users = map[primitive.ObjectID]bson.Raw{}
+			}
+			if test.organisations == nil {
+				test.organisations = map[primitive.ObjectID]bool{}
+			}
+			outcome := resolveOrganisationsBackfillAlert(
+				organisationsBackfillTestRaw(t, test.document),
+				test.users,
+				test.organisations,
+			)
+			test.check(t, outcome)
+		})
+	}
+}
+
+func TestOrganisationsBackfillAlertScope(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	if !organisationsBackfillAlertInScope(organisationsBackfillAlertOutcome{resolvedID: organisationID}, organisationID) {
+		t.Fatal("resolved legacy alert excluded from scope")
+	}
+	if organisationsBackfillAlertInScope(organisationsBackfillAlertOutcome{canonicalID: primitive.NewObjectID(), resolvedID: organisationID}, organisationID) {
+		t.Fatal("lower-precedence resolution overrode canonical scope")
+	}
+}

--- a/actions/organisations-backfill-alerts_test.go
+++ b/actions/organisations-backfill-alerts_test.go
@@ -55,7 +55,7 @@ func TestResolveOrganisationsBackfillAlertPrecedence(t *testing.T) {
 			organisations: map[primitive.ObjectID]bool{organisationA: true},
 			check: func(t *testing.T, outcome organisationsBackfillAlertOutcome) {
 				if !outcome.resolved || outcome.resolvedID != organisationA || !outcome.proposedWrite ||
-					!outcome.legacyMasterPresent || !outcome.legacyUserPresent || len(outcome.conflicts) != 0 {
+					!outcome.legacyMasterPresent || !outcome.legacyUserPresent || !outcome.projectMissing || len(outcome.conflicts) != 0 {
 					t.Fatalf("outcome = %+v", outcome)
 				}
 			},

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -509,6 +509,9 @@ func resetOrganisationsBackfillScopedInventory(report *organisationsBackfillColl
 	report.CanonicalMissing = 0
 	report.CanonicalWrongType = 0
 	report.CanonicalInvalidHex = 0
+	report.ProjectPresent = 0
+	report.ProjectMissing = 0
+	report.ProjectWrongType = 0
 	for candidate := range report.LegacyCandidateCount {
 		report.LegacyCandidateCount[candidate] = 0
 	}

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -16,20 +16,22 @@ import (
 const organisationsBackfillConflictLimit = 100
 
 type organisationsBackfillResolution struct {
-	Scanned             int64                           `json:"scanned"`
-	CanonicalValid      int64                           `json:"canonicalValid"`
-	CanonicalMissing    int64                           `json:"canonicalMissing"`
-	Resolved            int64                           `json:"resolved"`
-	ZeroCandidate       int64                           `json:"zeroCandidate"`
-	MultipleCandidates  int64                           `json:"multipleCandidates"`
-	Conflicts           int64                           `json:"conflicts"`
-	InvalidLegacy       int64                           `json:"invalidLegacy"`
-	OrphanUsers         int64                           `json:"orphanUsers"`
-	OrphanOrganisations int64                           `json:"orphanOrganisations"`
-	ProposedWrites      int64                           `json:"proposedWrites"`
-	ObservedFieldTypes  map[string]map[string]int64     `json:"observedFieldTypes"`
-	ObservedShapes      map[string]int64                `json:"observedShapes"`
-	ConflictEntries     []organisationsBackfillConflict `json:"conflictEntries"`
+	Scanned               int64                           `json:"scanned"`
+	CanonicalValid        int64                           `json:"canonicalValid"`
+	CanonicalMissing      int64                           `json:"canonicalMissing"`
+	Resolved              int64                           `json:"resolved"`
+	ZeroCandidate         int64                           `json:"zeroCandidate"`
+	MultipleCandidates    int64                           `json:"multipleCandidates"`
+	Conflicts             int64                           `json:"conflicts"`
+	InvalidLegacy         int64                           `json:"invalidLegacy"`
+	OrphanUsers           int64                           `json:"orphanUsers"`
+	OrphanOrganisations   int64                           `json:"orphanOrganisations"`
+	ProposedWrites        int64                           `json:"proposedWrites"`
+	ProjectResolved       int64                           `json:"projectResolved,omitempty"`
+	ProposedProjectWrites int64                           `json:"proposedProjectWrites,omitempty"`
+	ObservedFieldTypes    map[string]map[string]int64     `json:"observedFieldTypes"`
+	ObservedShapes        map[string]int64                `json:"observedShapes"`
+	ConflictEntries       []organisationsBackfillConflict `json:"conflictEntries"`
 }
 
 type organisationsBackfillConflict struct {

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -559,6 +559,7 @@ func inspectOrganisationsBackfillSubscriptionIndexes(ctx context.Context, collec
 	sort.Slice(indexes, func(left, right int) bool { return indexes[left].Name < indexes[right].Name })
 
 	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("active-subscription-scan", bson.D{{Key: "ends_at", Value: int32(1)}}),
 		organisationsBackfillNewIndexContract("canonical-active-lookup", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}}),
 		organisationsBackfillNewIndexContract("legacy-rollback", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "ends_at", Value: int32(1)}}),
 		organisationsBackfillNewIndexContract("cleanup", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "updated_at", Value: int32(-1)}, {Key: "created_at", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -13,28 +13,30 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-const organisationsBackfillSubscriptionConflictLimit = 100
+const organisationsBackfillConflictLimit = 100
 
-type organisationsBackfillSubscriptionResolution struct {
-	Scanned             int64                                       `json:"scanned"`
-	CanonicalValid      int64                                       `json:"canonicalValid"`
-	CanonicalMissing    int64                                       `json:"canonicalMissing"`
-	Resolved            int64                                       `json:"resolved"`
-	ZeroCandidate       int64                                       `json:"zeroCandidate"`
-	Conflicts           int64                                       `json:"conflicts"`
-	InvalidLegacy       int64                                       `json:"invalidLegacy"`
-	OrphanUsers         int64                                       `json:"orphanUsers"`
-	OrphanOrganisations int64                                       `json:"orphanOrganisations"`
-	ProposedWrites      int64                                       `json:"proposedWrites"`
-	ObservedFieldTypes  map[string]map[string]int64                 `json:"observedFieldTypes"`
-	ObservedShapes      map[string]int64                            `json:"observedShapes"`
-	ConflictEntries     []organisationsBackfillSubscriptionConflict `json:"conflictEntries"`
+type organisationsBackfillResolution struct {
+	Scanned             int64                           `json:"scanned"`
+	CanonicalValid      int64                           `json:"canonicalValid"`
+	CanonicalMissing    int64                           `json:"canonicalMissing"`
+	Resolved            int64                           `json:"resolved"`
+	ZeroCandidate       int64                           `json:"zeroCandidate"`
+	MultipleCandidates  int64                           `json:"multipleCandidates"`
+	Conflicts           int64                           `json:"conflicts"`
+	InvalidLegacy       int64                           `json:"invalidLegacy"`
+	OrphanUsers         int64                           `json:"orphanUsers"`
+	OrphanOrganisations int64                           `json:"orphanOrganisations"`
+	ProposedWrites      int64                           `json:"proposedWrites"`
+	ObservedFieldTypes  map[string]map[string]int64     `json:"observedFieldTypes"`
+	ObservedShapes      map[string]int64                `json:"observedShapes"`
+	ConflictEntries     []organisationsBackfillConflict `json:"conflictEntries"`
 }
 
-type organisationsBackfillSubscriptionConflict struct {
+type organisationsBackfillConflict struct {
 	Code                  string   `json:"code"`
 	DocumentID            string   `json:"documentId"`
 	CanonicalOrganisation string   `json:"canonicalOrganisation,omitempty"`
+	LegacyMaster          string   `json:"legacyMaster,omitempty"`
 	LegacyUser            string   `json:"legacyUser,omitempty"`
 	ResolvedOrganisations []string `json:"resolvedOrganisations,omitempty"`
 	Message               string   `json:"message"`
@@ -67,7 +69,7 @@ type organisationsBackfillSubscriptionOutcome struct {
 	orphanUser         bool
 	orphanOrganisation bool
 	proposedWrite      bool
-	conflicts          []organisationsBackfillSubscriptionConflict
+	conflicts          []organisationsBackfillConflict
 }
 
 type organisationsBackfillUserResolution struct {
@@ -87,7 +89,7 @@ func inspectOrganisationsBackfillSubscriptions(
 	if config.OrganisationID != "" {
 		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
 	}
-	documents, err := findOrganisationsBackfillSubscriptionDocuments(ctx, database.Collection(adapter.Collection), config)
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
 	if err != nil {
 		return report, err
 	}
@@ -121,7 +123,7 @@ func inspectOrganisationsBackfillSubscriptions(
 		return report, err
 	}
 
-	resolution := organisationsBackfillSubscriptionResolution{
+	resolution := organisationsBackfillResolution{
 		ObservedFieldTypes: make(map[string]map[string]int64),
 		ObservedShapes:     make(map[string]int64),
 	}
@@ -131,7 +133,7 @@ func inspectOrganisationsBackfillSubscriptions(
 	if !scopeID.IsZero() && !organisations[scopeID] {
 		resolution.OrphanOrganisations++
 		resolution.Conflicts++
-		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillSubscriptionConflict{
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
 			Code:                  "scope-organisation-not-found",
 			CanonicalOrganisation: scopeID.Hex(),
 			ResolvedOrganisations: []string{scopeID.Hex()},
@@ -143,7 +145,7 @@ func inspectOrganisationsBackfillSubscriptions(
 		if !organisationsBackfillSubscriptionInScope(outcome, scopeID) {
 			continue
 		}
-		observeOrganisationsBackfillSubscriptionDocument(&resolution, document)
+		observeOrganisationsBackfillDocument(&resolution, document)
 		addOrganisationsBackfillSubscriptionOutcome(&resolution, outcome)
 		if config.OrganisationID != "" {
 			addOrganisationsBackfillScopedInventory(&report, outcome)
@@ -160,8 +162,8 @@ func inspectOrganisationsBackfillSubscriptions(
 		}
 		return first.Message < second.Message
 	})
-	if len(resolution.ConflictEntries) > organisationsBackfillSubscriptionConflictLimit {
-		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillSubscriptionConflictLimit]
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
 	}
 	report.Resolution = &resolution
 
@@ -173,7 +175,7 @@ func inspectOrganisationsBackfillSubscriptions(
 	return report, nil
 }
 
-func observeOrganisationsBackfillSubscriptionDocument(report *organisationsBackfillSubscriptionResolution, document bson.Raw) {
+func observeOrganisationsBackfillDocument(report *organisationsBackfillResolution, document bson.Raw) {
 	elements, err := document.Elements()
 	if err != nil {
 		return
@@ -192,7 +194,7 @@ func observeOrganisationsBackfillSubscriptionDocument(report *organisationsBackf
 	report.ObservedShapes[strings.Join(shape, ",")]++
 }
 
-func findOrganisationsBackfillSubscriptionDocuments(
+func findOrganisationsBackfillDocuments(
 	ctx context.Context,
 	collection *mongo.Collection,
 	config OrganisationsBackfillConfig,
@@ -288,7 +290,7 @@ func resolveOrganisationsBackfillSubscription(
 	users map[primitive.ObjectID]bson.Raw,
 	organisations map[primitive.ObjectID]bool,
 ) (outcome organisationsBackfillSubscriptionOutcome) {
-	outcome.documentID = organisationsBackfillSubscriptionDocumentID(document)
+	outcome.documentID = organisationsBackfillDocumentID(document)
 	defer outcome.enrichConflicts()
 	legacyUserID, legacyState := organisationsBackfillSubscriptionLegacyUser(document)
 	if legacyState != organisationsBootstrapFieldEmpty {
@@ -365,7 +367,7 @@ func resolveOrganisationsBackfillUser(user bson.Raw) organisationsBackfillUserRe
 	// of which organisation owned a historical legacy subscription. The stable
 	// legacy master relationship, or the master's own deterministic primary
 	// organisation identity, is the only safe fallback for canonical-missing rows.
-	parentID, parentState := organisationsBackfillSubscriptionLegacyField(user, "user_id")
+	parentID, parentState := organisationsBackfillStringObjectIDField(user, "user_id")
 	if parentState == organisationsBootstrapFieldValue {
 		return organisationsBackfillUserResolution{organisationID: parentID}
 	}
@@ -376,7 +378,7 @@ func resolveOrganisationsBackfillUser(user bson.Raw) organisationsBackfillUserRe
 }
 
 func organisationsBackfillSubscriptionLegacyUser(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState) {
-	return organisationsBackfillSubscriptionLegacyField(document, "user_id")
+	return organisationsBackfillStringObjectIDField(document, "user_id")
 }
 
 func organisationsBackfillSubscriptionCanonicalOrganisation(document bson.Raw) (primitive.ObjectID, organisationsBootstrapFieldState) {
@@ -395,7 +397,7 @@ func organisationsBackfillSubscriptionCanonicalOrganisation(document bson.Raw) (
 	}
 }
 
-func organisationsBackfillSubscriptionLegacyField(document bson.Raw, field string) (primitive.ObjectID, organisationsBootstrapFieldState) {
+func organisationsBackfillStringObjectIDField(document bson.Raw, field string) (primitive.ObjectID, organisationsBootstrapFieldState) {
 	value := document.Lookup(field)
 	switch value.Type {
 	case bsontype.Type(0), bsontype.Null, bsontype.Undefined:
@@ -415,7 +417,7 @@ func organisationsBackfillSubscriptionLegacyField(document bson.Raw, field strin
 	}
 }
 
-func organisationsBackfillSubscriptionDocumentID(document bson.Raw) string {
+func organisationsBackfillDocumentID(document bson.Raw) string {
 	value := document.Lookup("_id")
 	if value.Type == bsontype.ObjectID {
 		return value.ObjectID().Hex()
@@ -427,7 +429,7 @@ func organisationsBackfillSubscriptionDocumentID(document bson.Raw) string {
 }
 
 func (outcome *organisationsBackfillSubscriptionOutcome) addConflict(code, message string) {
-	outcome.conflicts = append(outcome.conflicts, organisationsBackfillSubscriptionConflict{
+	outcome.conflicts = append(outcome.conflicts, organisationsBackfillConflict{
 		Code:       code,
 		DocumentID: outcome.documentID,
 		Message:    message,
@@ -469,7 +471,7 @@ func organisationsBackfillSubscriptionInScope(outcome organisationsBackfillSubsc
 }
 
 func addOrganisationsBackfillSubscriptionOutcome(
-	report *organisationsBackfillSubscriptionResolution,
+	report *organisationsBackfillResolution,
 	outcome organisationsBackfillSubscriptionOutcome,
 ) {
 	report.Scanned++

--- a/actions/organisations-backfill-subscriptions_test.go
+++ b/actions/organisations-backfill-subscriptions_test.go
@@ -179,7 +179,7 @@ func TestOrganisationsBackfillSubscriptionScopeUsesResolvedUserOrganisation(t *t
 		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "organisation_id", Value: otherOrganisation}}),
 	}
 
-	report := organisationsBackfillSubscriptionResolution{}
+	report := organisationsBackfillResolution{}
 	for _, document := range documents {
 		outcome := resolveOrganisationsBackfillSubscription(document, users, organisations)
 		if organisationsBackfillSubscriptionInScope(outcome, requestedOrganisation) {
@@ -274,7 +274,7 @@ func TestOrganisationsBackfillOrderedIndexCoverage(t *testing.T) {
 }
 
 func TestObserveOrganisationsBackfillSubscriptionDocumentRecordsTypesAndShape(t *testing.T) {
-	report := organisationsBackfillSubscriptionResolution{
+	report := organisationsBackfillResolution{
 		ObservedFieldTypes: make(map[string]map[string]int64),
 		ObservedShapes:     make(map[string]int64),
 	}
@@ -283,7 +283,7 @@ func TestObserveOrganisationsBackfillSubscriptionDocumentRecordsTypesAndShape(t 
 		{Key: "organisation_id", Value: primitive.NewObjectID()},
 		{Key: "user_id", Value: primitive.NewObjectID().Hex()},
 	})
-	observeOrganisationsBackfillSubscriptionDocument(&report, document)
+	observeOrganisationsBackfillDocument(&report, document)
 	if report.ObservedFieldTypes["organisation_id"]["objectID"] != 1 || report.ObservedFieldTypes["user_id"]["string"] != 1 {
 		t.Fatalf("observed field types = %#v", report.ObservedFieldTypes)
 	}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -23,6 +23,7 @@ const (
 	organisationsBackfillExitData             = 2
 	organisationsBackfillExitUsage            = 64
 	organisationsBackfillResolverSubscription = "subscription-user"
+	organisationsBackfillResolverAlert        = "alert-tenant"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -80,23 +81,23 @@ type organisationsBackfillScope struct {
 }
 
 type organisationsBackfillCollection struct {
-	TargetField           string                                       `json:"targetField"`
-	TargetBSONType        string                                       `json:"targetBsonType"`
-	LegacyCandidates      []string                                     `json:"legacyCandidates"`
-	PreservedFields       []string                                     `json:"preservedFields"`
-	ResolverKind          string                                       `json:"resolverKind,omitempty"`
-	MinimumWriterVersions []string                                     `json:"minimumWriterVersions,omitempty"`
-	MinimumReaderVersions []string                                     `json:"minimumReaderVersions,omitempty"`
-	Total                 int64                                        `json:"total"`
-	CanonicalPresent      int64                                        `json:"canonicalPresent"`
-	CanonicalMissing      int64                                        `json:"canonicalMissing"`
-	CanonicalWrongType    int64                                        `json:"canonicalWrongType"`
-	CanonicalInvalidHex   int64                                        `json:"canonicalInvalidHex"`
-	LegacyCandidateCount  map[string]int64                             `json:"legacyCandidateCount"`
-	Indexes               []string                                     `json:"indexes"`
-	TargetIndexCovered    bool                                         `json:"targetIndexCovered"`
-	IndexContracts        []organisationsBackfillIndexContract         `json:"indexContracts,omitempty"`
-	Resolution            *organisationsBackfillSubscriptionResolution `json:"resolution,omitempty"`
+	TargetField           string                               `json:"targetField"`
+	TargetBSONType        string                               `json:"targetBsonType"`
+	LegacyCandidates      []string                             `json:"legacyCandidates"`
+	PreservedFields       []string                             `json:"preservedFields"`
+	ResolverKind          string                               `json:"resolverKind,omitempty"`
+	MinimumWriterVersions []string                             `json:"minimumWriterVersions,omitempty"`
+	MinimumReaderVersions []string                             `json:"minimumReaderVersions,omitempty"`
+	Total                 int64                                `json:"total"`
+	CanonicalPresent      int64                                `json:"canonicalPresent"`
+	CanonicalMissing      int64                                `json:"canonicalMissing"`
+	CanonicalWrongType    int64                                `json:"canonicalWrongType"`
+	CanonicalInvalidHex   int64                                `json:"canonicalInvalidHex"`
+	LegacyCandidateCount  map[string]int64                     `json:"legacyCandidateCount"`
+	Indexes               []string                             `json:"indexes"`
+	TargetIndexCovered    bool                                 `json:"targetIndexCovered"`
+	IndexContracts        []organisationsBackfillIndexContract `json:"indexContracts,omitempty"`
+	Resolution            *organisationsBackfillResolution     `json:"resolution,omitempty"`
 }
 
 type organisationsBackfillError struct {
@@ -220,6 +221,9 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverSubscription {
 		return inspectOrganisationsBackfillSubscriptions(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverAlert {
+		return inspectOrganisationsBackfillAlerts(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -336,11 +340,14 @@ func selectOrganisationsBackfillAdapters(collection string, all bool) ([]organis
 func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 	return map[string]organisationsBackfillAdapter{
 		"alerts": {
-			Collection:       "alerts",
-			TargetField:      "organisationId",
-			TargetBSONType:   "string",
-			LegacyCandidates: []string{"master_user_id"},
-			PreservedFields:  []string{"user_id"},
+			Collection:            "alerts",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			LegacyCandidates:      []string{"master_user_id", "user_id"},
+			PreservedFields:       []string{"user_id"},
+			ResolverKind:          organisationsBackfillResolverAlert,
+			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
+			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-notification:v1.3.19", "hub-pipeline-analysis:unreleased-PR91"},
 		},
 		"devices": {
 			Collection:       "devices",

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -56,6 +56,8 @@ type organisationsBackfillAdapter struct {
 	Collection            string
 	TargetField           string
 	TargetBSONType        string
+	ProjectField          string
+	ProjectBSONType       string
 	LegacyCandidates      []string
 	PreservedFields       []string
 	ResolverKind          string
@@ -83,6 +85,8 @@ type organisationsBackfillScope struct {
 type organisationsBackfillCollection struct {
 	TargetField           string                               `json:"targetField"`
 	TargetBSONType        string                               `json:"targetBsonType"`
+	ProjectField          string                               `json:"projectField,omitempty"`
+	ProjectBSONType       string                               `json:"projectBsonType,omitempty"`
 	LegacyCandidates      []string                             `json:"legacyCandidates"`
 	PreservedFields       []string                             `json:"preservedFields"`
 	ResolverKind          string                               `json:"resolverKind,omitempty"`
@@ -93,6 +97,9 @@ type organisationsBackfillCollection struct {
 	CanonicalMissing      int64                                `json:"canonicalMissing"`
 	CanonicalWrongType    int64                                `json:"canonicalWrongType"`
 	CanonicalInvalidHex   int64                                `json:"canonicalInvalidHex"`
+	ProjectPresent        int64                                `json:"projectPresent,omitempty"`
+	ProjectMissing        int64                                `json:"projectMissing,omitempty"`
+	ProjectWrongType      int64                                `json:"projectWrongType,omitempty"`
 	LegacyCandidateCount  map[string]int64                     `json:"legacyCandidateCount"`
 	Indexes               []string                             `json:"indexes"`
 	TargetIndexCovered    bool                                 `json:"targetIndexCovered"`
@@ -187,7 +194,7 @@ func OrganisationsBackfill(config OrganisationsBackfillConfig) error {
 		if err != nil {
 			return &organisationsBackfillError{code: organisationsBackfillExitOperational, err: fmt.Errorf("inspect %s: %w", adapter.Collection, err)}
 		}
-		if collectionReport.CanonicalWrongType > 0 || collectionReport.CanonicalInvalidHex > 0 ||
+		if collectionReport.CanonicalWrongType > 0 || collectionReport.CanonicalInvalidHex > 0 || collectionReport.ProjectWrongType > 0 ||
 			(collectionReport.Resolution != nil && collectionReport.Resolution.Conflicts > 0) {
 			hasDataConflict = true
 			report.PreflightStatus = "blocked"
@@ -343,6 +350,8 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			Collection:            "alerts",
 			TargetField:           "organisationId",
 			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
 			LegacyCandidates:      []string{"master_user_id", "user_id"},
 			PreservedFields:       []string{"user_id"},
 			ResolverKind:          organisationsBackfillResolverAlert,
@@ -415,6 +424,8 @@ func inspectOrganisationsBackfillCollection(
 	report := organisationsBackfillCollection{
 		TargetField:           adapter.TargetField,
 		TargetBSONType:        adapter.TargetBSONType,
+		ProjectField:          adapter.ProjectField,
+		ProjectBSONType:       adapter.ProjectBSONType,
 		LegacyCandidates:      append([]string(nil), adapter.LegacyCandidates...),
 		PreservedFields:       append([]string(nil), adapter.PreservedFields...),
 		ResolverKind:          adapter.ResolverKind,
@@ -458,6 +469,29 @@ func inspectOrganisationsBackfillCollection(
 			return report, err
 		}
 		*count.target = value
+	}
+	if adapter.ProjectField != "" {
+		projectCounts := []struct {
+			target *int64
+			filter bson.M
+		}{
+			{&report.ProjectPresent, combineOrganisationsBackfillFilters(baseFilter, bson.M{adapter.ProjectField: bson.M{"$type": adapter.ProjectBSONType}})},
+			{&report.ProjectMissing, combineOrganisationsBackfillFilters(baseFilter, bson.M{"$or": bson.A{
+				bson.M{adapter.ProjectField: bson.M{"$exists": false}},
+				bson.M{adapter.ProjectField: nil},
+			}})},
+			{&report.ProjectWrongType, combineOrganisationsBackfillFilters(baseFilter, bson.M{
+				adapter.ProjectField: bson.M{"$exists": true, "$ne": nil},
+				"$expr":              bson.M{"$ne": bson.A{bson.M{"$type": "$" + adapter.ProjectField}, adapter.ProjectBSONType}},
+			})},
+		}
+		for _, count := range projectCounts {
+			value, err := collection.CountDocuments(ctx, count.filter)
+			if err != nil {
+				return report, err
+			}
+			*count.target = value
+		}
 	}
 	for _, candidate := range adapter.LegacyCandidates {
 		count, err := collection.CountDocuments(ctx, combineOrganisationsBackfillFilters(baseFilter, bson.M{candidate: bson.M{"$exists": true, "$nin": bson.A{nil, ""}}}))

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -54,6 +54,7 @@ type OrganisationsBackfillConfig struct {
 
 type organisationsBackfillAdapter struct {
 	Collection            string
+	OwnershipScope        string
 	TargetField           string
 	TargetBSONType        string
 	ProjectField          string
@@ -83,6 +84,7 @@ type organisationsBackfillScope struct {
 }
 
 type organisationsBackfillCollection struct {
+	OwnershipScope        string                               `json:"ownershipScope"`
 	TargetField           string                               `json:"targetField"`
 	TargetBSONType        string                               `json:"targetBsonType"`
 	ProjectField          string                               `json:"projectField,omitempty"`
@@ -348,6 +350,7 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 	return map[string]organisationsBackfillAdapter{
 		"alerts": {
 			Collection:            "alerts",
+			OwnershipScope:        "project-scoped",
 			TargetField:           "organisationId",
 			TargetBSONType:        "string",
 			ProjectField:          "projectId",
@@ -356,7 +359,7 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			PreservedFields:       []string{"user_id"},
 			ResolverKind:          organisationsBackfillResolverAlert,
 			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
-			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-notification:v1.3.19", "hub-pipeline-analysis:unreleased-PR91"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR514", "hub-pipeline-notification:unreleased-PR116", "hub-pipeline-analysis:unreleased-PR91"},
 		},
 		"devices": {
 			Collection:       "devices",
@@ -381,13 +384,14 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 		},
 		"subscriptions": {
 			Collection:            "subscriptions",
+			OwnershipScope:        "organisation-only",
 			TargetField:           "organisation_id",
 			TargetBSONType:        "objectId",
 			LegacyCandidates:      []string{"user_id"},
 			PreservedFields:       []string{"user_id"},
 			ResolverKind:          organisationsBackfillResolverSubscription,
 			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
-			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-monitor:v1.3.14", "hub-cleanup:v1.4.19", "cli:v1.2.23"},
+			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-monitor:v1.3.14", "hub-cleanup:v1.4.19", "cli:v1.2.23", "hub-monitor-device:unreleased-PR22"},
 		},
 	}
 }
@@ -422,6 +426,7 @@ func inspectOrganisationsBackfillCollection(
 	}
 
 	report := organisationsBackfillCollection{
+		OwnershipScope:        adapter.OwnershipScope,
 		TargetField:           adapter.TargetField,
 		TargetBSONType:        adapter.TargetBSONType,
 		ProjectField:          adapter.ProjectField,

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -143,8 +143,18 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 
 func TestSubscriptionsAdapterDeclaresDeploymentPrerequisites(t *testing.T) {
 	adapter := organisationsBackfillAdapters()["subscriptions"]
-	if len(adapter.MinimumWriterVersions) == 0 || len(adapter.MinimumReaderVersions) != 4 {
+	if adapter.OwnershipScope != "organisation-only" || adapter.ProjectField != "" {
+		t.Fatalf("subscription ownership scope = %q project field = %q", adapter.OwnershipScope, adapter.ProjectField)
+	}
+	if len(adapter.MinimumWriterVersions) == 0 || len(adapter.MinimumReaderVersions) != 5 {
 		t.Fatalf("subscription deployment prerequisites = writers %#v readers %#v", adapter.MinimumWriterVersions, adapter.MinimumReaderVersions)
+	}
+}
+
+func TestAlertsAdapterDeclaresProjectScope(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["alerts"]
+	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ProjectBSONType != "objectId" {
+		t.Fatalf("alert ownership scope = %+v", adapter)
 	}
 }
 

--- a/indexes/migration-hub-alert-ownership-21-08-2026.txt
+++ b/indexes/migration-hub-alert-ownership-21-08-2026.txt
@@ -1,0 +1,6 @@
+alerts
+[
+  { v: 2, key: { organisationId: 1, enabled: 1 }, name: 'organisationId_1_enabled_1' },
+  { v: 2, key: { master_user_id: 1, enabled: 1 }, name: 'master_user_id_1_enabled_1' },
+  { v: 2, key: { user_id: 1, enabled: 1 }, name: 'user_id_1_enabled_1' }
+]

--- a/indexes/migration-hub-alert-ownership-21-08-2026.txt
+++ b/indexes/migration-hub-alert-ownership-21-08-2026.txt
@@ -1,6 +1,7 @@
 alerts
 [
-  { v: 2, key: { organisationId: 1, enabled: 1 }, name: 'organisationId_1_enabled_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, enabled: 1 }, name: 'organisationId_1_projectId_1_enabled_1' },
+  { v: 2, key: { master_user_id: 1, projectId: 1, enabled: 1 }, name: 'master_user_id_1_projectId_1_enabled_1' },
+  { v: 2, key: { user_id: 1, projectId: 1, enabled: 1 }, name: 'user_id_1_projectId_1_enabled_1' },
   { v: 2, key: { master_user_id: 1, enabled: 1 }, name: 'master_user_id_1_enabled_1' },
-  { v: 2, key: { user_id: 1, enabled: 1 }, name: 'user_id_1_enabled_1' }
 ]

--- a/indexes/migration-hub-subscription-ownership-21-08-2026.txt
+++ b/indexes/migration-hub-subscription-ownership-21-08-2026.txt
@@ -1,5 +1,6 @@
 subscriptions
 [
+  { v: 2, key: { ends_at: 1 }, name: 'ends_at_1' },
   { v: 2, key: { organisation_id: 1, ends_at: 1 }, name: 'organisation_id_1_ends_at_1' },
   { v: 2, key: { user_id: 1, ends_at: 1 }, name: 'user_id_1_ends_at_1' },
   { v: 2, key: { organisation_id: 1, updated_at: -1, created_at: -1, _id: -1 }, name: 'organisation_id_1_updated_at_-1_created_at_-1__id_-1' }


### PR DESCRIPTION
## Description

Adds a dedicated audit adapter for alert ownership resolution and index validation, bringing alerts into the same migration and consistency checks already used for other ownership-backed collections.

Alerts currently rely on layered ownership semantics (`organisationId` → `master_user_id` → `user_id`) with historical variations in field formats and relationships. This change formalizes that resolution logic into a read-only inspection flow that can:

- detect invalid or ambiguous ownership states,
- identify orphaned users, organisations, and projects,
- validate deterministic project ownership resolution,
- verify required index coverage for alert ownership queries and rollback paths.

The adapter is intentionally dry-run and audit-focused, allowing ownership migrations and index rollouts to be validated safely before any write operations are introduced. This reduces migration risk, improves observability into legacy data quality issues, and helps guarantee that alert ownership behaves consistently across old and canonical schemas.

The PR also adds comprehensive tests covering precedence rules, conflict handling, project validation, index contracts, and MongoDB read-only guarantees, ensuring the resolver remains deterministic and safe as ownership rules evolve.