### PR TITLE
feat(audit): add case ownership adapters

### DIFF
--- a/actions/organisations-backfill-case-children.go
+++ b/actions/organisations-backfill-case-children.go
@@ -2,9 +2,11 @@ package actions
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -51,7 +53,7 @@ func inspectOrganisationsBackfillCaseChildren(
 	}
 	taskIDs := make(map[primitive.ObjectID]struct{})
 	for _, document := range documents {
-		if taskID, state := organisationsBootstrapObjectID(document, "task_id"); state == organisationsBootstrapFieldValue {
+		if taskID, state := organisationsBackfillCaseChildTaskID(document, adapter.Collection == "case_shares"); state == organisationsBootstrapFieldValue {
 			taskIDs[taskID] = struct{}{}
 		}
 	}
@@ -104,11 +106,20 @@ func inspectOrganisationsBackfillCaseChildren(
 	resourceName := "case media"
 	if adapter.Collection == "case_attachments" {
 		resourceName = "case attachment"
+	} else if adapter.Collection == "case_shares" {
+		resourceName = "case share"
 	}
+	activeTokens := make(map[string]int64)
 	for _, document := range documents {
 		outcome := resolveOrganisationsBackfillCaseChild(document, resourceName, tasks, organisations, projects)
+		if adapter.Collection == "case_shares" {
+			outcome = resolveOrganisationsBackfillCaseShareToken(document, outcome)
+		}
 		if !organisationsBackfillSiteInScope(outcome.organisationsBackfillProjectResourceOutcome, scopeID) {
 			continue
+		}
+		if token, active := organisationsBackfillActiveCaseShareToken(document); active {
+			activeTokens[token]++
 		}
 		observeOrganisationsBackfillDocument(&resolution, document)
 		addOrganisationsBackfillSiteOutcome(&resolution, outcome.organisationsBackfillProjectResourceOutcome)
@@ -117,6 +128,16 @@ func inspectOrganisationsBackfillCaseChildren(
 		}
 		if config.OrganisationID != "" {
 			addOrganisationsBackfillSiteScopedInventory(&report, outcome.organisationsBackfillProjectResourceOutcome)
+		}
+	}
+	for _, count := range activeTokens {
+		if count > 1 {
+			resolution.DuplicateActiveTokens++
+			resolution.DuplicateActiveTokenDocuments += count
+			resolution.Conflicts += count
+			resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
+				Code: "duplicate-active-token", Message: fmt.Sprintf("%d active case shares reuse one token", count),
+			})
 		}
 	}
 	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
@@ -133,6 +154,24 @@ func inspectOrganisationsBackfillCaseChildren(
 	return report, err
 }
 
+func resolveOrganisationsBackfillCaseShareToken(document bson.Raw, outcome organisationsBackfillCaseChildOutcome) organisationsBackfillCaseChildOutcome {
+	value := document.Lookup("token")
+	if value.Type != bsontype.String || value.StringValue() == "" {
+		outcome.addConflict("invalid-share-token", "case share token must be a non-empty string")
+		outcome.enrichConflicts()
+	}
+	return outcome
+}
+
+func organisationsBackfillActiveCaseShareToken(document bson.Raw) (string, bool) {
+	token := document.Lookup("token")
+	active := document.Lookup("is_active")
+	if token.Type != bsontype.String || token.StringValue() == "" || active.Type != bsontype.Boolean || !active.Boolean() {
+		return "", false
+	}
+	return token.StringValue(), true
+}
+
 func resolveOrganisationsBackfillCaseChild(
 	document bson.Raw,
 	resourceName string,
@@ -144,7 +183,7 @@ func resolveOrganisationsBackfillCaseChild(
 	child.documentID = organisationsBackfillDocumentID(document)
 	defer child.enrichConflicts()
 
-	taskID, taskState := organisationsBootstrapObjectID(document, "task_id")
+	taskID, taskState := organisationsBackfillCaseChildTaskID(document, resourceName == "case share")
 	if taskState != organisationsBootstrapFieldValue {
 		child.addConflict("invalid-parent-task", resourceName+" task_id must be a non-zero BSON ObjectID")
 		return outcome
@@ -209,6 +248,13 @@ func resolveOrganisationsBackfillCaseChild(
 	return outcome
 }
 
+func organisationsBackfillCaseChildTaskID(document bson.Raw, stringID bool) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	if stringID {
+		return organisationsBackfillStringObjectIDField(document, "task_id")
+	}
+	return organisationsBootstrapObjectID(document, "task_id")
+}
+
 func findOrganisationsBackfillCaseParentTasks(
 	ctx context.Context,
 	collection *mongo.Collection,
@@ -252,12 +298,22 @@ func inspectOrganisationsBackfillCaseChildIndexes(ctx context.Context, collectio
 			organisationsBackfillNewIndexContract("project-status-recovery", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "status", Value: int32(1)}}),
 			organisationsBackfillNewIndexContract("source-media-lookup", bson.D{{Key: "source_media_id", Value: int32(1)}}),
 		)
+	} else if collectionName == "case_shares" {
+		contracts = caseShareIndexContracts()
 	} else {
 		contracts = append(contracts,
 			organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "created_at", Value: int32(1)}}),
 		)
 	}
 	return inspectOrganisationsBackfillCaseIndexes(ctx, collection, contracts)
