### PR TITLE
chore(indexes): add users.organisationId for subscription member lookup

### DIFF
--- a/indexes/migration-hub-subscription-ownership-21-08-2026.txt
+++ b/indexes/migration-hub-subscription-ownership-21-08-2026.txt
@@ -5,3 +5,7 @@ subscriptions
   { v: 2, key: { user_id: 1, ends_at: 1 }, name: 'user_id_1_ends_at_1' },
   { v: 2, key: { organisation_id: 1, updated_at: -1, created_at: -1, _id: -1 }, name: 'organisation_id_1_updated_at_-1_created_at_-1__id_-1' }
 ]
+users
+[
+  { v: 2, key: { organisationId: 1 }, name: 'organisationId_1' }
+]


### PR DESCRIPTION
## Description

This change adds an index on `users.organisationId` to support subscription member lookups more efficiently.

Queries filtering users by `organisationId` currently require collection scans as the dataset grows, which can negatively impact response times and increase database load. Adding this index ensures those lookups are optimized and scalable, especially for organisation-based subscription operations.

This improves overall query performance and helps keep subscription ownership and member retrieval fast as usage grows.