### PR TITLE
feat(audit): add workflow and analytics ownership adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,23 @@ go run . -action check-indexes \
          -index-version migration-hub-workflow-ownership-26-08-2026
 ```
 
+Analysis and detections are also project scoped. Analysis resolves canonical
+`organisationId`, then legacy tenant `userid`, then `user_id`; missing projects
+belong to the resolved organisation's deterministic default project. Detection
+ownership is derived from the matching analysis document by recording `key`,
+and persisted canonical ownership is checked against that trusted source. A
+missing source or ownership mismatch is a conflict rather than guessed from
+workflow, device, or actor fields.
+
+```sh
+go run . -action check-indexes \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collections analysis,detections \
+         -mode dry-run \
+         -index-version migration-hub-analysis-detection-ownership-27-08-2026
+```
+
 ### Vault to Hub Migration
 
 This tool migrates data from a Vault database to a Hub database.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ belong to the resolved organisation's deterministic default project. Detection
 ownership is derived from the matching analysis document by recording `key`,
 and persisted canonical ownership is checked against that trusted source. A
 missing source or ownership mismatch is a conflict rather than guessed from
-workflow, device, or actor fields.
+workflow, device, or actor fields. The detection writer floor includes Hub
+Pipeline Analysis PR 95, which keeps legacy tolerance limited to the default
+project while requiring exact non-default project matches.
 
 ```sh
 go run . -action check-indexes \