+}
+
+func caseShareIndexContracts() []organisationsBackfillIndexContract {
+	return []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "created_at", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("active-token", bson.D{{Key: "token", Value: int32(1)}, {Key: "is_active", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-management-rollback", bson.D{{Key: "task_id", Value: int32(1)}, {Key: "user_id", Value: int32(1)}, {Key: "created_at", Value: int32(-1)}}),
+	}
 }
 
 func inspectOrganisationsBackfillCaseIndexes(ctx context.Context, collection *mongo.Collection, contracts []organisationsBackfillIndexContract) ([]organisationsBackfillIndexContract, error) {

--- a/actions/organisations-backfill-case-children.go
+++ b/actions/organisations-backfill-case-children.go
@@ -245,14 +245,16 @@ func inspectOrganisationsBackfillTaskIndexes(ctx context.Context, collection *mo
 }
 
 func inspectOrganisationsBackfillCaseChildIndexes(ctx context.Context, collection *mongo.Collection, collectionName string) ([]organisationsBackfillIndexContract, error) {
-	contracts := []organisationsBackfillIndexContract{
-		organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "created_at", Value: int32(1)}}),
-		organisationsBackfillNewIndexContract("project-task-id-lookup", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "_id", Value: int32(1)}}),
-	}
+	contracts := []organisationsBackfillIndexContract{}
 	if collectionName == "case_media" {
 		contracts = append(contracts,
+			organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "role", Value: int32(1)}, {Key: "created_at", Value: int32(1)}}),
 			organisationsBackfillNewIndexContract("project-status-recovery", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "status", Value: int32(1)}}),
 			organisationsBackfillNewIndexContract("source-media-lookup", bson.D{{Key: "source_media_id", Value: int32(1)}}),
+		)
+	} else {
+		contracts = append(contracts,
+			organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "created_at", Value: int32(1)}}),
 		)
 	}
 	return inspectOrganisationsBackfillCaseIndexes(ctx, collection, contracts)

