### PR TITLE
feat(audit): add group ownership adapter

### DIFF
--- a/actions/organisations-backfill-groups.go
+++ b/actions/organisations-backfill-groups.go
@@ -1,0 +1,70 @@
+package actions
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func inspectOrganisationsBackfillGroups(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	return inspectOrganisationsBackfillProjectResource(
+		ctx,
+		database,
+		adapter,
+		config,
+		report,
+		"group",
+		inspectOrganisationsBackfillGroupIndexes,
+	)
+}
+
+func resolveOrganisationsBackfillGroup(
+	document bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) organisationsBackfillProjectResourceOutcome {
+	return resolveOrganisationsBackfillProjectResource(document, "group", organisations, projects)
+}
+
+func inspectOrganisationsBackfillGroupIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-list", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("device-membership-lookup", bson.D{{Key: "devices", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("site-membership-lookup", bson.D{{Key: "sites", Value: int32(1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-groups_mongo_test.go
+++ b/actions/organisations-backfill-groups_mongo_test.go
@@ -1,0 +1,56 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillGroupsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy default group", func(mt *mtest.T) {
+		groupID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		groupsNamespace := mt.DB.Name() + ".groups"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, groupsNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: groupID},
+				{Key: "user_id", Value: organisationID.Hex()},
+				{Key: "devices", Value: bson.A{"device-1"}},
+				{Key: "sites", Value: bson.A{"site-1"}},
+			}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, groupsNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "devices_1"}, {Key: "key", Value: bson.D{{Key: "devices", Value: int32(1)}}}},
+				bson.D{{Key: "name", Value: "sites_1"}, {Key: "key", Value: bson.D{{Key: "sites", Value: int32(1)}}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillGroups(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["groups"],
+			OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"user_id": 1}},
+		)
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillGroups() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 ||
+			report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 4 || report.IndexContracts[2].Status != "exact" || report.IndexContracts[3].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("group dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-groups_test.go
+++ b/actions/organisations-backfill-groups_test.go
@@ -7,7 +7,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func TestResolveOrganisationsBackfillSitePrecedence(t *testing.T) {
+func TestResolveOrganisationsBackfillGroupPrecedence(t *testing.T) {
 	organisationID := primitive.NewObjectID()
 	otherOrganisationID := primitive.NewObjectID()
 	projectID := primitive.NewObjectID()
@@ -21,14 +21,10 @@ func TestResolveOrganisationsBackfillSitePrecedence(t *testing.T) {
 		check    func(*testing.T, organisationsBackfillProjectResourceOutcome)
 	}{
 		{
-			name: "canonical ownership wins over legacy tenant",
-			document: bson.D{
-				{Key: "_id", Value: documentID},
-				{Key: "organisationId", Value: organisationID.Hex()},
-				{Key: "user_id", Value: otherOrganisationID.Hex()},
-			},
+			name:     "legacy tenant resolves both default axes",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: organisationID.Hex()}},
 			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
-				if !outcome.canonicalValid || outcome.resolved || !outcome.projectResolved || outcome.resolvedProjectID != organisationID || len(outcome.conflicts) != 0 {
+				if !outcome.resolved || outcome.resolvedID != organisationID || !outcome.proposedWrite || !outcome.projectResolved || outcome.resolvedProjectID != organisationID || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
 					t.Fatalf("outcome = %+v", outcome)
 				}
 			},
@@ -41,16 +37,7 @@ func TestResolveOrganisationsBackfillSitePrecedence(t *testing.T) {
 				{Key: "user_id", Value: "invalid"},
 			},
 			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
-				if !outcome.canonicalValid || outcome.resolved || outcome.invalidLegacy || !outcome.projectResolved || len(outcome.conflicts) != 0 {
-					t.Fatalf("outcome = %+v", outcome)
-				}
-			},
-		},
-		{
-			name:     "legacy tenant resolves both default axes",
-			document: bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: organisationID.Hex()}},
-			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
-				if !outcome.resolved || outcome.resolvedID != organisationID || !outcome.proposedWrite || !outcome.projectResolved || outcome.resolvedProjectID != organisationID || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+				if !outcome.canonicalValid || outcome.invalidLegacy || !outcome.projectResolved || len(outcome.conflicts) != 0 {
 					t.Fatalf("outcome = %+v", outcome)
 				}
 			},