--- a/README.md
+++ b/README.md
@@ -155,6 +155,27 @@ go run . -action check-indexes \
          -index-version migration-hub-alert-ownership-21-08-2026
 ```
 
+Workflows and workflow runs have separate project-scoped resolvers. Definitions
+use canonical `organisationId`, then `organisation_id`, then stable creator
+`user_id` only when both organisation fields are absent. Runs use canonical
+`organisationId`, then legacy tenant `userid`; accidental `user_id` is inventoried
+but never becomes ownership. Explicit projects must belong to the resolved
+organisation. Runs also validate case/media source ownership and database
+workflow ownership when those relationships can be resolved; a missing config
+workflow definition is not a conflict.
+
+The minimum runtime is Hub API PR 532 and hub-workflows PR 58. Cleanup remains
+unverified. Audit the ordered definition and run index families with:
+
+```sh
+go run . -action check-indexes \
+         -mongodb-uri "mongodb://<host>" \
+         -mongodb-destination-database <database> \
+         -collections workflows,workflow_runs \
+         -mode dry-run \
+         -index-version migration-hub-workflow-ownership-26-08-2026
+```
+
 ### Vault to Hub Migration
 
 This tool migrates data from a Vault database to a Hub database.

--- a/actions/organisations-backfill-analysis.go
+++ b/actions/organisations-backfill-analysis.go
@@ -1,0 +1,143 @@
+package actions
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func inspectOrganisationsBackfillAnalysis(ctx context.Context, database *mongo.Database, adapter organisationsBackfillAdapter, config OrganisationsBackfillConfig, report organisationsBackfillCollection) (organisationsBackfillCollection, error) {
+	return inspectOrganisationsBackfillAliasedProjectResource(ctx, database, adapter, config, report, "analysis", inspectOrganisationsBackfillAnalysisIndexes)
+}
+
+func inspectOrganisationsBackfillAliasedProjectResource(ctx context.Context, database *mongo.Database, adapter organisationsBackfillAdapter, config OrganisationsBackfillConfig, report organisationsBackfillCollection, resourceName string, inspectIndexes func(context.Context, *mongo.Collection) ([]organisationsBackfillIndexContract, error)) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if id, state := preferredOrganisationsBackfillTenant(document, adapter.LegacyCandidates); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		}
+		if id, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[id] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+	resolution := organisationsBackfillResolution{ObservedFieldTypes: make(map[string]map[string]int64), ObservedShapes: make(map[string]int64)}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	addOrganisationsBackfillMissingScopeConflict(&resolution, scopeID, organisations)
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillAliasedProjectResource(document, resourceName, adapter.LegacyCandidates, organisations, projects)
+		if !organisationsBackfillSiteInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome)
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome)
+		}
+	}
+	sortOrganisationsBackfillConflicts(&resolution)
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillAliasedProjectResource(document bson.Raw, resourceName string, aliases []string, organisations map[primitive.ObjectID]bool, projects map[primitive.ObjectID]primitive.ObjectID) (outcome organisationsBackfillProjectResourceOutcome) {
+	outcome.documentID = organisationsBackfillDocumentID(document)
+	defer outcome.enrichConflicts()
+	defer outcome.resolveProject(projects)
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		outcome.projectPresent = true
+		outcome.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		outcome.projectMissing = true
+	default:
+		outcome.projectWrong = true
+		outcome.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	if canonicalState == organisationsBootstrapFieldValue {
+		outcome.canonicalID = canonicalID
+		outcome.canonicalValid = true
+		if !organisations[canonicalID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		return outcome
+	}
+	if canonicalState == organisationsBootstrapFieldWrong {
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	}
+	outcome.canonicalMissing = true
+
+	legacyID, legacyState := preferredOrganisationsBackfillTenant(document, aliases)
+	outcome.legacyPresent = legacyState != organisationsBootstrapFieldEmpty
+	if legacyState == organisationsBootstrapFieldValue {
+		outcome.legacyUserID = legacyID
+		outcome.resolvedID = legacyID
+		if !organisations[legacyID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "legacy tenant does not resolve to an organisation")
+			return outcome
+		}
+		outcome.resolved = true
+		outcome.proposedWrite = true
+		return outcome
+	}
+	if legacyState == organisationsBootstrapFieldWrong {
+		outcome.invalidLegacy = true
+		outcome.addConflict("invalid-legacy-tenant", "highest-precedence legacy tenant must contain an ObjectID hex string")
+		return outcome
+	}
+	outcome.zeroCandidate = true
+	outcome.addConflict("zero-candidate", resourceName+" has no canonical or stable legacy tenant")
+	return outcome
+}
+
+func preferredOrganisationsBackfillTenant(document bson.Raw, aliases []string) (primitive.ObjectID, organisationsBootstrapFieldState) {
+	if id, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state != organisationsBootstrapFieldEmpty {
+		return id, state
+	}
+	for _, field := range aliases {
+		if id, state := organisationsBackfillStringObjectIDField(document, field); state != organisationsBootstrapFieldEmpty {
+			return id, state
+		}
+	}
+	return primitive.NilObjectID, organisationsBootstrapFieldEmpty
+}
+
+func inspectOrganisationsBackfillAnalysisIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillOrderedIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-key", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-userid-key", bson.D{{Key: "userid", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-user-id-key", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}),
+	})
+}

--- a/actions/organisations-backfill-analysis_mongo_test.go
+++ b/actions/organisations-backfill-analysis_mongo_test.go
@@ -1,0 +1,35 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillAnalysisIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy default project", func(mt *mtest.T) {
+		organisationID := primitive.NewObjectID()
+		analysisNamespace := mt.DB.Name() + ".analysis"
+		organisationNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, analysisNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "key", Value: "media-1"}, {Key: "userid", Value: organisationID.Hex()}}),
+			mtest.CreateCursorResponse(0, organisationNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, analysisNamespace, mtest.FirstBatch, bson.D{{Key: "name", Value: "userid_1_projectId_1_key_1"}, {Key: "key", Value: bson.D{{Key: "userid", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}}}),
+		)
+		report, err := inspectOrganisationsBackfillAnalysis(context.Background(), mt.DB, organisationsBackfillAdapters()["analysis"], OrganisationsBackfillConfig{BatchSize: 500}, organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"userid": 1, "user_id": 0}})
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillAnalysis() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProjectResolved != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 3 || report.IndexContracts[1].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		assertOrganisationsBackfillReadOnlyCommands(mt)
+	})
+}

--- a/actions/organisations-backfill-analysis_test.go
+++ b/actions/organisations-backfill-analysis_test.go
@@ -1,0 +1,45 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillAnalysisUsesOrderedPrecedence(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true, otherID: true}
+
+	canonical := resolveOrganisationsBackfillAliasedProjectResource(organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisationId", Value: organisationID.Hex()},
+		{Key: "userid", Value: otherID.Hex()},
+	}), "analysis", []string{"userid", "user_id"}, organisations, nil)
+	if !canonical.canonicalValid || canonical.resolved || len(canonical.conflicts) != 0 || canonical.resolvedProjectID != organisationID {
+		t.Fatalf("canonical outcome = %+v", canonical)
+	}
+
+	legacy := resolveOrganisationsBackfillAliasedProjectResource(organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "userid", Value: organisationID.Hex()},
+		{Key: "user_id", Value: otherID.Hex()},
+	}), "analysis", []string{"userid", "user_id"}, organisations, nil)
+	if !legacy.resolved || legacy.resolvedID != organisationID || !legacy.proposedWrite || len(legacy.conflicts) != 0 {
+		t.Fatalf("legacy outcome = %+v", legacy)
+	}
+}
+
+func TestResolveOrganisationsBackfillAnalysisValidatesNonDefaultProject(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	outcome := resolveOrganisationsBackfillAliasedProjectResource(organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisationId", Value: organisationID.Hex()},
+		{Key: "projectId", Value: projectID},
+	}), "analysis", []string{"userid", "user_id"}, map[primitive.ObjectID]bool{organisationID: true}, map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID})
+	if !outcome.projectResolved || outcome.resolvedProjectID != projectID || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-detections.go
+++ b/actions/organisations-backfill-detections.go
@@ -1,0 +1,175 @@
+package actions
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func inspectOrganisationsBackfillDetections(ctx context.Context, database *mongo.Database, adapter organisationsBackfillAdapter, config OrganisationsBackfillConfig, report organisationsBackfillCollection) (organisationsBackfillCollection, error) {
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	keys := make(map[string]struct{})
+	for _, document := range documents {
+		if key := organisationsBackfillRawString(document, "key"); key != "" {
+			keys[key] = struct{}{}
+		}
+	}
+	sources, err := findOrganisationsBackfillRawByString(ctx, database.Collection("analysis"), "key", keys)
+	if err != nil {
+		return report, err
+	}
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if id, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		}
+		if id, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[id] = struct{}{}
+		}
+	}
+	for _, source := range sources {
+		if id, state := preferredOrganisationsBackfillTenant(source, []string{"userid", "user_id"}); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		}
+		if id, state := organisationsBootstrapObjectID(source, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[id] = struct{}{}
+		}
+	}
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+	resolution := organisationsBackfillResolution{ObservedFieldTypes: make(map[string]map[string]int64), ObservedShapes: make(map[string]int64)}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	addOrganisationsBackfillMissingScopeConflict(&resolution, scopeID, organisations)
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillDetection(document, sources, organisations, projects)
+		if !organisationsBackfillSiteInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome)
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome)
+		}
+	}
+	sortOrganisationsBackfillConflicts(&resolution)
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillDetectionIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillDetection(document bson.Raw, sources map[string]bson.Raw, organisations map[primitive.ObjectID]bool, projects map[primitive.ObjectID]primitive.ObjectID) (outcome organisationsBackfillProjectResourceOutcome) {
+	outcome.documentID = organisationsBackfillDocumentID(document)
+	defer outcome.enrichConflicts()
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		outcome.canonicalID = canonicalID
+		outcome.canonicalValid = true
+		if !organisations[canonicalID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+	case organisationsBootstrapFieldWrong:
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+	default:
+		outcome.canonicalMissing = true
+	}
+
+	storedProjectID, storedProjectState := organisationsBootstrapObjectID(document, "projectId")
+	switch storedProjectState {
+	case organisationsBootstrapFieldValue:
+		outcome.projectPresent = true
+		outcome.resolvedProjectID = storedProjectID
+	case organisationsBootstrapFieldEmpty:
+		outcome.projectMissing = true
+	default:
+		outcome.projectWrong = true
+		outcome.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+
+	key := organisationsBackfillRawString(document, "key")
+	if key == "" {
+		outcome.zeroCandidate = outcome.canonicalMissing
+		outcome.addConflict("unresolved-source", "detection has no recording key")
+		return outcome
+	}
+	source, exists := sources[key]
+	if !exists {
+		outcome.zeroCandidate = outcome.canonicalMissing
+		outcome.addConflict("unresolved-source", "detection key does not resolve to analysis")
+		return outcome
+	}
+	sourceID, sourceState := preferredOrganisationsBackfillTenant(source, []string{"userid", "user_id"})
+	if sourceState != organisationsBootstrapFieldValue {
+		outcome.zeroCandidate = outcome.canonicalMissing
+		outcome.addConflict("unresolved-source", "analysis source ownership cannot be resolved")
+		return outcome
+	}
+	if !organisations[sourceID] {
+		outcome.orphanOrganisation = true
+		outcome.addConflict("orphan-organisation", "analysis source organisation does not exist")
+	}
+	if outcome.canonicalMissing {
+		outcome.resolvedID = sourceID
+		outcome.resolved = true
+		outcome.proposedWrite = true
+	} else if outcome.canonicalValid && canonicalID != sourceID {
+		outcome.addConflict("source-organisation-mismatch", "detection belongs to a different organisation than its analysis source")
+	}
+
+	sourceProjectID, sourceProjectState := organisationsBootstrapObjectID(source, "projectId")
+	if sourceProjectState == organisationsBootstrapFieldWrong {
+		outcome.addConflict("invalid-source-project", "analysis source projectId must be a non-zero BSON ObjectID or null")
+		return outcome
+	}
+	if sourceProjectState == organisationsBootstrapFieldEmpty {
+		sourceProjectID = sourceID
+	}
+	if sourceProjectID != sourceID {
+		projectOrganisationID, exists := projects[sourceProjectID]
+		if !exists {
+			outcome.addConflict("orphan-project", "analysis source projectId does not resolve to a project")
+		} else if projectOrganisationID != sourceID {
+			outcome.addConflict("project-organisation-mismatch", "analysis source project belongs to a different organisation")
+		}
+	}
+	if outcome.projectMissing {
+		outcome.resolvedProjectID = sourceProjectID
+		outcome.projectResolved = true
+		outcome.proposedProjectWrite = true
+	} else if outcome.projectPresent && storedProjectID != sourceProjectID {
+		outcome.addConflict("source-project-mismatch", "detection belongs to a different project than its analysis source")
+	} else if outcome.projectPresent {
+		outcome.projectResolved = true
+	}
+	return outcome
+}
+
+func inspectOrganisationsBackfillDetectionIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillOrderedIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-key", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("canonical-run", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "source.runId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("identity", bson.D{{Key: "key", Value: int32(1)}, {Key: "source.runId", Value: int32(1)}}),
+	})
+}

--- a/actions/organisations-backfill-detections_mongo_test.go
+++ b/actions/organisations-backfill-detections_mongo_test.go
@@ -1,0 +1,40 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillDetectionsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("source derived non-default project", func(mt *mtest.T) {
+		organisationID := primitive.NewObjectID()
+		projectID := primitive.NewObjectID()
+		detectionNamespace := mt.DB.Name() + ".detections"
+		analysisNamespace := mt.DB.Name() + ".analysis"
+		organisationNamespace := mt.DB.Name() + ".organisation"
+		projectNamespace := mt.DB.Name() + ".project"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, detectionNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "key", Value: "media-1"}}),
+			mtest.CreateCursorResponse(0, analysisNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "key", Value: "media-1"}, {Key: "organisationId", Value: organisationID.Hex()}, {Key: "projectId", Value: projectID}}),
+			mtest.CreateCursorResponse(0, organisationNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, projectNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: projectID}, {Key: "organisationId", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, detectionNamespace, mtest.FirstBatch, bson.D{{Key: "name", Value: "organisationId_1_projectId_1_key_1"}, {Key: "key", Value: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}}}),
+		)
+		report, err := inspectOrganisationsBackfillDetections(context.Background(), mt.DB, organisationsBackfillAdapters()["detections"], OrganisationsBackfillConfig{BatchSize: 500}, organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"key": 1}})
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillDetections() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProjectResolved != 1 || report.Resolution.ProposedWrites != 1 || report.Resolution.ProposedProjectWrites != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 3 || report.IndexContracts[0].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		assertOrganisationsBackfillReadOnlyCommands(mt)
+	})
+}

--- a/actions/organisations-backfill-detections_test.go
+++ b/actions/organisations-backfill-detections_test.go
@@ -1,0 +1,47 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillDetectionDerivesSourceOwnership(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "key", Value: "recording"}})
+	sources := map[string]bson.Raw{"recording": organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "key", Value: "recording"},
+		{Key: "organisationId", Value: organisationID.Hex()},
+		{Key: "projectId", Value: projectID},
+	})}
+	outcome := resolveOrganisationsBackfillDetection(document, sources, map[primitive.ObjectID]bool{organisationID: true}, map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID})
+	if !outcome.resolved || outcome.resolvedID != organisationID || !outcome.projectResolved || outcome.resolvedProjectID != projectID || !outcome.proposedWrite || !outcome.proposedProjectWrite || outcome.canonicalValid || outcome.projectPresent || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillDetectionReportsSourceMismatch(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "key", Value: "recording"},
+		{Key: "organisationId", Value: organisationID.Hex()},
+	})
+	sources := map[string]bson.Raw{"recording": organisationsBackfillTestRaw(t, bson.D{{Key: "key", Value: "recording"}, {Key: "organisationId", Value: otherID.Hex()}})}
+	outcome := resolveOrganisationsBackfillDetection(document, sources, map[primitive.ObjectID]bool{organisationID: true, otherID: true}, nil)
+	if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "source-organisation-mismatch" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillDetectionReportsMissingSource(t *testing.T) {
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "key", Value: "missing"}})
+	outcome := resolveOrganisationsBackfillDetection(document, nil, nil, nil)
+	if !outcome.zeroCandidate || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "unresolved-source" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-workflow-runs.go
+++ b/actions/organisations-backfill-workflow-runs.go
@@ -1,0 +1,356 @@
+package actions
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type organisationsBackfillWorkflowRunOutcome struct {
+	organisationsBackfillProjectResourceOutcome
+	accidentalUserPresent bool
+}
+
+type organisationsBackfillRelatedOwnership struct {
+	organisationID primitive.ObjectID
+	projectID      primitive.ObjectID
+	resolved       bool
+}
+
+func inspectOrganisationsBackfillWorkflowRuns(ctx context.Context, database *mongo.Database, adapter organisationsBackfillAdapter, config OrganisationsBackfillConfig, report organisationsBackfillCollection) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	taskIDs := make(map[primitive.ObjectID]struct{})
+	mediaKeys := make(map[string]struct{})
+	workflowIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if id, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[id] = struct{}{}
+		} else if state == organisationsBootstrapFieldEmpty {
+			if id, legacyState := organisationsBackfillStringObjectIDField(document, "userid"); legacyState == organisationsBootstrapFieldValue {
+				organisationIDs[id] = struct{}{}
+			}
+		}
+		if id, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[id] = struct{}{}
+		}
+		if sourceRef := organisationsBackfillRawString(document, "sourceref"); sourceRef != "" {
+			if id, parseErr := primitive.ObjectIDFromHex(sourceRef); parseErr == nil {
+				taskIDs[id] = struct{}{}
+			}
+		} else if key := organisationsBackfillRawString(document, "key"); key != "" {
+			mediaKeys[key] = struct{}{}
+		}
+		if id, parseErr := primitive.ObjectIDFromHex(organisationsBackfillRawString(document, "workflowid")); parseErr == nil {
+			workflowIDs[id] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+	tasks, err := findOrganisationsBackfillRawByObjectID(ctx, database.Collection("tasks"), taskIDs)
+	if err != nil {
+		return report, err
+	}
+	media, err := findOrganisationsBackfillRawByString(ctx, database.Collection("media"), "key", mediaKeys)
+	if err != nil {
+		return report, err
+	}
+	workflows, err := findOrganisationsBackfillRawByObjectID(ctx, database.Collection("workflows"), workflowIDs)
+	if err != nil {
+		return report, err
+	}
+	definitionCreatorIDs := make(map[primitive.ObjectID]struct{})
+	for _, definition := range workflows {
+		canonicalID, canonicalState := organisationsBackfillStringObjectIDField(definition, "organisationId")
+		_, legacyState := organisationsBackfillStringObjectIDField(definition, "organisation_id")
+		if canonicalState == organisationsBootstrapFieldValue {
+			organisationIDs[canonicalID] = struct{}{}
+		} else if canonicalState == organisationsBootstrapFieldEmpty && legacyState == organisationsBootstrapFieldEmpty {
+			if creatorID, state := organisationsBackfillStringObjectIDField(definition, "user_id"); state == organisationsBootstrapFieldValue {
+				definitionCreatorIDs[creatorID] = struct{}{}
+			}
+		}
+	}
+	definitionUsers, err := findOrganisationsBackfillUsers(ctx, database.Collection("users"), definitionCreatorIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillResolution{ObservedFieldTypes: make(map[string]map[string]int64), ObservedShapes: make(map[string]int64)}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	addOrganisationsBackfillMissingScopeConflict(&resolution, scopeID, organisations)
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillWorkflowRun(document, organisations, projects, tasks, media, workflows, definitionUsers)
+		if !organisationsBackfillSiteInScope(outcome.organisationsBackfillProjectResourceOutcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome.organisationsBackfillProjectResourceOutcome)
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillWorkflowBaseInventory(&report, outcome.organisationsBackfillProjectResourceOutcome)
+			if outcome.legacyPresent {
+				report.LegacyCandidateCount["userid"]++
+			}
+			if outcome.accidentalUserPresent {
+				report.LegacyCandidateCount["user_id"]++
+			}
+		}
+	}
+	sortOrganisationsBackfillConflicts(&resolution)
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillWorkflowRunIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillWorkflowRun(document bson.Raw, organisations map[primitive.ObjectID]bool, projects map[primitive.ObjectID]primitive.ObjectID, tasks map[primitive.ObjectID]bson.Raw, media map[string]bson.Raw, workflows map[primitive.ObjectID]bson.Raw, definitionUsers map[primitive.ObjectID]bson.Raw) (outcome organisationsBackfillWorkflowRunOutcome) {
+	resource := &outcome.organisationsBackfillProjectResourceOutcome
+	resource.documentID = organisationsBackfillDocumentID(document)
+	defer resource.enrichConflicts()
+	defer resource.resolveProject(projects)
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		resource.projectPresent = true
+		resource.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		resource.projectMissing = true
+	default:
+		resource.projectWrong = true
+		resource.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "userid")
+	resource.legacyPresent = legacyState != organisationsBootstrapFieldEmpty
+	if legacyState == organisationsBootstrapFieldValue {
+		resource.legacyUserID = legacyID
+	}
+	_, accidentalState := organisationsBackfillStringObjectIDField(document, "user_id")
+	outcome.accidentalUserPresent = accidentalState != organisationsBootstrapFieldEmpty
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		resource.canonicalID = canonicalID
+		resource.canonicalValid = true
+		if !organisations[canonicalID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+	case organisationsBootstrapFieldWrong:
+		resource.canonicalWrong = true
+		resource.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+	default:
+		resource.canonicalMissing = true
+		switch legacyState {
+		case organisationsBootstrapFieldEmpty:
+			resource.zeroCandidate = true
+			resource.addConflict("zero-candidate", "workflow run has neither canonical organisationId nor legacy userid")
+		case organisationsBootstrapFieldWrong:
+			resource.invalidLegacy = true
+			resource.addConflict("invalid-legacy-userid", "userid must contain an ObjectID hex string")
+		case organisationsBootstrapFieldValue:
+			resource.resolvedID = legacyID
+			if !organisations[legacyID] {
+				resource.orphanOrganisation = true
+				resource.addConflict("orphan-organisation", "legacy userid organisation does not exist")
+			} else {
+				resource.resolved = true
+				resource.proposedWrite = true
+			}
+		}
+	}
+	organisationID := resource.resolvedID
+	if resource.canonicalValid {
+		organisationID = resource.canonicalID
+	}
+	if organisationID.IsZero() || len(resource.conflicts) > 0 {
+		return outcome
+	}
+	validateOrganisationsBackfillRunSource(resource, document, organisationID, tasks, media)
+	validateOrganisationsBackfillRunWorkflow(resource, document, organisationID, workflows, definitionUsers)
+	return outcome
+}
+
+func validateOrganisationsBackfillRunSource(resource *organisationsBackfillProjectResourceOutcome, document bson.Raw, organisationID primitive.ObjectID, tasks map[primitive.ObjectID]bson.Raw, media map[string]bson.Raw) {
+	sourceRef := organisationsBackfillRawString(document, "sourceref")
+	if sourceRef != "" {
+		taskID, err := primitive.ObjectIDFromHex(sourceRef)
+		if err != nil {
+			resource.addConflict("unresolved-source", "sourceref is not a case ObjectID")
+			return
+		}
+		task, exists := tasks[taskID]
+		if !exists {
+			resource.addConflict("unresolved-source", "sourceref does not resolve to a case")
+			return
+		}
+		validateOrganisationsBackfillRelatedOwnership(resource, "source", organisationID, relatedOrganisationsBackfillOwnership(task, nil))
+		return
+	}
+	key := organisationsBackfillRawString(document, "key")
+	if key == "" {
+		resource.addConflict("unresolved-source", "workflow run has neither sourceref nor media key")
+		return
+	}
+	source, exists := media[key]
+	if !exists {
+		resource.addConflict("unresolved-source", "key does not resolve to media")
+		return
+	}
+	validateOrganisationsBackfillRelatedOwnership(resource, "source", organisationID, relatedOrganisationsBackfillOwnership(source, nil))
+}
+
+func validateOrganisationsBackfillRunWorkflow(resource *organisationsBackfillProjectResourceOutcome, document bson.Raw, organisationID primitive.ObjectID, workflows map[primitive.ObjectID]bson.Raw, users map[primitive.ObjectID]bson.Raw) {
+	workflowID, err := primitive.ObjectIDFromHex(organisationsBackfillRawString(document, "workflowid"))
+	if err != nil {
+		return
+	}
+	definition, exists := workflows[workflowID]
+	if !exists {
+		return
+	}
+	validateOrganisationsBackfillRelatedOwnership(resource, "definition", organisationID, relatedOrganisationsBackfillOwnership(definition, users))
+}
+
+func relatedOrganisationsBackfillOwnership(document bson.Raw, users map[primitive.ObjectID]bson.Raw) organisationsBackfillRelatedOwnership {
+	result := organisationsBackfillRelatedOwnership{}
+	if id, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+		result.organisationID = id
+		result.resolved = true
+	} else if state == organisationsBootstrapFieldEmpty {
+		if id, legacyState := organisationsBackfillStringObjectIDField(document, "organisation_id"); legacyState == organisationsBootstrapFieldValue {
+			result.organisationID = id
+			result.resolved = true
+		} else if legacyState == organisationsBootstrapFieldEmpty {
+			if id, tenantState := organisationsBackfillStringObjectIDField(document, "userid"); tenantState == organisationsBootstrapFieldValue {
+				result.organisationID = id
+				result.resolved = true
+			} else if creatorID, creatorState := organisationsBackfillStringObjectIDField(document, "user_id"); creatorState == organisationsBootstrapFieldValue && users != nil {
+				if user, exists := users[creatorID]; exists {
+					resolved := resolveOrganisationsBackfillUser(user)
+					if resolved.code == "" {
+						result.organisationID = resolved.organisationID
+						result.resolved = true
+					}
+				}
+			}
+		}
+	}
+	if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+		result.projectID = projectID
+	}
+	return result
+}
+
+func validateOrganisationsBackfillRelatedOwnership(resource *organisationsBackfillProjectResourceOutcome, relationship string, organisationID primitive.ObjectID, related organisationsBackfillRelatedOwnership) {
+	if !related.resolved {
+		resource.addConflict("unresolved-"+relationship, relationship+" ownership cannot be resolved")
+		return
+	}
+	if related.organisationID != organisationID {
+		resource.addConflict(relationship+"-organisation-mismatch", relationship+" belongs to a different organisation")
+		return
+	}
+	runProjectID := resource.resolvedProjectID
+	if resource.projectMissing {
+		runProjectID = organisationID
+	}
+	relatedProjectID := related.projectID
+	if relatedProjectID.IsZero() {
+		relatedProjectID = related.organisationID
+	}
+	if runProjectID != relatedProjectID {
+		resource.addConflict(relationship+"-project-mismatch", relationship+" belongs to a different project")
+	}
+}
+
+func inspectOrganisationsBackfillWorkflowRunIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillOrderedIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-status", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "sourceref", Value: int32(1)}, {Key: "origin", Value: int32(1)}, {Key: "start", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("legacy-userid-status-rollback", bson.D{{Key: "userid", Value: int32(1)}, {Key: "sourceref", Value: int32(1)}, {Key: "origin", Value: int32(1)}, {Key: "start", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("canonical-grouping", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-userid-grouping", bson.D{{Key: "userid", Value: int32(1)}, {Key: "key", Value: int32(1)}}),
+	})
+}
+
+func organisationsBackfillRawString(document bson.Raw, field string) string {
+	value := document.Lookup(field)
+	if value.Type != bsontype.String {
+		return ""
+	}
+	return value.StringValue()
+}
+
+func findOrganisationsBackfillRawByObjectID(ctx context.Context, collection *mongo.Collection, ids map[primitive.ObjectID]struct{}) (map[primitive.ObjectID]bson.Raw, error) {
+	result := make(map[primitive.ObjectID]bson.Raw)
+	if len(ids) == 0 {
+		return result, nil
+	}
+	values := make([]primitive.ObjectID, 0, len(ids))
+	for id := range ids {
+		values = append(values, id)
+	}
+	cursor, err := collection.Find(ctx, bson.M{"_id": bson.M{"$in": values}})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var documents []bson.Raw
+	if err := cursor.All(ctx, &documents); err != nil {
+		return nil, err
+	}
+	for _, document := range documents {
+		if id, state := organisationsBootstrapObjectID(document, "_id"); state == organisationsBootstrapFieldValue {
+			result[id] = document
+		}
+	}
+	return result, nil
+}
+
+func findOrganisationsBackfillRawByString(ctx context.Context, collection *mongo.Collection, field string, valuesSet map[string]struct{}) (map[string]bson.Raw, error) {
+	result := make(map[string]bson.Raw)
+	if len(valuesSet) == 0 {
+		return result, nil
+	}
+	values := make([]string, 0, len(valuesSet))
+	for value := range valuesSet {
+		values = append(values, value)
+	}
+	cursor, err := collection.Find(ctx, bson.M{field: bson.M{"$in": values}})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var documents []bson.Raw
+	if err := cursor.All(ctx, &documents); err != nil {
+		return nil, err
+	}
+	for _, document := range documents {
+		if value := organisationsBackfillRawString(document, field); value != "" {
+			result[value] = document
+		}
+	}
+	return result, nil
+}

--- a/actions/organisations-backfill-workflow-runs_mongo_test.go
+++ b/actions/organisations-backfill-workflow-runs_mongo_test.go
@@ -1,0 +1,38 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillWorkflowRunsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy default project config run", func(mt *mtest.T) {
+		runID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		runNamespace := mt.DB.Name() + ".workflow_runs"
+		organisationNamespace := mt.DB.Name() + ".organisation"
+		mediaNamespace := mt.DB.Name() + ".media"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, runNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: runID}, {Key: "userid", Value: organisationID.Hex()}, {Key: "key", Value: "media-1"}, {Key: "workflowid", Value: "config-workflow"}}),
+			mtest.CreateCursorResponse(0, organisationNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, mediaNamespace, mtest.FirstBatch, bson.D{{Key: "key", Value: "media-1"}, {Key: "organisationId", Value: organisationID.Hex()}}),
+			mtest.CreateCursorResponse(0, runNamespace, mtest.FirstBatch, bson.D{{Key: "name", Value: "organisationId_1_projectId_1_key_1"}, {Key: "key", Value: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "key", Value: int32(1)}}}}),
+		)
+		report, err := inspectOrganisationsBackfillWorkflowRuns(context.Background(), mt.DB, organisationsBackfillAdapters()["workflow_runs"], OrganisationsBackfillConfig{BatchSize: 500}, organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"userid": 1, "user_id": 0}})
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillWorkflowRuns() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProjectResolved != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 4 || report.IndexContracts[2].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		assertOrganisationsBackfillReadOnlyCommands(mt)
+	})
+}

--- a/actions/organisations-backfill-workflow-runs_test.go
+++ b/actions/organisations-backfill-workflow-runs_test.go
@@ -1,0 +1,62 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillWorkflowRunRelationships(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	workflowID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisationId", Value: organisationID.Hex()},
+		{Key: "projectId", Value: projectID},
+		{Key: "userid", Value: "stale"},
+		{Key: "user_id", Value: "actor-provenance"},
+		{Key: "sourceref", Value: taskID.Hex()},
+		{Key: "workflowid", Value: workflowID.Hex()},
+	})
+	tasks := map[primitive.ObjectID]bson.Raw{taskID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: taskID}, {Key: "organisationId", Value: organisationID.Hex()}, {Key: "projectId", Value: projectID}})}
+	workflows := map[primitive.ObjectID]bson.Raw{workflowID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: workflowID}, {Key: "organisationId", Value: organisationID.Hex()}, {Key: "projectId", Value: projectID}})}
+	outcome := resolveOrganisationsBackfillWorkflowRun(document, map[primitive.ObjectID]bool{organisationID: true}, map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID}, tasks, nil, workflows, nil)
+	if !outcome.canonicalValid || !outcome.accidentalUserPresent || outcome.invalidLegacy || !outcome.projectResolved || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillWorkflowRunConfigDefinitionMayBeAbsent(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "userid", Value: organisationID.Hex()},
+		{Key: "key", Value: "media-1"},
+		{Key: "workflowid", Value: "config-workflow"},
+	})
+	media := map[string]bson.Raw{"media-1": organisationsBackfillTestRaw(t, bson.D{{Key: "key", Value: "media-1"}, {Key: "organisationId", Value: organisationID.Hex()}})}
+	outcome := resolveOrganisationsBackfillWorkflowRun(document, map[primitive.ObjectID]bool{organisationID: true}, nil, nil, media, nil, nil)
+	if !outcome.resolved || !outcome.projectResolved || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillWorkflowRunReportsSourceAndDefinitionConflicts(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherOrganisationID := primitive.NewObjectID()
+	workflowID := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisationId", Value: organisationID.Hex()},
+		{Key: "key", Value: "missing-media"},
+		{Key: "workflowid", Value: workflowID.Hex()},
+	})
+	workflows := map[primitive.ObjectID]bson.Raw{workflowID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: workflowID}, {Key: "organisationId", Value: otherOrganisationID.Hex()}})}
+	outcome := resolveOrganisationsBackfillWorkflowRun(document, map[primitive.ObjectID]bool{organisationID: true}, nil, nil, nil, workflows, nil)
+	if len(outcome.conflicts) != 2 || outcome.conflicts[0].Code != "unresolved-source" || outcome.conflicts[1].Code != "definition-organisation-mismatch" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-workflows.go
+++ b/actions/organisations-backfill-workflows.go
@@ -1,0 +1,276 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type organisationsBackfillWorkflowOutcome struct {
+	organisationsBackfillProjectResourceOutcome
+	legacyOrganisationPresent bool
+	creatorPresent            bool
+	orphanUser                bool
+}
+
+func inspectOrganisationsBackfillWorkflows(ctx context.Context, database *mongo.Database, adapter organisationsBackfillAdapter, config OrganisationsBackfillConfig, report organisationsBackfillCollection) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	creatorIDs := make(map[primitive.ObjectID]struct{})
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+		legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "organisation_id")
+		if canonicalState == organisationsBootstrapFieldValue {
+			organisationIDs[canonicalID] = struct{}{}
+		} else if canonicalState == organisationsBootstrapFieldEmpty && legacyState == organisationsBootstrapFieldValue {
+			organisationIDs[legacyID] = struct{}{}
+		} else if canonicalState == organisationsBootstrapFieldEmpty && legacyState == organisationsBootstrapFieldEmpty {
+			if creatorID, state := organisationsBackfillStringObjectIDField(document, "user_id"); state == organisationsBootstrapFieldValue {
+				creatorIDs[creatorID] = struct{}{}
+			}
+		}
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
+	users, err := findOrganisationsBackfillUsers(ctx, database.Collection("users"), creatorIDs)
+	if err != nil {
+		return report, err
+	}
+	for _, user := range users {
+		resolved := resolveOrganisationsBackfillUser(user)
+		if resolved.code == "" {
+			organisationIDs[resolved.organisationID] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+	resolution := organisationsBackfillResolution{ObservedFieldTypes: make(map[string]map[string]int64), ObservedShapes: make(map[string]int64)}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	addOrganisationsBackfillMissingScopeConflict(&resolution, scopeID, organisations)
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillWorkflow(document, users, organisations, projects)
+		if !organisationsBackfillSiteInScope(outcome.organisationsBackfillProjectResourceOutcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome.organisationsBackfillProjectResourceOutcome)
+		if outcome.orphanUser {
+			resolution.OrphanUsers++
+		}
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillWorkflowInventory(&report, outcome)
+		}
+	}
+	sortOrganisationsBackfillConflicts(&resolution)
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillWorkflowIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillWorkflow(document bson.Raw, users map[primitive.ObjectID]bson.Raw, organisations map[primitive.ObjectID]bool, projects map[primitive.ObjectID]primitive.ObjectID) (outcome organisationsBackfillWorkflowOutcome) {
+	resource := &outcome.organisationsBackfillProjectResourceOutcome
+	resource.documentID = organisationsBackfillDocumentID(document)
+	defer resource.enrichConflicts()
+	defer resource.resolveProject(projects)
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		resource.projectPresent = true
+		resource.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		resource.projectMissing = true
+	default:
+		resource.projectWrong = true
+		resource.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "organisation_id")
+	outcome.legacyOrganisationPresent = legacyState != organisationsBootstrapFieldEmpty
+	creatorID, creatorState := organisationsBackfillStringObjectIDField(document, "user_id")
+	outcome.creatorPresent = creatorState != organisationsBootstrapFieldEmpty
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		resource.canonicalID = canonicalID
+		resource.canonicalValid = true
+		if !organisations[canonicalID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		resource.canonicalWrong = true
+		resource.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		resource.canonicalMissing = true
+	}
+
+	if legacyState == organisationsBootstrapFieldValue {
+		resource.legacyPresent = true
+		resource.legacyUserID = legacyID
+		resource.resolvedID = legacyID
+		if !organisations[legacyID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "legacy organisation_id does not resolve to an organisation")
+			return outcome
+		}
+		resource.resolved = true
+		resource.proposedWrite = true
+		return outcome
+	}
+	if legacyState == organisationsBootstrapFieldWrong {
+		resource.invalidLegacy = true
+		resource.addConflict("invalid-legacy-organisation-id", "organisation_id must contain an ObjectID hex string")
+		return outcome
+	}
+
+	switch creatorState {
+	case organisationsBootstrapFieldEmpty:
+		resource.zeroCandidate = true
+		resource.addConflict("zero-candidate", "workflow has no canonical, legacy, or stable creator ownership")
+	case organisationsBootstrapFieldWrong:
+		resource.invalidLegacy = true
+		resource.addConflict("invalid-creator-user-id", "user_id must contain an ObjectID hex string")
+	case organisationsBootstrapFieldValue:
+		resource.legacyPresent = true
+		resource.legacyUserID = creatorID
+		user, exists := users[creatorID]
+		if !exists {
+			outcome.orphanUser = true
+			resource.addConflict("orphan-user", "creator user_id does not resolve to a user")
+			return outcome
+		}
+		resolved := resolveOrganisationsBackfillUser(user)
+		if resolved.code != "" {
+			resource.addConflict(resolved.code, resolved.message)
+			return outcome
+		}
+		resource.resolvedID = resolved.organisationID
+		if !organisations[resource.resolvedID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "creator's stable organisation does not exist")
+			return outcome
+		}
+		resource.resolved = true
+		resource.proposedWrite = true
+	}
+	return outcome
+}
+
+func inspectOrganisationsBackfillWorkflowIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillOrderedIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-enabled", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-organisation-enabled", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-creator-enabled", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("canonical-name", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "name", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-organisation-name", bson.D{{Key: "organisation_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "name", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-creator-name", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "name", Value: int32(1)}}),
+	})
+}
+
+func addOrganisationsBackfillWorkflowInventory(report *organisationsBackfillCollection, outcome organisationsBackfillWorkflowOutcome) {
+	addOrganisationsBackfillWorkflowBaseInventory(report, outcome.organisationsBackfillProjectResourceOutcome)
+	if outcome.legacyOrganisationPresent {
+		report.LegacyCandidateCount["organisation_id"]++
+	}
+	if outcome.creatorPresent {
+		report.LegacyCandidateCount["user_id"]++
+	}
+}
+
+func addOrganisationsBackfillWorkflowBaseInventory(report *organisationsBackfillCollection, outcome organisationsBackfillProjectResourceOutcome) {
+	report.Total++
+	if outcome.canonicalValid {
+		report.CanonicalPresent++
+	}
+	if outcome.canonicalMissing {
+		report.CanonicalMissing++
+	}
+	if outcome.canonicalWrong {
+		report.CanonicalWrongType++
+	}
+	if outcome.projectPresent {
+		report.ProjectPresent++
+	}
+	if outcome.projectMissing {
+		report.ProjectMissing++
+	}
+	if outcome.projectWrong {
+		report.ProjectWrongType++
+	}
+}
+
+func addOrganisationsBackfillMissingScopeConflict(resolution *organisationsBackfillResolution, scopeID primitive.ObjectID, organisations map[primitive.ObjectID]bool) {
+	if scopeID.IsZero() || organisations[scopeID] {
+		return
+	}
+	resolution.OrphanOrganisations++
+	resolution.Conflicts++
+	resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{Code: "scope-organisation-not-found", CanonicalOrganisation: scopeID.Hex(), ResolvedOrganisations: []string{scopeID.Hex()}, Message: "requested organisation does not exist"})
+}
+
+func sortOrganisationsBackfillConflicts(resolution *organisationsBackfillResolution) {
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		if resolution.ConflictEntries[left].DocumentID != resolution.ConflictEntries[right].DocumentID {
+			return resolution.ConflictEntries[left].DocumentID < resolution.ConflictEntries[right].DocumentID
+		}
+		return resolution.ConflictEntries[left].Code < resolution.ConflictEntries[right].Code
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+}
+
+func inspectOrganisationsBackfillOrderedIndexes(ctx context.Context, collection *mongo.Collection, contracts []organisationsBackfillIndexContract) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-workflows_mongo_test.go
+++ b/actions/organisations-backfill-workflows_mongo_test.go
@@ -1,0 +1,44 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestInspectOrganisationsBackfillWorkflowsIsReadOnly(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("legacy organisation", func(mt *mtest.T) {
+		workflowID := primitive.NewObjectID()
+		organisationID := primitive.NewObjectID()
+		workflowNamespace := mt.DB.Name() + ".workflows"
+		organisationNamespace := mt.DB.Name() + ".organisation"
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(0, workflowNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: workflowID}, {Key: "organisation_id", Value: organisationID.Hex()}, {Key: "enabled", Value: true}, {Key: "name", Value: "notify"}}),
+			mtest.CreateCursorResponse(0, organisationNamespace, mtest.FirstBatch, bson.D{{Key: "_id", Value: organisationID}}),
+			mtest.CreateCursorResponse(0, workflowNamespace, mtest.FirstBatch, bson.D{{Key: "name", Value: "organisationId_1_projectId_1_enabled_1"}, {Key: "key", Value: bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "enabled", Value: int32(1)}}}}),
+		)
+		report, err := inspectOrganisationsBackfillWorkflows(context.Background(), mt.DB, organisationsBackfillAdapters()["workflows"], OrganisationsBackfillConfig{BatchSize: 500}, organisationsBackfillCollection{LegacyCandidateCount: map[string]int64{"organisation_id": 1, "user_id": 0}})
+		if err != nil {
+			mt.Fatalf("inspectOrganisationsBackfillWorkflows() error = %v", err)
+		}
+		if report.Resolution == nil || report.Resolution.Resolved != 1 || report.Resolution.ProjectResolved != 1 || report.Resolution.Conflicts != 0 {
+			mt.Fatalf("resolution = %+v", report.Resolution)
+		}
+		if len(report.IndexContracts) != 6 || report.IndexContracts[0].Status != "exact" {
+			mt.Fatalf("index contracts = %+v", report.IndexContracts)
+		}
+		assertOrganisationsBackfillReadOnlyCommands(mt)
+	})
+}
+
+func assertOrganisationsBackfillReadOnlyCommands(mt *mtest.T) {
+	for _, event := range mt.GetAllStartedEvents() {
+		if event.CommandName != "find" && event.CommandName != "listIndexes" {
+			mt.Fatalf("dry-run issued non-read command %q", event.CommandName)
+		}
+	}
+}

--- a/actions/organisations-backfill-workflows_test.go
+++ b/actions/organisations-backfill-workflows_test.go
@@ -1,0 +1,59 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillWorkflowPrecedence(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	creatorID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true}
+	users := map[primitive.ObjectID]bson.Raw{creatorID: organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: creatorID}, {Key: "user_id", Value: organisationID.Hex()}})}
+
+	t.Run("canonical preserves malformed creator provenance", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillWorkflow(organisationsBackfillTestRaw(t, bson.D{
+			{Key: "_id", Value: primitive.NewObjectID()},
+			{Key: "organisationId", Value: organisationID.Hex()},
+			{Key: "organisation_id", Value: "stale"},
+			{Key: "user_id", Value: "invalid"},
+		}), users, organisations, nil)
+		if !outcome.canonicalValid || outcome.invalidLegacy || len(outcome.conflicts) != 0 || !outcome.projectResolved || outcome.resolvedProjectID != organisationID {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+
+	t.Run("legacy organisation precedes creator", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillWorkflow(organisationsBackfillTestRaw(t, bson.D{
+			{Key: "_id", Value: primitive.NewObjectID()},
+			{Key: "organisation_id", Value: organisationID.Hex()},
+			{Key: "user_id", Value: "invalid"},
+		}), users, organisations, nil)
+		if !outcome.resolved || outcome.resolvedID != organisationID || outcome.invalidLegacy || !outcome.proposedWrite || len(outcome.conflicts) != 0 {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+
+	t.Run("creator resolves only when both organisation fields are absent", func(t *testing.T) {
+		outcome := resolveOrganisationsBackfillWorkflow(organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "user_id", Value: creatorID.Hex()}}), users, organisations, nil)
+		if !outcome.resolved || outcome.resolvedID != organisationID || outcome.orphanUser || len(outcome.conflicts) != 0 {
+			t.Fatalf("outcome = %+v", outcome)
+		}
+	})
+}
+
+func TestResolveOrganisationsBackfillWorkflowValidatesExplicitProject(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	otherOrganisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	outcome := resolveOrganisationsBackfillWorkflow(organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisationId", Value: organisationID.Hex()},
+		{Key: "projectId", Value: projectID},
+	}), nil, map[primitive.ObjectID]bool{organisationID: true}, map[primitive.ObjectID]primitive.ObjectID{projectID: otherOrganisationID})
+	if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "project-organisation-mismatch" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -419,8 +419,8 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			LegacyCandidates:      []string{"key"},
 			PreservedFields:       []string{"key", "source.runId", "workflowId", "deviceId"},
 			ResolverKind:          organisationsBackfillResolverDetection,
-			MinimumWriterVersions: []string{"hub-api:unreleased-workflow-detection-analysis-project-scope", "hub-workflows:unreleased-PR58"},
-			MinimumReaderVersions: []string{"hub-api:unreleased-workflow-detection-analysis-project-scope", "hub-workflows:unreleased-PR58"},
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR534", "hub-pipeline-analysis:unreleased-PR95", "hub-workflows:unreleased-PR58"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR534", "hub-workflows:unreleased-PR58"},
 		},
 		"groups": {
 			Collection:            "groups",

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -27,6 +27,8 @@ const (
 	organisationsBackfillResolverSite         = "site-tenant"
 	organisationsBackfillResolverGroup        = "group-tenant"
 	organisationsBackfillResolverIO           = "io-actor"
+	organisationsBackfillResolverWorkflow     = "workflow-definition"
+	organisationsBackfillResolverWorkflowRun  = "workflow-run"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -245,6 +247,12 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverIO {
 		return inspectOrganisationsBackfillIO(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverWorkflow {
+		return inspectOrganisationsBackfillWorkflows(ctx, database, adapter, config, report)
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverWorkflowRun {
+		return inspectOrganisationsBackfillWorkflowRuns(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -430,6 +438,32 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
 			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-monitor:v1.3.14", "hub-cleanup:v1.4.19", "cli:v1.2.23", "hub-monitor-device:unreleased-PR22"},
 		},
+		"workflow_runs": {
+			Collection:            "workflow_runs",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"userid", "user_id"},
+			PreservedFields:       []string{"userid", "user_id", "workflowid", "sourceref", "key"},
+			ResolverKind:          organisationsBackfillResolverWorkflowRun,
+			MinimumWriterVersions: []string{"hub-workflows:unreleased-PR58"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR532", "hub-workflows:unreleased-PR58", "hub-cleanup:unverified"},
+		},
+		"workflows": {
+			Collection:            "workflows",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"organisation_id", "user_id"},
+			PreservedFields:       []string{"user_id", "userId", "created_by", "updated_by", "audit"},
+			ResolverKind:          organisationsBackfillResolverWorkflow,
+			MinimumWriterVersions: []string{"hub-api:unreleased-PR532"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-PR532", "hub-workflows:unreleased-PR58", "hub-cleanup:unverified"},
+		},
 	}
 }
 
@@ -445,7 +479,6 @@ func organisationsBackfillBlockedAdapters() map[string]string {
 		"settings":      "shared model does not declare a canonical tenant field",
 		"tasks":         "shared model and canonical BSON type are not declared",
 		"videowalls":    "shared model does not declare organisationId",
-		"workflow_runs": "persisted canonical BSON type is not verified",
 	}
 }
 

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -29,6 +29,8 @@ const (
 	organisationsBackfillResolverIO           = "io-actor"
 	organisationsBackfillResolverWorkflow     = "workflow-definition"
 	organisationsBackfillResolverWorkflowRun  = "workflow-run"
+	organisationsBackfillResolverAnalysis     = "analysis-tenant"
+	organisationsBackfillResolverDetection    = "detection-source"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -253,6 +255,12 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverWorkflowRun {
 		return inspectOrganisationsBackfillWorkflowRuns(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverAnalysis {
+		return inspectOrganisationsBackfillAnalysis(ctx, database, adapter, config, report)
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverDetection {
+		return inspectOrganisationsBackfillDetections(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -368,6 +376,19 @@ func selectOrganisationsBackfillAdapters(collection string, all bool) ([]organis
 
 func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 	return map[string]organisationsBackfillAdapter{
+		"analysis": {
+			Collection:            "analysis",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"userid", "user_id"},
+			PreservedFields:       []string{"userid", "user_id", "key", "deviceid"},
+			ResolverKind:          organisationsBackfillResolverAnalysis,
+			MinimumWriterVersions: []string{"hub-pipeline-analysis:v1.8.6"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-workflow-detection-analysis-project-scope", "hub-pipeline-analysis:v1.8.6"},
+		},
 		"alerts": {
 			Collection:            "alerts",
 			OwnershipScope:        "project-scoped",
@@ -387,6 +408,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			TargetBSONType:   "string",
 			LegacyCandidates: []string{"user_id"},
 			PreservedFields:  []string{"user_id"},
+		},
+		"detections": {
+			Collection:            "detections",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"key"},
+			PreservedFields:       []string{"key", "source.runId", "workflowId", "deviceId"},
+			ResolverKind:          organisationsBackfillResolverDetection,
+			MinimumWriterVersions: []string{"hub-api:unreleased-workflow-detection-analysis-project-scope", "hub-workflows:unreleased-PR58"},
+			MinimumReaderVersions: []string{"hub-api:unreleased-workflow-detection-analysis-project-scope", "hub-workflows:unreleased-PR58"},
 		},
 		"groups": {
 			Collection:            "groups",
@@ -469,7 +503,6 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 
 func organisationsBackfillBlockedAdapters() map[string]string {
 	return map[string]string{
-		"analysis":      "shared model and canonical BSON type are not declared",
 		"channels":      "persistence and ownership contracts are unverified",
 		"counting":      "persisted shapes require a production audit",
 		"heatmap":       "persisted shapes require a production audit",

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions", "workflow_runs", "workflows"}
+	want := []string{"alerts", "analysis", "detections", "devices", "groups", "io", "sites", "subscriptions", "workflow_runs", "workflows"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -189,6 +189,17 @@ func TestWorkflowAdaptersDeclareSeparateResolvers(t *testing.T) {
 	runs := organisationsBackfillAdapters()["workflow_runs"]
 	if runs.ResolverKind != organisationsBackfillResolverWorkflowRun || runs.ProjectBSONType != "objectId" {
 		t.Fatalf("workflow run adapter = %+v", runs)
+	}
+}
+
+func TestAnalysisAndDetectionAdaptersDeclareProjectScope(t *testing.T) {
+	analysis := organisationsBackfillAdapters()["analysis"]
+	if analysis.ResolverKind != organisationsBackfillResolverAnalysis || analysis.ProjectBSONType != "objectId" {
+		t.Fatalf("analysis adapter = %+v", analysis)
+	}
+	detections := organisationsBackfillAdapters()["detections"]
+	if detections.ResolverKind != organisationsBackfillResolverDetection || detections.ProjectBSONType != "objectId" {
+		t.Fatalf("detections adapter = %+v", detections)
 	}
 }
 

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions"}
+	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions", "workflow_runs", "workflows"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -178,6 +178,17 @@ func TestIOAdapterDeclaresProjectScopeAndActorFallback(t *testing.T) {
 	}
 	if len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "user_id" || len(adapter.PreservedFields) != 1 || adapter.PreservedFields[0] != "user_id" {
 		t.Fatalf("IO actor contract = %+v", adapter)
+	}
+}
+
+func TestWorkflowAdaptersDeclareSeparateResolvers(t *testing.T) {
+	definitions := organisationsBackfillAdapters()["workflows"]
+	if definitions.ResolverKind != organisationsBackfillResolverWorkflow || definitions.ProjectBSONType != "objectId" {
+		t.Fatalf("workflow adapter = %+v", definitions)
+	}
+	runs := organisationsBackfillAdapters()["workflow_runs"]
+	if runs.ResolverKind != organisationsBackfillResolverWorkflowRun || runs.ProjectBSONType != "objectId" {
+		t.Fatalf("workflow run adapter = %+v", runs)
 	}
 }
 

--- a/indexes/migration-hub-analysis-detection-ownership-27-08-2026.txt
+++ b/indexes/migration-hub-analysis-detection-ownership-27-08-2026.txt
@@ -1,0 +1,13 @@
+analysis
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, key: 1 }, name: 'organisationId_1_projectId_1_key_1' },
+  { v: 2, key: { userid: 1, projectId: 1, key: 1 }, name: 'userid_1_projectId_1_key_1' },
+  { v: 2, key: { user_id: 1, projectId: 1, key: 1 }, name: 'user_id_1_projectId_1_key_1' },
+]
+
+detections
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, key: 1 }, name: 'organisationId_1_projectId_1_key_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, 'source.runId': 1 }, name: 'organisationId_1_projectId_1_source.runId_1' },
+  { v: 2, key: { key: 1, 'source.runId': 1 }, name: 'key_1_source.runId_1' },
+]

--- a/indexes/migration-hub-workflow-ownership-26-08-2026.txt
+++ b/indexes/migration-hub-workflow-ownership-26-08-2026.txt
@@ -1,0 +1,17 @@
+workflows
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, enabled: 1 }, name: 'organisationId_1_projectId_1_enabled_1' },
+  { v: 2, key: { organisation_id: 1, projectId: 1, enabled: 1 }, name: 'organisation_id_1_projectId_1_enabled_1' },
+  { v: 2, key: { user_id: 1, projectId: 1, enabled: 1 }, name: 'user_id_1_projectId_1_enabled_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, name: 1 }, name: 'organisationId_1_projectId_1_name_1' },
+  { v: 2, key: { organisation_id: 1, projectId: 1, name: 1 }, name: 'organisation_id_1_projectId_1_name_1' },
+  { v: 2, key: { user_id: 1, projectId: 1, name: 1 }, name: 'user_id_1_projectId_1_name_1' },
+]
+
+workflow_runs
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, sourceref: 1, origin: 1, start: -1 }, name: 'organisationId_1_projectId_1_sourceref_1_origin_1_start_-1' },
+  { v: 2, key: { userid: 1, sourceref: 1, origin: 1, start: -1 }, name: 'userid_1_sourceref_1_origin_1_start_-1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, key: 1 }, name: 'organisationId_1_projectId_1_key_1' },
+  { v: 2, key: { userid: 1, key: 1 }, name: 'userid_1_key_1' },
+]


### PR DESCRIPTION
## Description

Adds project-scoped ownership auditing for workflows, workflow runs, analysis, and detections, along with index validation and conflict detection logic needed to safely backfill canonical organisation/project ownership data.

The new adapters standardize how ownership is resolved across legacy and canonical fields while enforcing deterministic precedence rules. This reduces ambiguity in migrated data, prevents incorrect ownership inference, and surfaces invalid or orphaned relationships as explicit conflicts instead of silently accepting inconsistent state.

Key improvements:
- Adds ownership resolution and validation for:
  - workflow definitions and workflow runs
  - analysis documents
  - detections derived from trusted analysis sources
- Enforces canonical organisation/project consistency across related resources
- Validates legacy fallback behaviour without promoting accidental fields into ownership
- Adds ordered index contract inspection for all newly supported collections
- Introduces comprehensive unit and Mongo integration tests to guarantee read-only inspection behaviour and precedence correctness
- Documents runtime compatibility requirements and operational audit commands in the README

This improves migration safety and auditability by ensuring ownership data is derived from authoritative sources, conflicts are detected early, and index expectations are verified before rollout.