--- a/actions/organisations-backfill-case-children.go
+++ b/actions/organisations-backfill-case-children.go
@@ -53,7 +53,7 @@ func inspectOrganisationsBackfillCaseChildren(
 	}
 	taskIDs := make(map[primitive.ObjectID]struct{})
 	for _, document := range documents {
-		if taskID, state := organisationsBackfillCaseChildTaskID(document, adapter.Collection == "case_shares"); state == organisationsBootstrapFieldValue {
+		if taskID, state := organisationsBackfillCaseChildTaskID(document, adapter.Collection); state == organisationsBootstrapFieldValue {
 			taskIDs[taskID] = struct{}{}
 		}
 	}
@@ -108,6 +108,8 @@ func inspectOrganisationsBackfillCaseChildren(
 		resourceName = "case attachment"
 	} else if adapter.Collection == "case_shares" {
 		resourceName = "case share"
+	} else if adapter.Collection == "comments" {
+		resourceName = "task comment"
 	}
 	activeTokens := make(map[string]int64)
 	for _, document := range documents {
@@ -183,7 +185,13 @@ func resolveOrganisationsBackfillCaseChild(
 	child.documentID = organisationsBackfillDocumentID(document)
 	defer child.enrichConflicts()
 
-	taskID, taskState := organisationsBackfillCaseChildTaskID(document, resourceName == "case share")
+	collectionName := ""
+	if resourceName == "case share" {
+		collectionName = "case_shares"
+	} else if resourceName == "task comment" {
+		collectionName = "comments"
+	}
+	taskID, taskState := organisationsBackfillCaseChildTaskID(document, collectionName)
 	if taskState != organisationsBootstrapFieldValue {
 		child.addConflict("invalid-parent-task", resourceName+" task_id must be a non-zero BSON ObjectID")
 		return outcome
@@ -209,13 +217,17 @@ func resolveOrganisationsBackfillCaseChild(
 	child.resolvedID = expectedOrganisationID
 	child.resolvedProjectID = expectedProjectID
 
-	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisation_id")
+	canonicalField := "organisation_id"
+	if resourceName == "task comment" {
+		canonicalField = "organisationId"
+	}
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, canonicalField)
 	switch canonicalState {
 	case organisationsBootstrapFieldValue:
 		child.canonicalID = canonicalID
 		child.canonicalValid = true
 		if canonicalID != expectedOrganisationID {
-			child.addConflict("parent-organisation-mismatch", resourceName+" organisation_id differs from its parent task")
+			child.addConflict("parent-organisation-mismatch", resourceName+" "+canonicalField+" differs from its parent task")
 		} else {
 			child.resolved = true
 		}
@@ -225,7 +237,7 @@ func resolveOrganisationsBackfillCaseChild(
 		child.proposedWrite = true
 	default:
 		child.canonicalWrong = true
-		child.addConflict("invalid-canonical-organisation", "organisation_id must contain an ObjectID hex string")
+		child.addConflict("invalid-canonical-organisation", canonicalField+" must contain an ObjectID hex string")
 	}
 
 	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
@@ -248,9 +260,12 @@ func resolveOrganisationsBackfillCaseChild(
 	return outcome
 }
 
-func organisationsBackfillCaseChildTaskID(document bson.Raw, stringID bool) (primitive.ObjectID, organisationsBootstrapFieldState) {
-	if stringID {
+func organisationsBackfillCaseChildTaskID(document bson.Raw, collectionName string) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	if collectionName == "case_shares" {
 		return organisationsBackfillStringObjectIDField(document, "task_id")
+	}
+	if collectionName == "comments" {
+		return organisationsBackfillStringObjectIDField(document, "parent_id")
 	}
 	return organisationsBootstrapObjectID(document, "task_id")
 }
@@ -300,6 +315,10 @@ func inspectOrganisationsBackfillCaseChildIndexes(ctx context.Context, collectio
 		)
 	} else if collectionName == "case_shares" {
 		contracts = caseShareIndexContracts()
+	} else if collectionName == "comments" {
+		contracts = []organisationsBackfillIndexContract{
+			organisationsBackfillNewIndexContract("project-parent-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "parent_id", Value: int32(1)}, {Key: "creation_date", Value: int32(-1)}}),
+		}
 	} else {
 		contracts = append(contracts,
 			organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "created_at", Value: int32(1)}}),

--- a/actions/organisations-backfill-case-children.go
+++ b/actions/organisations-backfill-case-children.go
@@ -1,0 +1,288 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type organisationsBackfillCaseChildOutcome struct {
+	organisationsBackfillProjectResourceOutcome
+	taskID       primitive.ObjectID
+	orphanParent bool
+}
+
+func inspectOrganisationsBackfillTasks(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	return inspectOrganisationsBackfillProjectResource(
+		ctx,
+		database,
+		adapter,
+		config,
+		report,
+		"task",
+		inspectOrganisationsBackfillTaskIndexes,
+	)
+}
+
+func inspectOrganisationsBackfillCaseChildren(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	taskIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if taskID, state := organisationsBootstrapObjectID(document, "task_id"); state == organisationsBootstrapFieldValue {
+			taskIDs[taskID] = struct{}{}
+		}
+	}
+	tasks, err := findOrganisationsBackfillCaseParentTasks(ctx, database.Collection("tasks"), taskIDs)
+	if err != nil {
+		return report, err
+	}
+
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, task := range tasks {
+		if id, state := organisationsBackfillStringObjectIDField(task, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		} else if state == organisationsBootstrapFieldEmpty {
+			if id, legacyState := organisationsBackfillStringObjectIDField(task, "user_id"); legacyState == organisationsBootstrapFieldValue {
+				organisationIDs[id] = struct{}{}
+			}
+		}
+		if id, state := organisationsBootstrapObjectID(task, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[id] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	if !scopeID.IsZero() && !organisations[scopeID] {
+		resolution.OrphanOrganisations++
+		resolution.Conflicts++
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
+			Code: "scope-organisation-not-found", CanonicalOrganisation: scopeID.Hex(),
+			ResolvedOrganisations: []string{scopeID.Hex()}, Message: "requested organisation does not exist",
+		})
+	}
+	resourceName := "case media"
+	if adapter.Collection == "case_attachments" {
+		resourceName = "case attachment"
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillCaseChild(document, resourceName, tasks, organisations, projects)
+		if !organisationsBackfillSiteInScope(outcome.organisationsBackfillProjectResourceOutcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome.organisationsBackfillProjectResourceOutcome)
+		if outcome.orphanParent {
+			resolution.OrphanParents++
+		}
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome.organisationsBackfillProjectResourceOutcome)
+		}
+	}
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		if resolution.ConflictEntries[left].DocumentID != resolution.ConflictEntries[right].DocumentID {
+			return resolution.ConflictEntries[left].DocumentID < resolution.ConflictEntries[right].DocumentID
+		}
+		return resolution.ConflictEntries[left].Code < resolution.ConflictEntries[right].Code
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillCaseChildIndexes(ctx, database.Collection(adapter.Collection), adapter.Collection)
+	return report, err
+}
+
+func resolveOrganisationsBackfillCaseChild(
+	document bson.Raw,
+	resourceName string,
+	tasks map[primitive.ObjectID]bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillCaseChildOutcome) {
+	child := &outcome.organisationsBackfillProjectResourceOutcome
+	child.documentID = organisationsBackfillDocumentID(document)
+	defer child.enrichConflicts()
+
+	taskID, taskState := organisationsBootstrapObjectID(document, "task_id")
+	if taskState != organisationsBootstrapFieldValue {
+		child.addConflict("invalid-parent-task", resourceName+" task_id must be a non-zero BSON ObjectID")
+		return outcome
+	}
+	outcome.taskID = taskID
+	parent, exists := tasks[taskID]
+	if !exists {
+		outcome.orphanParent = true
+		child.addConflict("orphan-parent-task", resourceName+" task_id does not resolve to a task")
+		return outcome
+	}
+
+	parentOutcome := resolveOrganisationsBackfillProjectResource(parent, "task", organisations, projects)
+	if len(parentOutcome.conflicts) > 0 || !parentOutcome.projectResolved {
+		child.addConflict("parent-ownership-conflict", "parent task ownership is unresolved or conflicting")
+		return outcome
+	}
+	expectedOrganisationID := parentOutcome.canonicalID
+	if expectedOrganisationID.IsZero() {
+		expectedOrganisationID = parentOutcome.resolvedID
+	}
+	expectedProjectID := parentOutcome.resolvedProjectID
+	child.resolvedID = expectedOrganisationID
+	child.resolvedProjectID = expectedProjectID
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisation_id")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		child.canonicalID = canonicalID
+		child.canonicalValid = true
+		if canonicalID != expectedOrganisationID {
+			child.addConflict("parent-organisation-mismatch", resourceName+" organisation_id differs from its parent task")
+		} else {
+			child.resolved = true
+		}
+	case organisationsBootstrapFieldEmpty:
+		child.canonicalMissing = true
+		child.resolved = true
+		child.proposedWrite = true
+	default:
+		child.canonicalWrong = true
+		child.addConflict("invalid-canonical-organisation", "organisation_id must contain an ObjectID hex string")
+	}
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		child.projectPresent = true
+		if projectID != expectedProjectID {
+			child.addConflict("parent-project-mismatch", resourceName+" projectId differs from its parent task")
+		} else {
+			child.projectResolved = true
+		}
+	case organisationsBootstrapFieldEmpty:
+		child.projectMissing = true
+		child.projectResolved = true
+		child.proposedProjectWrite = true
+	default:
+		child.projectWrong = true
+		child.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+	return outcome
+}
+
+func findOrganisationsBackfillCaseParentTasks(
+	ctx context.Context,
+	collection *mongo.Collection,
+	ids map[primitive.ObjectID]struct{},
+) (map[primitive.ObjectID]bson.Raw, error) {
+	tasks := make(map[primitive.ObjectID]bson.Raw, len(ids))
+	if len(ids) == 0 {
+		return tasks, nil
+	}
+	cursor, err := collection.Find(ctx, bson.M{"_id": bson.M{"$in": sortedOrganisationsBackfillObjectIDs(ids)}}, options.Find().SetProjection(bson.M{
+		"_id": 1, "organisationId": 1, "projectId": 1, "user_id": 1,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return nil, err
+		}
+		if id, state := organisationsBootstrapObjectID(document, "_id"); state == organisationsBootstrapFieldValue {
+			tasks[id] = document
+		}
+	}
+	return tasks, cursor.Err()
+}
+
+func inspectOrganisationsBackfillTaskIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillCaseIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "creation_date", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-list", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "creation_date", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),
+	})
+}
+
+func inspectOrganisationsBackfillCaseChildIndexes(ctx context.Context, collection *mongo.Collection, collectionName string) ([]organisationsBackfillIndexContract, error) {
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("project-task-list", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "created_at", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("project-task-id-lookup", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "task_id", Value: int32(1)}, {Key: "_id", Value: int32(1)}}),
+	}
+	if collectionName == "case_media" {
+		contracts = append(contracts,
+			organisationsBackfillNewIndexContract("project-status-recovery", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "status", Value: int32(1)}}),
+			organisationsBackfillNewIndexContract("source-media-lookup", bson.D{{Key: "source_media_id", Value: int32(1)}}),
+		)
+	}
+	return inspectOrganisationsBackfillCaseIndexes(ctx, collection, contracts)
+}
+
+func inspectOrganisationsBackfillCaseIndexes(ctx context.Context, collection *mongo.Collection, contracts []organisationsBackfillIndexContract) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-case-children_mongo_test.go
+++ b/actions/organisations-backfill-case-children_mongo_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -60,6 +61,55 @@ func TestInspectOrganisationsBackfillCaseChildrenIsReadOnly(t *testing.T) {
 		for _, event := range mt.GetAllStartedEvents() {
 			if event.CommandName != "find" && event.CommandName != "listIndexes" {
 				mt.Fatalf("case child dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}
+
+func TestInspectOrganisationsBackfillCaseSharesReportsDuplicateActiveTokens(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("duplicate active token", func(mt *mtest.T) {
+		organisationID := primitive.NewObjectID()
+		taskID := primitive.NewObjectID()
+		sharesNamespace := mt.DB.Name() + ".case_shares"
+		tasksNamespace := mt.DB.Name() + ".tasks"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, sharesNamespace, mtest.FirstBatch,
+				bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "task_id", Value: taskID.Hex()}, {Key: "token", Value: "secret-token"}, {Key: "is_active", Value: true}},
+				bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "task_id", Value: taskID.Hex()}, {Key: "token", Value: "secret-token"}, {Key: "is_active", Value: true}},
+			),
+			mtest.CreateCursorResponse(0, tasksNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: taskID}, {Key: "user_id", Value: organisationID.Hex()}}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, sharesNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "token_1_is_active_1"}, {Key: "key", Value: bson.D{{Key: "token", Value: int32(1)}, {Key: "is_active", Value: int32(1)}}}},
+				bson.D{{Key: "name", Value: "task_id_1_user_id_1_created_at_-1"}, {Key: "key", Value: bson.D{{Key: "task_id", Value: int32(1)}, {Key: "user_id", Value: int32(1)}, {Key: "created_at", Value: int32(-1)}}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillCaseChildren(
+			context.Background(), mt.DB, organisationsBackfillAdapters()["case_shares"], OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{}},
+		)
+		if err != nil {
+			mt.Fatalf("inspect case shares: %v", err)
+		}
+		resolution := report.Resolution
+		if resolution == nil || resolution.Resolved != 2 || resolution.ProjectResolved != 2 ||
+			resolution.DuplicateActiveTokens != 1 || resolution.DuplicateActiveTokenDocuments != 2 || resolution.Conflicts != 2 {
+			mt.Fatalf("resolution = %+v", resolution)
+		}
+		if len(resolution.ConflictEntries) != 1 || resolution.ConflictEntries[0].Code != "duplicate-active-token" ||
+			strings.Contains(resolution.ConflictEntries[0].Message, "secret-token") {
+			mt.Fatalf("duplicate conflict = %+v", resolution.ConflictEntries)
+		}
+		if len(report.IndexContracts) != 3 || report.IndexContracts[0].Status != "missing" ||
+			report.IndexContracts[1].Status != "exact" || report.IndexContracts[2].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("case share dry-run issued non-read command %q", event.CommandName)
 			}
 		}
 	})

