### PR TITLE
feat(indexes): add device scope lookup contract

### DIFF
--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -272,6 +272,40 @@ func TestAlertOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
 	}
 }
 
+func TestDeviceScopeIndexFileDeclaresCanonicalAndLegacyContracts(t *testing.T) {
+	path := filepath.Join("..", "indexes", "migration-hub-device-scope-25-08-2026.txt")
+	canonical, err := loadCanonicalIndexSpecsFromFile(path)
+	if err != nil {
+		t.Fatalf("loadCanonicalIndexSpecsFromFile: %v", err)
+	}
+
+	want := []IndexSpec{
+		{
+			Name: "organisationId_1_projectId_1_key_1",
+			Key: bson.D{
+				{Key: "organisationId", Value: int32(1)},
+				{Key: "projectId", Value: int32(1)},
+				{Key: "key", Value: int32(1)},
+			},
+		},
+		{
+			Name: "key_1_user_id_1",
+			Key: bson.D{
+				{Key: "key", Value: int32(1)},
+				{Key: "user_id", Value: int32(1)},
+			},
+		},
+	}
+	if got := canonical["devices"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("device scope indexes = %#v, want %#v", got, want)
+	}
+	for _, spec := range canonical["devices"] {
+		if spec.Unique {
+			t.Fatalf("device scope index %q must remain non-unique before reconciliation", spec.Name)
+		}
+	}
+}
+
 func findSpecByKey(t *testing.T, specs []IndexSpec, normalized string) IndexSpec {
 	t.Helper()
 	for _, s := range specs {

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -289,10 +289,27 @@ func TestDeviceScopeIndexFileDeclaresCanonicalAndLegacyContracts(t *testing.T) {
 			},
 		},
 		{
+			Name: "organisationId_1_projectId_1_key_1_analytics.cloudpublickey_1",
+			Key: bson.D{
+				{Key: "organisationId", Value: int32(1)},
+				{Key: "projectId", Value: int32(1)},
+				{Key: "key", Value: int32(1)},
+				{Key: "analytics.cloudpublickey", Value: int32(1)},
+			},
+		},
+		{
 			Name: "key_1_user_id_1",
 			Key: bson.D{
 				{Key: "key", Value: int32(1)},
 				{Key: "user_id", Value: int32(1)},
+			},
+		},
+		{
+			Name: "key_1_user_id_1_analytics.cloudpublickey_1",
+			Key: bson.D{
+				{Key: "key", Value: int32(1)},
+				{Key: "user_id", Value: int32(1)},
+				{Key: "analytics.cloudpublickey", Value: int32(1)},
 			},
 		},
 	}
@@ -303,6 +320,13 @@ func TestDeviceScopeIndexFileDeclaresCanonicalAndLegacyContracts(t *testing.T) {
 		if spec.Unique {
 			t.Fatalf("device scope index %q must remain non-unique before reconciliation", spec.Name)
 		}
+	}
+	wantUsers := []IndexSpec{{
+		Name: "amazon_access_key_id_1",
+		Key:  bson.D{{Key: "amazon_access_key_id", Value: int32(1)}},
+	}}
+	if got := canonical["users"]; !reflect.DeepEqual(got, wantUsers) {
+		t.Fatalf("cloud-key user indexes = %#v, want %#v", got, wantUsers)
 	}
 }
 

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -298,6 +298,13 @@ func TestDeviceScopeIndexFileDeclaresCanonicalAndLegacyContracts(t *testing.T) {
 			},
 		},
 		{
+			Name: "key_1_analytics.cloudpublickey_1",
+			Key: bson.D{
+				{Key: "key", Value: int32(1)},
+				{Key: "analytics.cloudpublickey", Value: int32(1)},
+			},
+		},
+		{
 			Name: "key_1_user_id_1",
 			Key: bson.D{
 				{Key: "key", Value: int32(1)},

--- a/indexes/migration-hub-device-scope-25-08-2026.txt
+++ b/indexes/migration-hub-device-scope-25-08-2026.txt
@@ -1,5 +1,11 @@
 devices
 [
   { v: 2, key: { organisationId: 1, projectId: 1, key: 1 }, name: 'organisationId_1_projectId_1_key_1' },
-  { v: 2, key: { key: 1, user_id: 1 }, name: 'key_1_user_id_1' }
+  { v: 2, key: { organisationId: 1, projectId: 1, key: 1, 'analytics.cloudpublickey': 1 }, name: 'organisationId_1_projectId_1_key_1_analytics.cloudpublickey_1' },
+  { v: 2, key: { key: 1, user_id: 1 }, name: 'key_1_user_id_1' },
+  { v: 2, key: { key: 1, user_id: 1, 'analytics.cloudpublickey': 1 }, name: 'key_1_user_id_1_analytics.cloudpublickey_1' }
+]
+users
+[
+  { v: 2, key: { amazon_access_key_id: 1 }, name: 'amazon_access_key_id_1' }
 ]

--- a/indexes/migration-hub-device-scope-25-08-2026.txt
+++ b/indexes/migration-hub-device-scope-25-08-2026.txt
@@ -2,6 +2,7 @@ devices
 [
   { v: 2, key: { organisationId: 1, projectId: 1, key: 1 }, name: 'organisationId_1_projectId_1_key_1' },
   { v: 2, key: { organisationId: 1, projectId: 1, key: 1, 'analytics.cloudpublickey': 1 }, name: 'organisationId_1_projectId_1_key_1_analytics.cloudpublickey_1' },
+  { v: 2, key: { key: 1, 'analytics.cloudpublickey': 1 }, name: 'key_1_analytics.cloudpublickey_1' },
   { v: 2, key: { key: 1, user_id: 1 }, name: 'key_1_user_id_1' },
   { v: 2, key: { key: 1, user_id: 1, 'analytics.cloudpublickey': 1 }, name: 'key_1_user_id_1_analytics.cloudpublickey_1' }
 ]

--- a/indexes/migration-hub-device-scope-25-08-2026.txt
+++ b/indexes/migration-hub-device-scope-25-08-2026.txt
@@ -1,0 +1,5 @@
+devices
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, key: 1 }, name: 'organisationId_1_projectId_1_key_1' },
+  { v: 2, key: { key: 1, user_id: 1 }, name: 'key_1_user_id_1' }
+]


### PR DESCRIPTION
## Description

Adds a new device scope index contract for Migration Hub and validates it through automated tests.

The new index specification captures both canonical and legacy lookup paths used by device and cloud key queries. Keeping these contracts explicitly versioned improves visibility into expected database access patterns and helps prevent accidental index regressions during future schema or migration work.

The accompanying test coverage ensures:
- the expected device and user indexes are declared correctly,
- index ordering and key composition remain stable,
- legacy compatibility is preserved,
- and indexes remain non-unique until reconciliation is completed.

This improves the reliability of index management by turning database lookup assumptions into enforceable CI checks.