@@ -83,15 +70,6 @@ func TestResolveOrganisationsBackfillSitePrecedence(t *testing.T) {
 				}
 			},
 		},
-		{
-			name:     "invalid canonical blocks legacy fallback",
-			document: bson.D{{Key: "_id", Value: documentID}, {Key: "organisationId", Value: "invalid"}, {Key: "user_id", Value: organisationID.Hex()}},
-			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
-				if !outcome.canonicalWrong || outcome.resolved || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-canonical-organisation" {
-					t.Fatalf("outcome = %+v", outcome)
-				}
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -99,18 +77,19 @@ func TestResolveOrganisationsBackfillSitePrecedence(t *testing.T) {
 			if test.projects == nil {
 				test.projects = map[primitive.ObjectID]primitive.ObjectID{}
 			}
-			outcome := resolveOrganisationsBackfillSite(organisationsBackfillTestRaw(t, test.document), organisations, test.projects)
+			outcome := resolveOrganisationsBackfillGroup(organisationsBackfillTestRaw(t, test.document), organisations, test.projects)
 			test.check(t, outcome)
 		})
 	}
 }
 
-func TestOrganisationsBackfillSiteScopeUsesCanonicalPrecedence(t *testing.T) {
-	organisationID := primitive.NewObjectID()
-	if !organisationsBackfillSiteInScope(organisationsBackfillProjectResourceOutcome{resolvedID: organisationID}, organisationID) {
-		t.Fatal("resolved legacy site excluded from scope")
-	}
-	if organisationsBackfillSiteInScope(organisationsBackfillProjectResourceOutcome{canonicalID: primitive.NewObjectID(), resolvedID: organisationID}, organisationID) {
-		t.Fatal("lower-precedence legacy ownership overrode canonical scope")
+func TestResolveOrganisationsBackfillGroupUsesGroupConflictLabel(t *testing.T) {
+	outcome := resolveOrganisationsBackfillGroup(
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}}),
+		map[primitive.ObjectID]bool{},
+		map[primitive.ObjectID]primitive.ObjectID{},
+	)
+	if len(outcome.conflicts) != 1 || outcome.conflicts[0].Message != "group has neither canonical organisationId nor legacy user_id" {
+		t.Fatalf("outcome = %+v", outcome)
 	}
 }

