### PR TITLE
feat(organisations): audit active project resources

### DIFF
--- a/actions/generate-default-labels.go
+++ b/actions/generate-default-labels.go
@@ -10,10 +10,16 @@ import (
 	"github.com/gosuri/uiprogress"
 	"github.com/uug-ai/cli/database"
 	"github.com/uug-ai/cli/models"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"gopkg.in/mgo.v2/bson"
 )
+
+type defaultLabelDocument struct {
+	models.Label   `bson:",inline"`
+	OrganisationId string             `bson:"organisationId"`
+	ProjectId      primitive.ObjectID `bson:"projectId"`
+}
 
 func GenerateDefaultLabels(
 	mode string,
@@ -103,7 +109,7 @@ func GenerateDefaultLabels(
 	// generate the new labels to be inserted
 	//
 	bar.Incr()
-	labelNamesArray := strings.Split(labelNames, ",")
+	labelNamesArray := defaultLabelNames(labelNames)
 
 	time.Sleep(time.Second * 2)
 
@@ -119,7 +125,11 @@ func GenerateDefaultLabels(
 
 		labels := GenerateDefaultLabelsForNames(labelNamesArray, owner.Id.Hex())
 		for _, label := range labels {
-			filter := bson.M{"user_id": label.UserId, "name": label.Name}
+			filter, err := defaultLabelMatch(label.OwnerId, label.Name)
+			if err != nil {
+				log.Println("Invalid label owner:", err)
+				continue
+			}
 			count, err := labelsCollection.CountDocuments(context.Background(), filter)
 			if err != nil {
 				log.Println("Error checking for existing label:", err)
@@ -129,7 +139,12 @@ func GenerateDefaultLabels(
 				if mode == "dry-run" {
 					// Nothing to do here..
 				} else if mode == "live" {
-					_, err = labelsCollection.InsertOne(context.Background(), label)
+					document, documentErr := buildDefaultLabelDocument(label)
+					if documentErr != nil {
+						log.Println("Invalid label ownership:", documentErr)
+						continue
+					}
+					_, err = labelsCollection.InsertOne(context.Background(), document)
 				}
 				addedLabels = append(addedLabels, label)
 				if err != nil {
@@ -160,6 +175,39 @@ func GenerateDefaultLabels(
 	log.Println("  +---------------------------------------------+----------------------+")
 	log.Println("")
 	log.Println("Process completed.")
+}
+
+func defaultLabelNames(value string) []string {
+	var names []string
+	for _, name := range strings.Split(value, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return []string{"Incident", "suspicious", "unauthorized"}
+	}
+	return names
+}
+
+func buildDefaultLabelDocument(label models.Label) (defaultLabelDocument, error) {
+	ownerId, err := primitive.ObjectIDFromHex(label.OwnerId)
+	if err != nil || ownerId.IsZero() {
+		return defaultLabelDocument{}, fmt.Errorf("owner_id %q is invalid", label.OwnerId)
+	}
+	return defaultLabelDocument{Label: label, OrganisationId: label.OwnerId, ProjectId: ownerId}, nil
+}
+
+func defaultLabelMatch(ownerId, name string) (bson.M, error) {
+	projectId, err := primitive.ObjectIDFromHex(ownerId)
+	if err != nil || projectId.IsZero() {
+		return nil, fmt.Errorf("owner_id %q is invalid", ownerId)
+	}
+	projectScope := bson.M{"$in": bson.A{projectId, nil}}
+	return bson.M{"$or": []bson.M{
+		{"organisationId": ownerId, "projectId": projectScope, "name": name},
+		{"organisationId": bson.M{"$in": bson.A{nil, ""}}, "owner_id": ownerId, "projectId": projectScope, "name": name},
+	}}, nil
 }
 
 func GetOwnersFromMongodb(client *mongo.Client, DatabaseName string, username string) []models.User {
@@ -205,7 +253,7 @@ func GenerateDefaultLabelsForNames(names []string, userId string) []models.Label
 
 	// Default label names if empty
 	if len(names) == 0 {
-		names = []string{"Incident", "suspicious", "unauthorized"}
+		names = defaultLabelNames("")
 	}
 
 	var labels []models.Label

--- a/actions/organisations-backfill-counting.go
+++ b/actions/organisations-backfill-counting.go
@@ -1,0 +1,47 @@
+package actions
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func inspectOrganisationsBackfillCountingIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillOrderedIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-time", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "timestamp", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("canonical-project-device-time", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "device_id", Value: int32(1)}, {Key: "timestamp", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-time", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "timestamp", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-device-time", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "device_id", Value: int32(1)}, {Key: "timestamp", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("global-retention", bson.D{{Key: "timestamp", Value: int32(1)}}),
+	})
+}
+
+func inspectOrganisationsBackfillOrderedIndexes(ctx context.Context, collection *mongo.Collection, contracts []organisationsBackfillIndexContract) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-counting_test.go
+++ b/actions/organisations-backfill-counting_test.go
@@ -1,0 +1,18 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillCountingUsesStableTenant(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	projectId := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "user_id", Value: organisationId.Hex()}, {Key: "projectId", Value: projectId}})
+	outcome := resolveOrganisationsBackfillProjectResource(document, "counting", "user_id", map[primitive.ObjectID]bool{organisationId: true}, map[primitive.ObjectID]primitive.ObjectID{projectId: organisationId})
+	if !outcome.resolved || outcome.resolvedID != organisationId || !outcome.projectResolved || outcome.resolvedProjectID != projectId || len(outcome.conflicts) != 0 {
+		t.Fatalf("counting outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-groups.go
+++ b/actions/organisations-backfill-groups.go
@@ -31,7 +31,7 @@ func resolveOrganisationsBackfillGroup(
 	organisations map[primitive.ObjectID]bool,
 	projects map[primitive.ObjectID]primitive.ObjectID,
 ) organisationsBackfillProjectResourceOutcome {
-	return resolveOrganisationsBackfillProjectResource(document, "group", organisations, projects)
+	return resolveOrganisationsBackfillProjectResource(document, "group", "user_id", organisations, projects)
 }
 
 func inspectOrganisationsBackfillGroupIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {

--- a/actions/organisations-backfill-io.go
+++ b/actions/organisations-backfill-io.go
@@ -96,7 +96,7 @@ func inspectOrganisationsBackfillIO(
 			resolution.OrphanUsers++
 		}
 		if config.OrganisationID != "" {
-			addOrganisationsBackfillSiteScopedInventory(&report, outcome.organisationsBackfillProjectResourceOutcome)
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome.organisationsBackfillProjectResourceOutcome, "user_id")
 		}
 	}
 	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {

--- a/actions/organisations-backfill-labels.go
+++ b/actions/organisations-backfill-labels.go
@@ -1,0 +1,41 @@
+package actions
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func inspectOrganisationsBackfillLabelIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-list", bson.D{{Key: "owner_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill-labels_test.go
+++ b/actions/organisations-backfill-labels_test.go
@@ -1,0 +1,61 @@
+package actions
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/uug-ai/cli/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestBuildDefaultLabelDocumentStampsDefaultOwnership(t *testing.T) {
+	ownerId := primitive.NewObjectID()
+	document, err := buildDefaultLabelDocument(models.Label{OwnerId: ownerId.Hex(), UserId: primitive.NewObjectID().Hex(), Name: "Incident"})
+	if err != nil {
+		t.Fatalf("build label: %v", err)
+	}
+	if document.OrganisationId != ownerId.Hex() || document.ProjectId != ownerId || document.UserId == document.OwnerId {
+		t.Fatalf("default label document = %+v", document)
+	}
+}
+
+func TestDefaultLabelMatchUsesCanonicalFirstDefaultScope(t *testing.T) {
+	ownerId := primitive.NewObjectID()
+	match, err := defaultLabelMatch(ownerId.Hex(), "Incident")
+	if err != nil {
+		t.Fatalf("build match: %v", err)
+	}
+	arms := match["$or"].([]bson.M)
+	if arms[0]["organisationId"] != ownerId.Hex() || arms[1]["owner_id"] != ownerId.Hex() {
+		t.Fatalf("ownership match = %#v", match)
+	}
+	wantProject := bson.M{"$in": bson.A{ownerId, nil}}
+	if !reflect.DeepEqual(arms[0]["projectId"], wantProject) || !reflect.DeepEqual(arms[1]["projectId"], wantProject) {
+		t.Fatalf("project match = %#v", match)
+	}
+}
+
+func TestDefaultLabelNamesDropsEmptyValues(t *testing.T) {
+	if got := defaultLabelNames(" , "); !reflect.DeepEqual(got, []string{"Incident", "suspicious", "unauthorized"}) {
+		t.Fatalf("default names = %#v", got)
+	}
+}
+
+func TestResolveOrganisationsBackfillLabelUsesStableOwner(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "owner_id", Value: organisationId.Hex()}, {Key: "user_id", Value: primitive.NewObjectID().Hex()}})
+	outcome := resolveOrganisationsBackfillProjectResource(document, "label", "owner_id", map[primitive.ObjectID]bool{organisationId: true}, nil)
+	if !outcome.resolved || outcome.resolvedID != organisationId || !outcome.projectResolved || outcome.resolvedProjectID != organisationId || len(outcome.conflicts) != 0 {
+		t.Fatalf("label outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillLabelCanonicalWins(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "organisationId", Value: organisationId.Hex()}, {Key: "owner_id", Value: "invalid"}})
+	outcome := resolveOrganisationsBackfillProjectResource(document, "label", "owner_id", map[primitive.ObjectID]bool{organisationId: true}, nil)
+	if !outcome.canonicalValid || outcome.resolved || outcome.invalidLegacy || !outcome.projectResolved || len(outcome.conflicts) != 0 {
+		t.Fatalf("label outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill-sites.go
+++ b/actions/organisations-backfill-sites.go
@@ -60,6 +60,7 @@ func inspectOrganisationsBackfillProjectResource(
 	inspectIndexes func(context.Context, *mongo.Collection) ([]organisationsBackfillIndexContract, error),
 ) (organisationsBackfillCollection, error) {
 	var scopeID primitive.ObjectID
+	legacyField := adapter.LegacyCandidates[0]
 	if config.OrganisationID != "" {
 		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
 	}
@@ -74,7 +75,7 @@ func inspectOrganisationsBackfillProjectResource(
 		if id, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
 			organisationIDs[id] = struct{}{}
 		} else if state == organisationsBootstrapFieldEmpty {
-			if legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "user_id"); legacyState == organisationsBootstrapFieldValue {
+			if legacyID, legacyState := organisationsBackfillStringObjectIDField(document, legacyField); legacyState == organisationsBootstrapFieldValue {
 				organisationIDs[legacyID] = struct{}{}
 			}
 		}
@@ -112,14 +113,14 @@ func inspectOrganisationsBackfillProjectResource(
 		})
 	}
 	for _, document := range documents {
-		outcome := resolveOrganisationsBackfillProjectResource(document, resourceName, organisations, projects)
+		outcome := resolveOrganisationsBackfillProjectResource(document, resourceName, legacyField, organisations, projects)
 		if !organisationsBackfillSiteInScope(outcome, scopeID) {
 			continue
 		}
 		observeOrganisationsBackfillDocument(&resolution, document)
 		addOrganisationsBackfillSiteOutcome(&resolution, outcome)
 		if config.OrganisationID != "" {
-			addOrganisationsBackfillSiteScopedInventory(&report, outcome)
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome, legacyField)
 		}
 	}
 	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
@@ -143,12 +144,13 @@ func resolveOrganisationsBackfillSite(
 	organisations map[primitive.ObjectID]bool,
 	projects map[primitive.ObjectID]primitive.ObjectID,
 ) (outcome organisationsBackfillProjectResourceOutcome) {
-	return resolveOrganisationsBackfillProjectResource(document, "site", organisations, projects)
+	return resolveOrganisationsBackfillProjectResource(document, "site", "user_id", organisations, projects)
 }
 
 func resolveOrganisationsBackfillProjectResource(
 	document bson.Raw,
 	resourceName string,
+	legacyField string,
 	organisations map[primitive.ObjectID]bool,
 	projects map[primitive.ObjectID]primitive.ObjectID,
 ) (outcome organisationsBackfillProjectResourceOutcome) {
@@ -156,7 +158,7 @@ func resolveOrganisationsBackfillProjectResource(
 	defer outcome.enrichConflicts()
 	defer outcome.resolveProject(projects)
 
-	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "user_id")
+	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, legacyField)
 	if legacyState != organisationsBootstrapFieldEmpty {
 		outcome.legacyPresent = true
 	}
@@ -197,15 +199,15 @@ func resolveOrganisationsBackfillProjectResource(
 	switch legacyState {
 	case organisationsBootstrapFieldEmpty:
 		outcome.zeroCandidate = true
-		outcome.addConflict("zero-candidate", resourceName+" has neither canonical organisationId nor legacy user_id")
+		outcome.addConflict("zero-candidate", resourceName+" has neither canonical organisationId nor legacy "+legacyField)
 	case organisationsBootstrapFieldWrong:
 		outcome.invalidLegacy = true
-		outcome.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
+		outcome.addConflict("invalid-legacy-owner-id", legacyField+" must contain an ObjectID hex string")
 	case organisationsBootstrapFieldValue:
 		outcome.resolvedID = legacyID
 		if !organisations[legacyID] {
 			outcome.orphanOrganisation = true
-			outcome.addConflict("orphan-organisation", "legacy user_id organisation does not exist")
+			outcome.addConflict("orphan-organisation", "legacy "+legacyField+" organisation does not exist")
 			return outcome
 		}
 		outcome.resolved = true
@@ -320,7 +322,7 @@ func addOrganisationsBackfillSiteOutcome(report *organisationsBackfillResolution
 	report.ConflictEntries = append(report.ConflictEntries, outcome.conflicts...)
 }
 
-func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillProjectResourceOutcome) {
+func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCollection, outcome organisationsBackfillProjectResourceOutcome, legacyField string) {
 	report.Total++
 	if outcome.canonicalValid {
 		report.CanonicalPresent++
@@ -341,7 +343,7 @@ func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCo
 		report.ProjectWrongType++
 	}
 	if outcome.legacyPresent {
-		report.LegacyCandidateCount["user_id"]++
+		report.LegacyCandidateCount[legacyField]++
 	}
 }
 

--- a/actions/organisations-backfill-videowalls.go
+++ b/actions/organisations-backfill-videowalls.go
@@ -1,0 +1,75 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func inspectOrganisationsBackfillVideowalls(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	report, err := inspectOrganisationsBackfillProjectResource(
+		ctx,
+		database,
+		adapter,
+		config,
+		report,
+		"videowall",
+		inspectOrganisationsBackfillVideowallIndexes,
+	)
+	if err != nil || report.Resolution == nil {
+		return report, err
+	}
+
+	if config.OrganisationID != "" || config.DocumentID != "" {
+		return report, nil
+	}
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"short_link": bson.M{"$type": "string", "$ne": ""}}}},
+		{{Key: "$group", Value: bson.M{"_id": "$short_link", "count": bson.M{"$sum": 1}}}},
+		{{Key: "$match", Value: bson.M{"count": bson.M{"$gt": 1}}}},
+		{{Key: "$project", Value: bson.M{"_id": 0, "count": 1}}},
+		{{Key: "$limit", Value: organisationsBackfillConflictLimit}},
+	}
+	cursor, err := database.Collection(adapter.Collection).Aggregate(ctx, pipeline)
+	if err != nil {
+		return report, err
+	}
+	defer cursor.Close(ctx)
+	var duplicates []struct {
+		Count int64 `bson:"count"`
+	}
+	if err := cursor.All(ctx, &duplicates); err != nil {
+		return report, err
+	}
+	for _, duplicate := range duplicates {
+		report.Resolution.MultipleCandidates += duplicate.Count
+		report.Resolution.Conflicts++
+		report.Resolution.ConflictEntries = append(report.Resolution.ConflictEntries, organisationsBackfillConflict{
+			Code:    "duplicate-short-link",
+			Message: "a redacted short-link capability resolves to multiple videowalls",
+		})
+	}
+	sort.Slice(report.Resolution.ConflictEntries, func(left, right int) bool {
+		return report.Resolution.ConflictEntries[left].Code < report.Resolution.ConflictEntries[right].Code
+	})
+	if len(report.Resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		report.Resolution.ConflictEntries = report.Resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+	return report, nil
+}
+
+func inspectOrganisationsBackfillVideowallIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	return inspectOrganisationsBackfillOrderedIndexes(ctx, collection, []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("canonical-project-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("legacy-project-list", bson.D{{Key: "master_user_id", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("short-link-capability", bson.D{{Key: "short_link", Value: int32(1)}}),
+	})
+}

--- a/actions/organisations-backfill-videowalls_test.go
+++ b/actions/organisations-backfill-videowalls_test.go
@@ -1,0 +1,35 @@
+package actions
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillVideowallUsesStableTenant(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "master_user_id", Value: organisationId.Hex()},
+		{Key: "user_id", Value: primitive.NewObjectID().Hex()},
+	})
+	outcome := resolveOrganisationsBackfillProjectResource(document, "videowall", "master_user_id", map[primitive.ObjectID]bool{organisationId: true}, nil)
+	if !outcome.resolved || outcome.resolvedID != organisationId || !outcome.projectResolved || outcome.resolvedProjectID != organisationId || len(outcome.conflicts) != 0 {
+		t.Fatalf("videowall outcome = %+v", outcome)
+	}
+}
+
+func TestResolveOrganisationsBackfillVideowallCanonicalWinsOverCreator(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "_id", Value: primitive.NewObjectID()},
+		{Key: "organisationId", Value: organisationId.Hex()},
+		{Key: "master_user_id", Value: "invalid"},
+		{Key: "user_id", Value: primitive.NewObjectID().Hex()},
+	})
+	outcome := resolveOrganisationsBackfillProjectResource(document, "videowall", "master_user_id", map[primitive.ObjectID]bool{organisationId: true}, nil)
+	if !outcome.canonicalValid || outcome.resolved || outcome.invalidLegacy || !outcome.projectResolved || len(outcome.conflicts) != 0 {
+		t.Fatalf("videowall outcome = %+v", outcome)
+	}
+}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -27,6 +27,9 @@ const (
 	organisationsBackfillResolverSite         = "site-tenant"
 	organisationsBackfillResolverGroup        = "group-tenant"
 	organisationsBackfillResolverIO           = "io-actor"
+	organisationsBackfillResolverLabel        = "label-owner"
+	organisationsBackfillResolverCounting     = "counting-source"
+	organisationsBackfillResolverVideowall    = "videowall-tenant"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -245,6 +248,15 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverIO {
 		return inspectOrganisationsBackfillIO(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverLabel {
+		return inspectOrganisationsBackfillProjectResource(ctx, database, adapter, config, report, "label", inspectOrganisationsBackfillLabelIndexes)
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverCounting {
+		return inspectOrganisationsBackfillProjectResource(ctx, database, adapter, config, report, "counting", inspectOrganisationsBackfillCountingIndexes)
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverVideowall {
+		return inspectOrganisationsBackfillVideowalls(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -380,6 +392,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			LegacyCandidates: []string{"user_id"},
 			PreservedFields:  []string{"user_id"},
 		},
+		"counting": {
+			Collection:            "counting",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"user_id"},
+			PreservedFields:       []string{"username", "device_id"},
+			ResolverKind:          organisationsBackfillResolverCounting,
+			MinimumWriterVersions: []string{"hub-pipeline-analysis:unreleased"},
+			MinimumReaderVersions: []string{"hub-api:unreleased"},
+		},
 		"groups": {
 			Collection:            "groups",
 			OwnershipScope:        "project-scoped",
@@ -406,6 +431,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:unreleased-PR524"},
 			MinimumReaderVersions: []string{"hub-api:unreleased-PR524", "hub-pipeline-notification:unreleased-PR120"},
 		},
+		"labels": {
+			Collection:            "labels",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"owner_id"},
+			PreservedFields:       []string{"user_id"},
+			ResolverKind:          organisationsBackfillResolverLabel,
+			MinimumWriterVersions: []string{"hub-api:unreleased"},
+			MinimumReaderVersions: []string{"hub-api:unreleased"},
+		},
 		"sites": {
 			Collection:            "sites",
 			OwnershipScope:        "project-scoped",
@@ -430,6 +468,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:v1.9.58"},
 			MinimumReaderVersions: []string{"hub-api:v1.9.58", "hub-pipeline-monitor:v1.3.14", "hub-cleanup:v1.4.19", "cli:v1.2.23", "hub-monitor-device:unreleased-PR22"},
 		},
+		"videowalls": {
+			Collection:            "videowalls",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"master_user_id"},
+			PreservedFields:       []string{"user_id", "assigned_users"},
+			ResolverKind:          organisationsBackfillResolverVideowall,
+			MinimumWriterVersions: []string{"hub-api:unreleased"},
+			MinimumReaderVersions: []string{"hub-api:unreleased"},
+		},
 	}
 }
 
@@ -437,14 +488,11 @@ func organisationsBackfillBlockedAdapters() map[string]string {
 	return map[string]string{
 		"analysis":      "shared model and canonical BSON type are not declared",
 		"channels":      "persistence and ownership contracts are unverified",
-		"counting":      "persisted shapes require a production audit",
 		"heatmap":       "persisted shapes require a production audit",
-		"labels":        "shared model does not declare organisationId",
 		"notifications": "shape-specific canonical models and writers are missing",
 		"sequences":     "shared model and canonical BSON type are not declared",
 		"settings":      "shared model does not declare a canonical tenant field",
 		"tasks":         "shared model and canonical BSON type are not declared",
-		"videowalls":    "shared model does not declare organisationId",
 		"workflow_runs": "persisted canonical BSON type is not verified",
 	}
 }

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -101,7 +101,7 @@ func TestValidateOrganisationsBackfillConfig(t *testing.T) {
 		{
 			name: "reports blocked adapter",
 			mutate: func(config OrganisationsBackfillConfig) OrganisationsBackfillConfig {
-				config.Collection = "videowalls"
+				config.Collection = "channels"
 				return config
 			},
 			wantError: "blocked",
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions"}
+	want := []string{"alerts", "counting", "devices", "groups", "io", "labels", "sites", "subscriptions", "videowalls"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}
@@ -178,6 +178,30 @@ func TestIOAdapterDeclaresProjectScopeAndActorFallback(t *testing.T) {
 	}
 	if len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "user_id" || len(adapter.PreservedFields) != 1 || adapter.PreservedFields[0] != "user_id" {
 		t.Fatalf("IO actor contract = %+v", adapter)
+	}
+}
+
+func TestLabelsAdapterDeclaresStableOwnerScope(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["labels"]
+	if adapter.OwnershipScope != "project-scoped" || adapter.ProjectField != "projectId" || adapter.ResolverKind != organisationsBackfillResolverLabel {
+		t.Fatalf("label ownership scope = %+v", adapter)
+	}
+	if len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "owner_id" || len(adapter.PreservedFields) != 1 || adapter.PreservedFields[0] != "user_id" {
+		t.Fatalf("label stable owner/provenance contract = %+v", adapter)
+	}
+}
+
+func TestCountingAdapterDeclaresSourceOwnership(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["counting"]
+	if adapter.ResolverKind != organisationsBackfillResolverCounting || len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "user_id" {
+		t.Fatalf("counting ownership contract = %+v", adapter)
+	}
+}
+
+func TestVideowallAdapterDeclaresTenantOwnership(t *testing.T) {
+	adapter := organisationsBackfillAdapters()["videowalls"]
+	if adapter.ResolverKind != organisationsBackfillResolverVideowall || len(adapter.LegacyCandidates) != 1 || adapter.LegacyCandidates[0] != "master_user_id" {
+		t.Fatalf("videowall ownership contract = %+v", adapter)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR expands the organisations backfill audit to cover additional project-scoped resources and standardises how tenant ownership is resolved across collections.

The change enables auditing for `counting`, `labels`, and `videowalls`, including collection-specific ownership resolution, index inspection, and conflict detection. These resources were previously blocked from the backfill process because their persisted ownership models were either inconsistent or not formally validated. Bringing them into the audit pipeline improves migration coverage and reduces the risk of orphaned or ambiguously owned data during organisation backfills.

The PR also generalises project resource resolution so each collection can define its own legacy ownership field (`user_id`, `owner_id`, `master_user_id`, etc.). This removes hardcoded assumptions from the resolver, improves compatibility with legacy schemas, and produces more accurate conflict reporting and scoped inventory metrics.

For labels specifically, default label generation now writes canonical `organisationId` and `projectId` fields alongside legacy ownership data. Duplicate detection was updated to recognise both canonical and legacy shapes, allowing the system to safely coexist with partially migrated datasets while preventing duplicate defaults from being inserted.

Additional index inspection logic and validation tests were added to ensure the new ownership contracts, fallback rules, and canonical precedence behaviour remain stable over time.