### PR TITLE
feat(audit): add site ownership adapter

### DIFF
--- a/actions/organisations-backfill-sites.go
+++ b/actions/organisations-backfill-sites.go
@@ -1,0 +1,351 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type organisationsBackfillSiteOutcome struct {
+	documentID           string
+	canonicalID          primitive.ObjectID
+	canonicalValid       bool
+	canonicalMissing     bool
+	canonicalWrong       bool
+	projectPresent       bool
+	projectMissing       bool
+	projectWrong         bool
+	resolvedProjectID    primitive.ObjectID
+	projectResolved      bool
+	proposedProjectWrite bool
+	legacyUserID         primitive.ObjectID
+	legacyPresent        bool
+	invalidLegacy        bool
+	resolvedID           primitive.ObjectID
+	resolved             bool
+	zeroCandidate        bool
+	orphanOrganisation   bool
+	proposedWrite        bool
+	conflicts            []organisationsBackfillConflict
+}
+
+func inspectOrganisationsBackfillSites(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if id, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		} else if state == organisationsBootstrapFieldEmpty {
+			if legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "user_id"); legacyState == organisationsBootstrapFieldValue {
+				organisationIDs[legacyID] = struct{}{}
+			}
+		}
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	if !scopeID.IsZero() && !organisations[scopeID] {
+		resolution.OrphanOrganisations++
+		resolution.Conflicts++
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
+			Code:                  "scope-organisation-not-found",
+			CanonicalOrganisation: scopeID.Hex(),
+			ResolvedOrganisations: []string{scopeID.Hex()},
+			Message:               "requested organisation does not exist",
+		})
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillSite(document, organisations, projects)
+		if !organisationsBackfillSiteInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome)
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome)
+		}
+	}
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		first := resolution.ConflictEntries[left]
+		second := resolution.ConflictEntries[right]
+		if first.DocumentID != second.DocumentID {
+			return first.DocumentID < second.DocumentID
+		}
+		return first.Code < second.Code
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillSiteIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillSite(
+	document bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillSiteOutcome) {
+	outcome.documentID = organisationsBackfillDocumentID(document)
+	defer outcome.enrichConflicts()
+	defer outcome.resolveProject(projects)
+
+	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "user_id")
+	if legacyState != organisationsBootstrapFieldEmpty {
+		outcome.legacyPresent = true
+	}
+	if legacyState == organisationsBootstrapFieldValue {
+		outcome.legacyUserID = legacyID
+	}
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		outcome.projectPresent = true
+		outcome.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		outcome.projectMissing = true
+	default:
+		outcome.projectWrong = true
+		outcome.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		outcome.canonicalID = canonicalID
+		outcome.canonicalValid = true
+		if !organisations[canonicalID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		outcome.canonicalMissing = true
+	}
+
+	switch legacyState {
+	case organisationsBootstrapFieldEmpty:
+		outcome.zeroCandidate = true
+		outcome.addConflict("zero-candidate", "site has neither canonical organisationId nor legacy user_id")
+	case organisationsBootstrapFieldWrong:
+		outcome.invalidLegacy = true
+		outcome.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
+	case organisationsBootstrapFieldValue:
+		outcome.resolvedID = legacyID
+		if !organisations[legacyID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "legacy user_id organisation does not exist")
+			return outcome
+		}
+		outcome.resolved = true
+		outcome.proposedWrite = true
+	}
+	return outcome
+}
+
+func (outcome *organisationsBackfillSiteOutcome) resolveProject(projects map[primitive.ObjectID]primitive.ObjectID) {
+	if outcome.projectWrong || len(outcome.conflicts) > 0 {
+		return
+	}
+	organisationID := outcome.resolvedID
+	if outcome.canonicalValid {
+		organisationID = outcome.canonicalID
+	}
+	if organisationID.IsZero() {
+		return
+	}
+	if outcome.projectPresent {
+		if outcome.resolvedProjectID == organisationID {
+			outcome.projectResolved = true
+			return
+		}
+		projectOrganisationID, exists := projects[outcome.resolvedProjectID]
+		if !exists {
+			outcome.addConflict("orphan-project", "projectId does not resolve to a project")
+			return
+		}
+		if projectOrganisationID != organisationID {
+			outcome.addConflict("project-organisation-mismatch", "projectId belongs to a different organisation")
+			return
+		}
+		outcome.projectResolved = true
+		return
+	}
+	if outcome.projectMissing {
+		outcome.resolvedProjectID = organisationID
+		outcome.projectResolved = true
+		outcome.proposedProjectWrite = true
+	}
+}
+
+func (outcome *organisationsBackfillSiteOutcome) addConflict(code, message string) {
+	outcome.conflicts = append(outcome.conflicts, organisationsBackfillConflict{Code: code, DocumentID: outcome.documentID, Message: message})
+}
+
+func (outcome *organisationsBackfillSiteOutcome) enrichConflicts() {
+	resolved := make(map[string]struct{})
+	if !outcome.canonicalID.IsZero() {
+		resolved[outcome.canonicalID.Hex()] = struct{}{}
+	}
+	if !outcome.resolvedID.IsZero() {
+		resolved[outcome.resolvedID.Hex()] = struct{}{}
+	}
+	resolvedOrganisations := make([]string, 0, len(resolved))
+	for id := range resolved {
+		resolvedOrganisations = append(resolvedOrganisations, id)
+	}
+	sort.Strings(resolvedOrganisations)
+	for index := range outcome.conflicts {
+		if !outcome.canonicalID.IsZero() {
+			outcome.conflicts[index].CanonicalOrganisation = outcome.canonicalID.Hex()
+		}
+		if !outcome.legacyUserID.IsZero() {
+			outcome.conflicts[index].LegacyUser = outcome.legacyUserID.Hex()
+		}
+		outcome.conflicts[index].ResolvedOrganisations = append([]string(nil), resolvedOrganisations...)
+	}
+}
+
+func organisationsBackfillSiteInScope(outcome organisationsBackfillSiteOutcome, scopeID primitive.ObjectID) bool {
+	if scopeID.IsZero() {
+		return true
+	}
+	if !outcome.canonicalID.IsZero() {
+		return outcome.canonicalID == scopeID
+	}
+	return outcome.resolvedID == scopeID
+}
+
+func addOrganisationsBackfillSiteOutcome(report *organisationsBackfillResolution, outcome organisationsBackfillSiteOutcome) {
+	report.Scanned++
+	if outcome.canonicalValid {
+		report.CanonicalValid++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.resolved {
+		report.Resolved++
+	}
+	if outcome.zeroCandidate {
+		report.ZeroCandidate++
+	}
+	if outcome.invalidLegacy {
+		report.InvalidLegacy++
+	}
+	if outcome.orphanOrganisation {
+		report.OrphanOrganisations++
+	}
+	if outcome.proposedWrite {
+		report.ProposedWrites++
+	}
+	if outcome.projectResolved {
+		report.ProjectResolved++
+	}
+	if outcome.proposedProjectWrite {
+		report.ProposedProjectWrites++
+	}
+	report.Conflicts += int64(len(outcome.conflicts))
+	report.ConflictEntries = append(report.ConflictEntries, outcome.conflicts...)
+}
+
+func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillSiteOutcome) {
+	report.Total++
+	if outcome.canonicalValid {
+		report.CanonicalPresent++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.canonicalWrong {
+		report.CanonicalWrongType++
+	}
+	if outcome.projectPresent {
+		report.ProjectPresent++
+	}
+	if outcome.projectMissing {
+		report.ProjectMissing++
+	}
+	if outcome.projectWrong {
+		report.ProjectWrongType++
+	}
+	if outcome.legacyPresent {
+		report.LegacyCandidateCount["user_id"]++
+	}
+}
+
+func inspectOrganisationsBackfillSiteIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-list", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("device-membership-lookup", bson.D{{Key: "devices", Value: int32(1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-sites_mongo_test.go
+++ b/actions/organisations-backfill-sites_mongo_test.go
@@ -1,0 +1,54 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillSitesIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy default site", func(mt *mtest.T) {
+		siteID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		sitesNamespace := mt.DB.Name() + ".sites"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, sitesNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: siteID},
+				{Key: "user_id", Value: organisationID.Hex()},
+				{Key: "devices", Value: bson.A{"device-1"}},
+			}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, sitesNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "devices_1"}, {Key: "key", Value: bson.D{{Key: "devices", Value: int32(1)}}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillSites(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["sites"],
+			OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"user_id": 1}},
+		)
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillSites() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 ||
+			report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 3 || report.IndexContracts[2].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("site dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-sites_test.go
+++ b/actions/organisations-backfill-sites_test.go
@@ -1,0 +1,116 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillSitePrecedence(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherOrganisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	documentID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true, otherOrganisationID: true}
+
+	tests := []struct {
+		name     string
+		document bson.D
+		projects map[primitive.ObjectID]primitive.ObjectID
+		check    func(*testing.T, organisationsBackfillSiteOutcome)
+	}{
+		{
+			name: "canonical ownership wins over legacy tenant",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationID.Hex()},
+				{Key: "user_id", Value: otherOrganisationID.Hex()},
+			},
+			check: func(t *testing.T, outcome organisationsBackfillSiteOutcome) {
+				if !outcome.canonicalValid || outcome.resolved || !outcome.projectResolved || outcome.resolvedProjectID != organisationID || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "canonical ownership ignores malformed lower precedence tenant",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationID.Hex()},
+				{Key: "user_id", Value: "invalid"},
+			},
+			check: func(t *testing.T, outcome organisationsBackfillSiteOutcome) {
+				if !outcome.canonicalValid || outcome.resolved || outcome.invalidLegacy || !outcome.projectResolved || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "legacy tenant resolves both default axes",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: organisationID.Hex()}},
+			check: func(t *testing.T, outcome organisationsBackfillSiteOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationID || !outcome.proposedWrite || !outcome.projectResolved || outcome.resolvedProjectID != organisationID || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "non-default project in organisation is preserved",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationID.Hex()},
+				{Key: "projectId", Value: projectID},
+			},
+			projects: map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID},
+			check: func(t *testing.T, outcome organisationsBackfillSiteOutcome) {
+				if !outcome.projectResolved || outcome.resolvedProjectID != projectID || outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "cross-organisation project conflicts",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationID.Hex()},
+				{Key: "projectId", Value: projectID},
+			},
+			projects: map[primitive.ObjectID]primitive.ObjectID{projectID: otherOrganisationID},
+			check: func(t *testing.T, outcome organisationsBackfillSiteOutcome) {
+				if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "project-organisation-mismatch" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "invalid canonical blocks legacy fallback",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "organisationId", Value: "invalid"}, {Key: "user_id", Value: organisationID.Hex()}},
+			check: func(t *testing.T, outcome organisationsBackfillSiteOutcome) {
+				if !outcome.canonicalWrong || outcome.resolved || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-canonical-organisation" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.projects == nil {
+				test.projects = map[primitive.ObjectID]primitive.ObjectID{}
+			}
+			outcome := resolveOrganisationsBackfillSite(organisationsBackfillTestRaw(t, test.document), organisations, test.projects)
+			test.check(t, outcome)
+		})
+	}
+}
+
+func TestOrganisationsBackfillSiteScopeUsesCanonicalPrecedence(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	if !organisationsBackfillSiteInScope(organisationsBackfillSiteOutcome{resolvedID: organisationID}, organisationID) {
+		t.Fatal("resolved legacy site excluded from scope")
+	}
+	if organisationsBackfillSiteInScope(organisationsBackfillSiteOutcome{canonicalID: primitive.NewObjectID(), resolvedID: organisationID}, organisationID) {
+		t.Fatal("lower-precedence legacy ownership overrode canonical scope")
+	}
+}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -24,6 +24,7 @@ const (
 	organisationsBackfillExitUsage            = 64
 	organisationsBackfillResolverSubscription = "subscription-user"
 	organisationsBackfillResolverAlert        = "alert-tenant"
+	organisationsBackfillResolverSite         = "site-tenant"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -233,6 +234,9 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverAlert {
 		return inspectOrganisationsBackfillAlerts(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverSite {
+		return inspectOrganisationsBackfillSites(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -376,11 +380,17 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			PreservedFields:  []string{"created_by", "updated_by"},
 		},
 		"sites": {
-			Collection:       "sites",
-			TargetField:      "organisationId",
-			TargetBSONType:   "string",
-			LegacyCandidates: []string{"user_id"},
-			PreservedFields:  []string{"created_by", "updated_by"},
+			Collection:            "sites",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"user_id"},
+			PreservedFields:       []string{"created_by", "updated_by"},
+			ResolverKind:          organisationsBackfillResolverSite,
+			MinimumWriterVersions: []string{"hub-api:v1.9.56"},
+			MinimumReaderVersions: []string{"hub-api:v1.9.56", "hub-pipeline-notification:v1.3.19"},
 		},
 		"subscriptions": {
 			Collection:            "subscriptions",

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -83,12 +83,11 @@ func TestValidateOrganisationsBackfillConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "rejects scoped sites",
+			name: "accepts scoped sites",
 			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
 				config.OrganisationID = "507f1f77bcf86cd799439011"
 				return config
 			},
-			wantError: "not implemented",
 		},
 		{
 			name: "rejects invalid scope",
@@ -155,6 +154,13 @@ func TestAlertsAdapterDeclaresProjectScope(t *testing.T) {
 	adapter := organisationsBackfillAdapters()["alerts"]
 	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ProjectBSONType != "objectId" {
 		t.Fatalf("alert ownership scope = %+v", adapter)
+	}
+}
+
+func TestSitesAdapterDeclaresProjectScope(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["sites"]
+	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ProjectBSONType != "objectId" || adapter.ResolverKind != organisationsBackfillResolverSite {
+		t.Fatalf("site ownership scope = %+v", adapter)
 	}
 }
 


### PR DESCRIPTION
## Description

This change adds a dedicated site ownership adapter to the organisations backfill flow, enabling sites to participate in organisation and project ownership reconciliation with the same level of validation already available for other resources.

Sites currently rely on a mix of canonical `organisationId`, legacy `user_id`, and optional `projectId` fields, which makes ownership migration difficult to audit safely. The new adapter introduces explicit resolution rules and conflict detection so the backfill process can consistently determine ownership precedence, identify orphaned or malformed references, and propose safe writes without mutating data during inspection.

The implementation also adds project-aware validation for sites. This improves the reliability of ownership reconciliation by ensuring that:
- canonical organisation ownership always takes precedence over legacy fields
- project membership is validated against the resolved organisation
- missing default project relationships can be inferred safely
- cross-organisation project references are surfaced as conflicts instead of silently accepted

In addition, the adapter now reports index coverage requirements for site ownership queries, making it easier to verify that deployments are prepared for the new access patterns before rollout.

The accompanying test coverage verifies precedence rules, scoped backfill behaviour, conflict handling, inferred project ownership, and guarantees that inspection mode remains strictly read-only.