--- a/actions/organisations-backfill-case-children_mongo_test.go
+++ b/actions/organisations-backfill-case-children_mongo_test.go
@@ -114,3 +114,49 @@ func TestInspectOrganisationsBackfillCaseSharesReportsDuplicateActiveTokens(t *t
 		}
 	})
 }
+
+func TestInspectOrganisationsBackfillTaskCommentsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy default parent", func(mt *mtest.T) {
+		organisationID := primitive.NewObjectID()
+		taskID := primitive.NewObjectID()
+		commenterID := primitive.NewObjectID()
+		commentsNamespace := mt.DB.Name() + ".comments"
+		tasksNamespace := mt.DB.Name() + ".tasks"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, commentsNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: primitive.NewObjectID()},
+				{Key: "parent_id", Value: taskID.Hex()},
+				{Key: "user_id", Value: commenterID.Hex()},
+				{Key: "comment", Value: "evidence note"},
+			}),
+			mtest.CreateCursorResponse(0, tasksNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: taskID}, {Key: "user_id", Value: organisationID.Hex()}}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, commentsNamespace, mtest.FirstBatch),
+		)
+
+		report, err := inspectOrganisationsBackfillCaseChildren(
+			context.Background(), mt.DB, organisationsBackfillAdapters()["comments"], OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{}},
+		)
+		if err != nil {
+			mt.Fatalf("inspect comments: %v", err)
+		}
+		resolution := report.Resolution
+		if resolution == nil || resolution.Resolved != 1 || resolution.ProjectResolved != 1 || resolution.ProposedWrites != 1 || resolution.ProposedProjectWrites != 1 || resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", resolution)
+		}
+		if len(report.IndexContracts) != 1 || report.IndexContracts[0].Status != "missing" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		if resolution.ObservedFieldTypes["user_id"]["string"] != 1 {
+			mt.Fatalf("commenter provenance evidence = %+v", resolution.ObservedFieldTypes)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("comment dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-case-children_mongo_test.go
+++ b/actions/organisations-backfill-case-children_mongo_test.go
@@ -1,0 +1,65 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillCaseChildrenIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy default parent", func(mt *mtest.T) {
+		organisationID := primitive.NewObjectID()
+		taskID := primitive.NewObjectID()
+		childID := primitive.NewObjectID()
+		childrenNamespace := mt.DB.Name() + ".case_media"
+		tasksNamespace := mt.DB.Name() + ".tasks"
+		organisationsNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, childrenNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: childID},
+				{Key: "task_id", Value: taskID},
+				{Key: "role", Value: "source"},
+			}),
+			mtest.CreateCursorResponse(0, tasksNamespace, mtest.FirstBatch, bson.D{
+				{Key: "_id", Value: taskID},
+				{Key: "user_id", Value: organisationID.Hex()},
+			}),
+			mtest.CreateCursorResponse(0, organisationsNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, childrenNamespace, mtest.FirstBatch,
+				bson.D{{Key: "name", Value: "project_task_list"}, {Key: "key", Value: bson.D{
+					{Key: "organisation_id", Value: int32(1)},
+					{Key: "projectId", Value: int32(1)},
+					{Key: "task_id", Value: int32(1)},
+					{Key: "created_at", Value: int32(1)},
+				}}},
+			),
+		)
+
+		report, err := inspectOrganisationsBackfillCaseChildren(
+			context.Background(),
+			mt.DB,
+			organisationsBackfillAdapters()["case_media"],
+			OrganisationsBackfillConfig{BatchSize: 500},
+			organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{}},
+		)
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillCaseChildren() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProposedWrites != 1 ||
+			report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 4 || report.IndexContracts[0].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		for _, event := range mt.GetAllStartedEvents() {
+			if event.CommandName != "find" && event.CommandName != "listIndexes" {
+				mt.Fatalf("case child dry-run issued non-read command %q", event.CommandName)
+			}
+		}
+	})
+}