--- a/actions/organisations-backfill-sites.go
+++ b/actions/organisations-backfill-sites.go
@@ -9,7 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-type organisationsBackfillSiteOutcome struct {
+type organisationsBackfillProjectResourceOutcome struct {
 	documentID           string
 	canonicalID          primitive.ObjectID
 	canonicalValid       bool
@@ -38,6 +38,26 @@ func inspectOrganisationsBackfillSites(
 	adapter organisationsBackfillAdapter,
 	config OrganisationsBackfillConfig,
 	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	return inspectOrganisationsBackfillProjectResource(
+		ctx,
+		database,
+		adapter,
+		config,
+		report,
+		"site",
+		inspectOrganisationsBackfillSiteIndexes,
+	)
+}
+
+func inspectOrganisationsBackfillProjectResource(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+	resourceName string,
+	inspectIndexes func(context.Context, *mongo.Collection) ([]organisationsBackfillIndexContract, error),
 ) (organisationsBackfillCollection, error) {
 	var scopeID primitive.ObjectID
 	if config.OrganisationID != "" {
@@ -92,7 +112,7 @@ func inspectOrganisationsBackfillSites(
 		})
 	}
 	for _, document := range documents {
-		outcome := resolveOrganisationsBackfillSite(document, organisations, projects)
+		outcome := resolveOrganisationsBackfillProjectResource(document, resourceName, organisations, projects)
 		if !organisationsBackfillSiteInScope(outcome, scopeID) {
 			continue
 		}
@@ -114,7 +134,7 @@ func inspectOrganisationsBackfillSites(
 		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
 	}
 	report.Resolution = &resolution
-	report.IndexContracts, err = inspectOrganisationsBackfillSiteIndexes(ctx, database.Collection(adapter.Collection))
+	report.IndexContracts, err = inspectIndexes(ctx, database.Collection(adapter.Collection))
 	return report, err
 }
 
@@ -122,7 +142,16 @@ func resolveOrganisationsBackfillSite(
 	document bson.Raw,
 	organisations map[primitive.ObjectID]bool,
 	projects map[primitive.ObjectID]primitive.ObjectID,
-) (outcome organisationsBackfillSiteOutcome) {
+) (outcome organisationsBackfillProjectResourceOutcome) {
+	return resolveOrganisationsBackfillProjectResource(document, "site", organisations, projects)
+}
+
+func resolveOrganisationsBackfillProjectResource(
+	document bson.Raw,
+	resourceName string,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillProjectResourceOutcome) {
 	outcome.documentID = organisationsBackfillDocumentID(document)
 	defer outcome.enrichConflicts()
 	defer outcome.resolveProject(projects)
@@ -168,7 +197,7 @@ func resolveOrganisationsBackfillSite(
 	switch legacyState {
 	case organisationsBootstrapFieldEmpty:
 		outcome.zeroCandidate = true
-		outcome.addConflict("zero-candidate", "site has neither canonical organisationId nor legacy user_id")
+		outcome.addConflict("zero-candidate", resourceName+" has neither canonical organisationId nor legacy user_id")
 	case organisationsBootstrapFieldWrong:
 		outcome.invalidLegacy = true
 		outcome.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
@@ -185,7 +214,7 @@ func resolveOrganisationsBackfillSite(
 	return outcome
 }
 
-func (outcome *organisationsBackfillSiteOutcome) resolveProject(projects map[primitive.ObjectID]primitive.ObjectID) {
+func (outcome *organisationsBackfillProjectResourceOutcome) resolveProject(projects map[primitive.ObjectID]primitive.ObjectID) {
 	if outcome.projectWrong || len(outcome.conflicts) > 0 {
 		return
 	}
@@ -220,11 +249,11 @@ func (outcome *organisationsBackfillSiteOutcome) resolveProject(projects map[pri
 	}
 }
 
-func (outcome *organisationsBackfillSiteOutcome) addConflict(code, message string) {
+func (outcome *organisationsBackfillProjectResourceOutcome) addConflict(code, message string) {
 	outcome.conflicts = append(outcome.conflicts, organisationsBackfillConflict{Code: code, DocumentID: outcome.documentID, Message: message})
 }
 
-func (outcome *organisationsBackfillSiteOutcome) enrichConflicts() {
+func (outcome *organisationsBackfillProjectResourceOutcome) enrichConflicts() {
 	resolved := make(map[string]struct{})
 	if !outcome.canonicalID.IsZero() {
 		resolved[outcome.canonicalID.Hex()] = struct{}{}
@@ -248,7 +277,7 @@ func (outcome *organisationsBackfillSiteOutcome) enrichConflicts() {
 	}
 }
 
-func organisationsBackfillSiteInScope(outcome organisationsBackfillSiteOutcome, scopeID primitive.ObjectID) bool {
+func organisationsBackfillSiteInScope(outcome organisationsBackfillProjectResourceOutcome, scopeID primitive.ObjectID) bool {
 	if scopeID.IsZero() {
 		return true
 	}
@@ -258,7 +287,7 @@ func organisationsBackfillSiteInScope(outcome organisationsBackfillSiteOutcome, 
 	return outcome.resolvedID == scopeID
 }
 
-func addOrganisationsBackfillSiteOutcome(report *organisationsBackfillResolution, outcome organisationsBackfillSiteOutcome) {
+func addOrganisationsBackfillSiteOutcome(report *organisationsBackfillResolution, outcome organisationsBackfillProjectResourceOutcome) {
 	report.Scanned++
 	if outcome.canonicalValid {
 		report.CanonicalValid++
@@ -291,7 +320,7 @@ func addOrganisationsBackfillSiteOutcome(report *organisationsBackfillResolution
 	report.ConflictEntries = append(report.ConflictEntries, outcome.conflicts...)
 }
 
-func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillSiteOutcome) {
+func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillProjectResourceOutcome) {
 	report.Total++
 	if outcome.canonicalValid {
 		report.CanonicalPresent++

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -25,6 +25,7 @@ const (
 	organisationsBackfillResolverSubscription = "subscription-user"
 	organisationsBackfillResolverAlert        = "alert-tenant"
 	organisationsBackfillResolverSite         = "site-tenant"
+	organisationsBackfillResolverGroup        = "group-tenant"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -237,6 +238,9 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverSite {
 		return inspectOrganisationsBackfillSites(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverGroup {
+		return inspectOrganisationsBackfillGroups(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -373,11 +377,17 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			PreservedFields:  []string{"user_id"},
 		},
 		"groups": {
-			Collection:       "groups",
-			TargetField:      "organisationId",
-			TargetBSONType:   "string",
-			LegacyCandidates: []string{"user_id"},
-			PreservedFields:  []string{"created_by", "updated_by"},
+			Collection:            "groups",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"user_id"},
+			PreservedFields:       []string{"created_by", "updated_by"},
+			ResolverKind:          organisationsBackfillResolverGroup,
+			MinimumWriterVersions: []string{"hub-api:v1.9.56"},
+			MinimumReaderVersions: []string{"hub-api:v1.9.56", "hub-pipeline-notification:v1.3.19"},
 		},
 		"sites": {
 			Collection:            "sites",

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -164,6 +164,13 @@ func TestSitesAdapterDeclaresProjectScope(t *testing.T) {
 	}
 }
 
+func TestGroupsAdapterDeclaresProjectScope(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["groups"]
+	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ProjectBSONType != "objectId" || adapter.ResolverKind != organisationsBackfillResolverGroup {
+		t.Fatalf("group ownership scope = %+v", adapter)
+	}
+}
+
 func TestOrganisationsBackfillIndexCoversField(t *testing.T) {
 	key := bson.D{{Key: "organisationId", Value: 1}, {Key: "timestamp", Value: -1}}
 	if !organisationsBackfillIndexCoversField(key, "organisationId") {


### PR DESCRIPTION
## Description

This change adds a dedicated group ownership adapter to the organisations backfill flow and extends the existing site ownership resolution logic into a reusable project-scoped resource model.

Groups now participate in the same organisation and project ownership validation pipeline as sites, including:
- canonical vs legacy ownership resolution
- project consistency checks
- conflict reporting
- scoped inventory and resolution reporting
- index contract inspection

The implementation extracts the shared ownership resolution behavior into generic project-resource helpers, reducing duplication and ensuring groups and sites follow identical ownership semantics. This improves maintainability and lowers the risk of ownership rules diverging across resource types over time.

The new adapter also defines required reader/writer version gates and validates expected indexes for group membership lookups, helping ensure backfill safety and query performance before rollout.

Comprehensive unit and Mongo integration tests were added to verify:
- ownership precedence rules
- project conflict handling
- read-only dry-run behavior
- resource-specific conflict messaging
- adapter configuration correctness

Overall, this enables organisation ownership backfill support for groups while making the ownership resolution framework more consistent, extensible, and safer to evolve.