### PR TITLE
feat(audit): add IO ownership adapter

### DIFF
--- a/actions/organisations-backfill-io.go
+++ b/actions/organisations-backfill-io.go
@@ -1,0 +1,242 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type organisationsBackfillIOOutcome struct {
+	organisationsBackfillProjectResourceOutcome
+	orphanUser bool
+}
+
+func inspectOrganisationsBackfillIO(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+
+	legacyUserIDs := make(map[primitive.ObjectID]struct{})
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if organisationID, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[organisationID] = struct{}{}
+		} else if state == organisationsBootstrapFieldEmpty {
+			if userID, userState := organisationsBackfillStringObjectIDField(document, "user_id"); userState == organisationsBootstrapFieldValue {
+				legacyUserIDs[userID] = struct{}{}
+			}
+		}
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
+
+	users, err := findOrganisationsBackfillUsers(ctx, database.Collection("users"), legacyUserIDs)
+	if err != nil {
+		return report, err
+	}
+	for _, user := range users {
+		resolved := resolveOrganisationsBackfillUser(user)
+		if resolved.code == "" {
+			organisationIDs[resolved.organisationID] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	if !scopeID.IsZero() && !organisations[scopeID] {
+		resolution.OrphanOrganisations++
+		resolution.Conflicts++
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
+			Code:                  "scope-organisation-not-found",
+			CanonicalOrganisation: scopeID.Hex(),
+			ResolvedOrganisations: []string{scopeID.Hex()},
+			Message:               "requested organisation does not exist",
+		})
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillIO(document, users, organisations, projects)
+		if !organisationsBackfillIOInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome.organisationsBackfillProjectResourceOutcome)
+		if outcome.orphanUser {
+			resolution.OrphanUsers++
+		}
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome.organisationsBackfillProjectResourceOutcome)
+		}
+	}
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		first := resolution.ConflictEntries[left]
+		second := resolution.ConflictEntries[right]
+		if first.DocumentID != second.DocumentID {
+			return first.DocumentID < second.DocumentID
+		}
+		return first.Code < second.Code
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillIOIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillIO(
+	document bson.Raw,
+	users map[primitive.ObjectID]bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillIOOutcome) {
+	resource := &outcome.organisationsBackfillProjectResourceOutcome
+	resource.documentID = organisationsBackfillDocumentID(document)
+	defer resource.enrichConflicts()
+	defer resource.resolveProject(projects)
+
+	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "user_id")
+	if legacyState != organisationsBootstrapFieldEmpty {
+		resource.legacyPresent = true
+	}
+	if legacyState == organisationsBootstrapFieldValue {
+		resource.legacyUserID = legacyID
+	}
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		resource.projectPresent = true
+		resource.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		resource.projectMissing = true
+	default:
+		resource.projectWrong = true
+		resource.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		resource.canonicalID = canonicalID
+		resource.canonicalValid = true
+		if !organisations[canonicalID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		resource.canonicalWrong = true
+		resource.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		resource.canonicalMissing = true
+	}
+
+	switch legacyState {
+	case organisationsBootstrapFieldEmpty:
+		resource.zeroCandidate = true
+		resource.addConflict("zero-candidate", "IO has neither canonical organisationId nor legacy user_id actor")
+	case organisationsBootstrapFieldWrong:
+		resource.invalidLegacy = true
+		resource.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
+	case organisationsBootstrapFieldValue:
+		user, exists := users[legacyID]
+		if !exists {
+			outcome.orphanUser = true
+			resource.addConflict("orphan-user", "legacy user_id actor does not resolve to a user")
+			return outcome
+		}
+		userResolution := resolveOrganisationsBackfillUser(user)
+		if userResolution.code != "" {
+			resource.addConflict(userResolution.code, userResolution.message)
+			return outcome
+		}
+		resource.resolvedID = userResolution.organisationID
+		if !organisations[resource.resolvedID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "organisation resolved from legacy actor does not exist")
+			return outcome
+		}
+		resource.resolved = true
+		resource.proposedWrite = true
+	}
+	return outcome
+}
+
+func organisationsBackfillIOInScope(outcome organisationsBackfillIOOutcome, scopeID primitive.ObjectID) bool {
+	if scopeID.IsZero() {
+		return true
+	}
+	if outcome.canonicalValid {
+		return outcome.canonicalID == scopeID
+	}
+	return outcome.resolvedID == scopeID
+}
+
+func inspectOrganisationsBackfillIOIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-device-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "device", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-device-list", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "device", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("canonical-project-hash-mutation", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "hash", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-hash-mutation", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "hash", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("global-hash-conflict", bson.D{{Key: "hash", Value: int32(1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-io.go
+++ b/actions/organisations-backfill-io.go
@@ -223,7 +223,7 @@ func inspectOrganisationsBackfillIOIndexes(ctx context.Context, collection *mong
 		organisationsBackfillNewIndexContract("legacy-project-device-list", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "device", Value: int32(1)}}),
 		organisationsBackfillNewIndexContract("canonical-project-hash-mutation", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "hash", Value: int32(1)}}),
 		organisationsBackfillNewIndexContract("legacy-project-hash-mutation", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "hash", Value: int32(1)}}),