--- a/actions/organisations-backfill-case-children_mongo_test.go
+++ b/actions/organisations-backfill-case-children_mongo_test.go
@@ -34,6 +34,7 @@ func TestInspectOrganisationsBackfillCaseChildrenIsReadOnly(t *testing.T) {
 					{Key: "organisation_id", Value: int32(1)},
 					{Key: "projectId", Value: int32(1)},
 					{Key: "task_id", Value: int32(1)},
+					{Key: "role", Value: int32(1)},
 					{Key: "created_at", Value: int32(1)},
 				}}},
 			),
@@ -53,7 +54,7 @@ func TestInspectOrganisationsBackfillCaseChildrenIsReadOnly(t *testing.T) {
 			report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
 			mt.Fatalf("resolution = %+v", report.Resolution)
 		}
-		if len(report.IndexContracts) != 4 || report.IndexContracts[0].Status != "exact" {
+		if len(report.IndexContracts) != 3 || report.IndexContracts[0].Status != "exact" {
 			mt.Fatalf("index contracts = %+v", report.IndexContracts)
 		}
 		for _, event := range mt.GetAllStartedEvents() {

--- a/actions/organisations-backfill-case-children_test.go
+++ b/actions/organisations-backfill-case-children_test.go
@@ -94,3 +94,28 @@ func TestResolveOrganisationsBackfillCaseChildRejectsOrphanParent(t *testing.T) 
 		t.Fatalf("outcome = %+v", outcome)
 	}
 }
+
+func TestResolveOrganisationsBackfillCaseShareRejectsMissingToken(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	tasks := map[primitive.ObjectID]bson.Raw{
+		taskID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: taskID}, {Key: "user_id", Value: organisationID.Hex()}}),
+	}
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "task_id", Value: taskID.Hex()}})
+	outcome := resolveOrganisationsBackfillCaseChild(document, "case share", tasks, map[primitive.ObjectID]bool{organisationID: true}, map[primitive.ObjectID]primitive.ObjectID{})
+	outcome = resolveOrganisationsBackfillCaseShareToken(document, outcome)
+	if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "invalid-share-token" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestCaseShareActiveTokenAndIndexContracts(t *testing.T) {
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "token", Value: "token"}, {Key: "is_active", Value: true}})
+	if token, active := organisationsBackfillActiveCaseShareToken(document); !active || token != "token" {
+		t.Fatalf("active token = %q/%v", token, active)
+	}
+	contracts := caseShareIndexContracts()
+	if len(contracts) != 3 || contracts[1].Name != "active-token" || contracts[2].Name != "legacy-management-rollback" {
+		t.Fatalf("index contracts = %+v", contracts)
+	}
+}

--- a/actions/organisations-backfill-case-children_test.go
+++ b/actions/organisations-backfill-case-children_test.go
@@ -119,3 +119,24 @@ func TestCaseShareActiveTokenAndIndexContracts(t *testing.T) {
 		t.Fatalf("index contracts = %+v", contracts)
 	}
 }
+
+func TestResolveOrganisationsBackfillTaskCommentPreservesCommenter(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	commenterID := primitive.NewObjectID()
+	tasks := map[primitive.ObjectID]bson.Raw{
+		taskID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: taskID}, {Key: "user_id", Value: organisationID.Hex()}}),
+	}
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "parent_id", Value: taskID.Hex()},
+		{Key: "user_id", Value: commenterID.Hex()},
+	})
+	outcome := resolveOrganisationsBackfillCaseChild(document, "task comment", tasks, map[primitive.ObjectID]bool{organisationID: true}, map[primitive.ObjectID]primitive.ObjectID{})
+	if !outcome.resolved || outcome.resolvedID != organisationID || outcome.resolvedProjectID != organisationID || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if outcome.legacyPresent || outcome.legacyUserID == commenterID {
+		t.Fatalf("commenter was reinterpreted as ownership: %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-case-children_test.go
+++ b/actions/organisations-backfill-case-children_test.go
@@ -1,0 +1,96 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillCaseChildInheritsParentOwnership(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	childID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true}
+	projects := map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID}
+	tasks := map[primitive.ObjectID]bson.Raw{
+		taskID: organisationsBackfillTestRaw(t, bson.D{
+			{Key: "_id", Value: taskID},
+			{Key: "organisationId", Value: organisationID.Hex()},
+			{Key: "projectId", Value: projectID},
+		}),
+	}
+
+	outcome := resolveOrganisationsBackfillCaseChild(
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: childID}, {Key: "task_id", Value: taskID}}),
+		"case media",
+		tasks,
+		organisations,
+		projects,
+	)
+	if !outcome.resolved || outcome.resolvedID != organisationID || !outcome.proposedWrite ||
+		!outcome.projectResolved || outcome.resolvedProjectID != projectID || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillCaseChildUsesLegacyParentDefault(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	tasks := map[primitive.ObjectID]bson.Raw{
+		taskID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: taskID}, {Key: "user_id", Value: organisationID.Hex()}}),
+	}
+	outcome := resolveOrganisationsBackfillCaseChild(
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "task_id", Value: taskID}}),
+		"case attachment",
+		tasks,
+		map[primitive.ObjectID]bool{organisationID: true},
+		map[primitive.ObjectID]primitive.ObjectID{},
+	)
+	if outcome.resolvedID != organisationID || outcome.resolvedProjectID != organisationID || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillCaseChildRejectsParentMismatches(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherOrganisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	tasks := map[primitive.ObjectID]bson.Raw{
+		taskID: organisationsBackfillTestRaw(t, bson.D{
+			{Key: "_id", Value: taskID},
+			{Key: "organisationId", Value: organisationID.Hex()},
+			{Key: "projectId", Value: projectID},
+		}),
+	}
+	outcome := resolveOrganisationsBackfillCaseChild(
+		organisationsBackfillTestRaw(t, bson.D{
+			{Key: "_id", Value: primitive.NewObjectID()},
+			{Key: "task_id", Value: taskID},
+			{Key: "organisation_id", Value: otherOrganisationID.Hex()},
+			{Key: "projectId", Value: primitive.NewObjectID()},
+		}),
+		"case media",
+		tasks,
+		map[primitive.ObjectID]bool{organisationID: true, otherOrganisationID: true},
+		map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID},
+	)
+	if len(outcome.conflicts) != 2 || outcome.conflicts[0].Code != "parent-organisation-mismatch" || outcome.conflicts[1].Code != "parent-project-mismatch" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillCaseChildRejectsOrphanParent(t *testing.T) {
+	outcome := resolveOrganisationsBackfillCaseChild(
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "task_id", Value: primitive.NewObjectID()}}),
+		"case attachment",
+		map[primitive.ObjectID]bson.Raw{},
+		map[primitive.ObjectID]bool{},
+		map[primitive.ObjectID]primitive.ObjectID{},
+	)
+	if !outcome.orphanParent || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-parent-task" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -16,23 +16,25 @@ import (
 const organisationsBackfillConflictLimit = 100
 
 type organisationsBackfillResolution struct {
-	Scanned               int64                           `json:"scanned"`
-	CanonicalValid        int64                           `json:"canonicalValid"`
-	CanonicalMissing      int64                           `json:"canonicalMissing"`
-	Resolved              int64                           `json:"resolved"`
-	ZeroCandidate         int64                           `json:"zeroCandidate"`
-	MultipleCandidates    int64                           `json:"multipleCandidates"`
-	Conflicts             int64                           `json:"conflicts"`
-	InvalidLegacy         int64                           `json:"invalidLegacy"`
-	OrphanUsers           int64                           `json:"orphanUsers"`
-	OrphanParents         int64                           `json:"orphanParents,omitempty"`
-	OrphanOrganisations   int64                           `json:"orphanOrganisations"`
-	ProposedWrites        int64                           `json:"proposedWrites"`
-	ProjectResolved       int64                           `json:"projectResolved,omitempty"`
-	ProposedProjectWrites int64                           `json:"proposedProjectWrites,omitempty"`
-	ObservedFieldTypes    map[string]map[string]int64     `json:"observedFieldTypes"`
-	ObservedShapes        map[string]int64                `json:"observedShapes"`
-	ConflictEntries       []organisationsBackfillConflict `json:"conflictEntries"`
+	Scanned                       int64                           `json:"scanned"`
+	CanonicalValid                int64                           `json:"canonicalValid"`
+	CanonicalMissing              int64                           `json:"canonicalMissing"`
+	Resolved                      int64                           `json:"resolved"`
+	ZeroCandidate                 int64                           `json:"zeroCandidate"`
+	MultipleCandidates            int64                           `json:"multipleCandidates"`
+	Conflicts                     int64                           `json:"conflicts"`
+	InvalidLegacy                 int64                           `json:"invalidLegacy"`
+	OrphanUsers                   int64                           `json:"orphanUsers"`
+	OrphanParents                 int64                           `json:"orphanParents,omitempty"`
+	OrphanOrganisations           int64                           `json:"orphanOrganisations"`
+	DuplicateActiveTokens         int64                           `json:"duplicateActiveTokens,omitempty"`
+	DuplicateActiveTokenDocuments int64                           `json:"duplicateActiveTokenDocuments,omitempty"`
+	ProposedWrites                int64                           `json:"proposedWrites"`
+	ProjectResolved               int64                           `json:"projectResolved,omitempty"`
+	ProposedProjectWrites         int64                           `json:"proposedProjectWrites,omitempty"`
+	ObservedFieldTypes            map[string]map[string]int64     `json:"observedFieldTypes"`
+	ObservedShapes                map[string]int64                `json:"observedShapes"`
+	ConflictEntries               []organisationsBackfillConflict `json:"conflictEntries"`
 }
 
 type organisationsBackfillConflict struct {

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -25,6 +25,7 @@ type organisationsBackfillResolution struct {
 	Conflicts             int64                           `json:"conflicts"`
 	InvalidLegacy         int64                           `json:"invalidLegacy"`
 	OrphanUsers           int64                           `json:"orphanUsers"`
+	OrphanParents         int64                           `json:"orphanParents,omitempty"`
 	OrphanOrganisations   int64                           `json:"orphanOrganisations"`
 	ProposedWrites        int64                           `json:"proposedWrites"`
 	ProjectResolved       int64                           `json:"projectResolved,omitempty"`

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -391,7 +391,7 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			PreservedFields:       []string{"created_by"},
 			ResolverKind:          organisationsBackfillResolverCaseChild,
 			MinimumWriterVersions: []string{"hub-api:unreleased-PR526"},
-			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
 		},
 		"case_media": {
 			Collection:            "case_media",
@@ -402,8 +402,8 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			ProjectBSONType:       "objectId",
 			PreservedFields:       []string{"created_by", "source_media_id", "origin_attachment_id"},
 			ResolverKind:          organisationsBackfillResolverCaseChild,
-			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
-			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
 		},
 		"devices": {
 			Collection:       "devices",
@@ -472,8 +472,8 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			LegacyCandidates:      []string{"user_id"},
 			PreservedFields:       []string{"reporter_id", "assignees"},
 			ResolverKind:          organisationsBackfillResolverTask,
-			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
-			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
 		},
 	}
 }

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -405,6 +405,18 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
 			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:unreleased-PR30"},
 		},