-		organisationsBackfillNewIndexContract("global-hash-conflict", bson.D{{Key: "hash", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("heartbeat-device-hash-candidate", bson.D{{Key: "device", Value: int32(1)}, {Key: "hash", Value: int32(1)}}),
 	}
 	for index := range contracts {
 		contracts[index].Status = "missing"

--- a/actions/organisations-backfill-io_mongo_test.go
+++ b/actions/organisations-backfill-io_mongo_test.go
@@ -31,7 +31,7 @@ func TestInspectOrganisationsBackfillIOIsReadOnly(t *testing.T) {
 			}),
 			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
 			mtest.CreateCursorResponse(0, ioNamespace, mtest.FirstBatch,
-				bson.D{{Key: "name", Value: "hash_1"}, {Key: "key", Value: bson.D{{Key: "hash", Value: int32(1)}}}},
+				bson.D{{Key: "name", Value: "device_1_hash_1"}, {Key: "key", Value: bson.D{{Key: "device", Value: int32(1)}, {Key: "hash", Value: int32(1)}}}},
 			),
 		)
 

--- a/actions/organisations-backfill-io_mongo_test.go
+++ b/actions/organisations-backfill-io_mongo_test.go
@@ -1,0 +1,61 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillIOIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy sub-user actor", func(mt *mtest.T) {
+		ioID := primitive.NewObjectID()
+		actorID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		ioNamespace := mt.DB.Name() + ".io"
+		usersNamespace := mt.DB.Name() + ".users"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, ioNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: ioID},
+				{Key: "user_id", Value: actorID.Hex()},
+				{Key: "device", Value: "device-1"},
+				{Key: "hash", Value: "hash-1"},
+			}),
+			mtest.CreateCursorResponse(0, usersNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: actorID},
+				{Key: "user_id", Value: organisationID.Hex()},
+			}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, ioNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "hash_1"}, {Key: "key", Value: bson.D{{Key: "hash", Value: int32(1)}}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillIO(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["io"],
+			OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"user_id": 1}},
+		)
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillIO() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 ||
+			report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 5 || report.IndexContracts[4].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("IO dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-io_test.go
+++ b/actions/organisations-backfill-io_test.go
@@ -1,0 +1,88 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillIOPrecedence(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	actorID := primitive.NewObjectID()
+	documentID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true}
+	users := map[primitive.ObjectID]bson.Raw{
+		actorID: organisationsBackfillTestRaw(t, bson.D{
+			{Key: "_id", Value: actorID},
+			{Key: "user_id", Value: organisationID.Hex()},
+		}),
+	}
+
+	t.Run("legacy actor resolves stable default ownership", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillIO(
+			organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: actorID.Hex()}}),
+			users,
+			organisations,
+			map[primitive.ObjectID]primitive.ObjectID{},
+		)
+		if !outcome.resolved || outcome.resolvedID != organisationID || !outcome.proposedWrite ||
+			!outcome.projectResolved || outcome.resolvedProjectID != organisationID || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+
+	t.Run("canonical ownership ignores malformed actor provenance", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillIO(
+			organisationsBackfillTestRaw(t, bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationID.Hex()},
+				{Key: "user_id", Value: "invalid"},
+			}),
+			users,
+			organisations,
+			map[primitive.ObjectID]primitive.ObjectID{},
+		)
+		if !outcome.canonicalValid || outcome.invalidLegacy || !outcome.projectResolved ||
+			outcome.resolvedProjectID != organisationID || len(outcome.conflicts) != 0 {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+}
+
+func TestResolveOrganisationsBackfillIOConflicts(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherOrganisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	actorID := primitive.NewObjectID()
+	documentID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true, otherOrganisationID: true}
+
+	t.Run("legacy actor must resolve to a persisted user", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillIO(
+			organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: documentID}, {Key: "user_id", Value: actorID.Hex()}}),
+			map[primitive.ObjectID]bson.Raw{},
+			organisations,
+			map[primitive.ObjectID]primitive.ObjectID{},
+		)
+		if !outcome.orphanUser || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-user" {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+
+	t.Run("project must belong to canonical organisation", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillIO(
+			organisationsBackfillTestRaw(t, bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationID.Hex()},
+				{Key: "projectId", Value: projectID},
+			}),
+			map[primitive.ObjectID]bson.Raw{},
+			organisations,
+			map[primitive.ObjectID]primitive.ObjectID{projectID: otherOrganisationID},
+		)
+		if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "project-organisation-mismatch" {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -26,6 +26,7 @@ const (
 	organisationsBackfillResolverAlert        = "alert-tenant"
 	organisationsBackfillResolverSite         = "site-tenant"
 	organisationsBackfillResolverGroup        = "group-tenant"
+	organisationsBackfillResolverIO           = "io-actor"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -241,6 +242,9 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverGroup {
 		return inspectOrganisationsBackfillGroups(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverIO {
+		return inspectOrganisationsBackfillIO(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -389,6 +393,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:v1.9.56"},
 			MinimumReaderVersions: []string{"hub-api:v1.9.56", "hub-pipeline-notification:v1.3.19"},
 		},
+		"io": {
+			Collection:            "io",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"user_id"},
+			PreservedFields:       []string{"user_id"},
+			ResolverKind:          organisationsBackfillResolverIO,
+			MinimumWriterVersions: []string{"hub-api:unreleased-project-scoped-io"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-project-scoped-io", "hub-pipeline-notification:unverified"},
+		},
 		"sites": {
 			Collection:            "sites",
 			OwnershipScope:        "project-scoped",
@@ -422,7 +439,6 @@ func organisationsBackfillBlockedAdapters() map[string]string {
 		"channels":      "persistence and ownership contracts are unverified",
 		"counting":      "persisted shapes require a production audit",
 		"heatmap":       "persisted shapes require a production audit",
-		"io":            "product ownership remains undecided",
 		"labels":        "shared model does not declare organisationId",
 		"notifications": "shape-specific canonical models and writers are missing",
 		"sequences":     "shared model and canonical BSON type are not declared",

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -403,8 +403,8 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			LegacyCandidates:      []string{"user_id"},
 			PreservedFields:       []string{"user_id"},
 			ResolverKind:          organisationsBackfillResolverIO,
-			MinimumWriterVersions: []string{"hub-api:unreleased-project-scoped-io"},
-			MinimumReaderVersions: []string{"hub-api:unreleased-project-scoped-io", "hub-pipeline-notification:unverified"},
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR524"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR524", "hub-pipeline-notification:unreleased-PR120"},
 		},
 		"sites": {
 			Collection:            "sites",

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "sites", "subscriptions"}
+	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -168,6 +168,16 @@ func TestGroupsAdapterDeclaresProjectScope(t *testing.T) {
 	adapter := organisationsBackfillAdapters()["groups"]
 	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ProjectBSONType != "objectId" || adapter.ResolverKind != organisationsBackfillResolverGroup {
 		t.Fatalf("group ownership scope = %+v", adapter)
+	}
+}
+
+func TestIOAdapterDeclaresProjectScopeAndActorFallback(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["io"]
+	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ProjectBSONType != "objectId" || adapter.ResolverKind != organisationsBackfillResolverIO {
+		t.Fatalf("IO ownership scope = %+v", adapter)
+	}
+	if len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "user_id" || len(adapter.PreservedFields) != 1 || adapter.PreservedFields[0] != "user_id" {
+		t.Fatalf("IO actor contract = %+v", adapter)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR enables the `io` collection to participate in the organisations backfill audit pipeline through a dedicated IO ownership adapter.

The change closes a major gap in ownership auditing by allowing IO records to resolve canonical organisation ownership from either an explicit `organisationId` or legacy `user_id` actor provenance. This improves migration safety for collections that still rely on historical actor relationships while preserving compatibility with existing data shapes.

The adapter introduces:
- Resolution logic for canonical and legacy ownership paths
- Project-to-organisation validation and conflict reporting
- Detection of orphaned users and organisations
- Scoped inspection support for targeted audits
- Index contract inspection for expected IO access patterns
- Read-only audit guarantees verified through Mongo integration tests

This also removes the IO adapter from the blocked backfill list, making IO ownership readiness visible and enforceable alongside the rest of the audited collections.

The added tests strengthen confidence in precedence rules, conflict handling, index validation, and dry-run safety, helping ensure the backfill process remains deterministic and production-safe before any write path is introduced.