+		"case_shares": {
+			Collection:            "case_shares",
+			OwnershipScope:        "project-scoped-parent-derived-capability",
+			TargetField:           "organisation_id",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			PreservedFields:       []string{"user_id", "user_email", "email", "token"},
+			ResolverKind:          organisationsBackfillResolverCaseChild,
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR528"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR528"},
+		},
 		"devices": {
 			Collection:       "devices",
 			TargetField:      "organisationId",

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -417,6 +417,18 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:unreleased-PR528"},
 			MinimumReaderVersions: []string{"hub-api:unreleased-PR528"},
 		},
+		"comments": {
+			Collection:            "comments",
+			OwnershipScope:        "project-scoped-parent-derived",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			PreservedFields:       []string{"user_id", "author"},
+			ResolverKind:          organisationsBackfillResolverCaseChild,
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR529"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR529"},
+		},
 		"devices": {
 			Collection:       "devices",
 			TargetField:      "organisationId",

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -27,6 +27,8 @@ const (
 	organisationsBackfillResolverSite         = "site-tenant"
 	organisationsBackfillResolverGroup        = "group-tenant"
 	organisationsBackfillResolverIO           = "io-actor"
+	organisationsBackfillResolverTask         = "task-tenant"
+	organisationsBackfillResolverCaseChild    = "case-parent"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -245,6 +247,12 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverIO {
 		return inspectOrganisationsBackfillIO(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverTask {
+		return inspectOrganisationsBackfillTasks(ctx, database, adapter, config, report)
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverCaseChild {
+		return inspectOrganisationsBackfillCaseChildren(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -373,6 +381,30 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
 			MinimumReaderVersions: []string{"hub-api:unreleased-PR514", "hub-pipeline-notification:unreleased-PR116", "hub-pipeline-analysis:unreleased-PR91"},
 		},
+		"case_attachments": {
+			Collection:            "case_attachments",
+			OwnershipScope:        "project-scoped-parent-derived",
+			TargetField:           "organisation_id",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			PreservedFields:       []string{"created_by"},
+			ResolverKind:          organisationsBackfillResolverCaseChild,
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR526"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+		},
+		"case_media": {
+			Collection:            "case_media",
+			OwnershipScope:        "project-scoped-parent-derived",
+			TargetField:           "organisation_id",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			PreservedFields:       []string{"created_by", "source_media_id", "origin_attachment_id"},
+			ResolverKind:          organisationsBackfillResolverCaseChild,
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+		},
 		"devices": {
 			Collection:       "devices",
 			TargetField:      "organisationId",
@@ -430,6 +462,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
 			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-monitor:v1.3.14", "hub-cleanup:v1.4.19", "cli:v1.2.23", "hub-monitor-device:unreleased-PR22"},
 		},
+		"tasks": {
+			Collection:            "tasks",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"user_id"},
+			PreservedFields:       []string{"reporter_id", "assignees"},
+			ResolverKind:          organisationsBackfillResolverTask,
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR526", "hub-pipeline-export:v1.2.11"},
+		},
 	}
 }
 
@@ -443,7 +488,6 @@ func organisationsBackfillBlockedAdapters() map[string]string {
 		"notifications": "shape-specific canonical models and writers are missing",
 		"sequences":     "shared model and canonical BSON type are not declared",
 		"settings":      "shared model does not declare a canonical tenant field",
-		"tasks":         "shared model and canonical BSON type are not declared",
 		"videowalls":    "shared model does not declare organisationId",
 		"workflow_runs": "persisted canonical BSON type is not verified",
 	}

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions"}
+	want := []string{"alerts", "case_attachments", "case_media", "devices", "groups", "io", "sites", "subscriptions", "tasks"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -178,6 +178,18 @@ func TestIOAdapterDeclaresProjectScopeAndActorFallback(t *testing.T) {
 	}
 	if len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "user_id" || len(adapter.PreservedFields) != 1 || adapter.PreservedFields[0] != "user_id" {
 		t.Fatalf("IO actor contract = %+v", adapter)
+	}
+}
+
+func TestCaseAdaptersDeclareParentDerivedProjectScope(t *testing.T) {
+	for _, collection := range []string{"case_media", "case_attachments"} {
+		adapter := organisationsBackfillAdapters()[collection]
+		if adapter.OwnershipScope != "project-scoped-parent-derived" || adapter.TargetField != "organisation_id" || adapter.ProjectField != "projectId" || adapter.ResolverKind != organisationsBackfillResolverCaseChild {
+			t.Fatalf("%s ownership scope = %+v", collection, adapter)
+		}
+	}
+	if adapter := organisationsBackfillAdapters()["tasks"]; adapter.ResolverKind != organisationsBackfillResolverTask || adapter.TargetField != "organisationId" {
+		t.Fatalf("task ownership scope = %+v", adapter)
 	}
 }
 

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "case_attachments", "case_media", "devices", "groups", "io", "sites", "subscriptions", "tasks"}
+	want := []string{"alerts", "case_attachments", "case_media", "case_shares", "devices", "groups", "io", "sites", "subscriptions", "tasks"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -190,6 +190,10 @@ func TestCaseAdaptersDeclareParentDerivedProjectScope(t *testing.T) {
 	}
 	if adapter := organisationsBackfillAdapters()["tasks"]; adapter.ResolverKind != organisationsBackfillResolverTask || adapter.TargetField != "organisationId" {
 		t.Fatalf("task ownership scope = %+v", adapter)
+	}
+	share := organisationsBackfillAdapters()["case_shares"]
+	if share.OwnershipScope != "project-scoped-parent-derived-capability" || share.TargetField != "organisation_id" || share.ResolverKind != organisationsBackfillResolverCaseChild {
+		t.Fatalf("case share ownership scope = %+v", share)
 	}
 }
 

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "case_attachments", "case_media", "case_shares", "devices", "groups", "io", "sites", "subscriptions", "tasks"}
+	want := []string{"alerts", "case_attachments", "case_media", "case_shares", "comments", "devices", "groups", "io", "sites", "subscriptions", "tasks"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -194,6 +194,10 @@ func TestCaseAdaptersDeclareParentDerivedProjectScope(t *testing.T) {
 	share := organisationsBackfillAdapters()["case_shares"]
 	if share.OwnershipScope != "project-scoped-parent-derived-capability" || share.TargetField != "organisation_id" || share.ResolverKind != organisationsBackfillResolverCaseChild {
 		t.Fatalf("case share ownership scope = %+v", share)
+	}
+	comment := organisationsBackfillAdapters()["comments"]
+	if comment.OwnershipScope != "project-scoped-parent-derived" || comment.TargetField != "organisationId" || comment.ResolverKind != organisationsBackfillResolverCaseChild {
+		t.Fatalf("comment ownership scope = %+v", comment)
 	}
 }
 


### PR DESCRIPTION
## Description

This change adds audit and inspection support for case ownership relationships across tasks, case media, attachments, shares, and comments. The new adapters make ownership resolution consistent across related resources by deriving organisation and project ownership from parent tasks and validating that child documents remain aligned.

The implementation improves the reliability of organisation backfills by detecting orphaned parents, invalid ownership fields, project mismatches, malformed share tokens, and duplicate active share tokens before migration work is applied. It also introduces index contract inspection so CI and operational tooling can verify that collections have the indexes required for safe and efficient ownership queries.

A key improvement is that the inspection flow is strictly read-only and extensively covered by unit and Mongo integration tests. This reduces operational risk while giving clear visibility into data inconsistencies and migration readiness across legacy and canonical ownership models.