### PR TITLE
feat(organisations): audit inactive heatmap

### DIFF
--- a/actions/organisations-backfill-heatmap.go
+++ b/actions/organisations-backfill-heatmap.go
@@ -1,0 +1,240 @@
+package actions
+
+import (
+	"context"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type organisationsBackfillHeatmapOutcome struct {
+	organisationsBackfillProjectResourceOutcome
+	orphanUser bool
+}
+
+func inspectOrganisationsBackfillHeatmap(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	var scopeID primitive.ObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+	}
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+
+	legacyUserIDs := make(map[primitive.ObjectID]struct{})
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if organisationID, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[organisationID] = struct{}{}
+		} else if state == organisationsBootstrapFieldEmpty {
+			if userID, userState := organisationsBackfillStringObjectIDField(document, "user_id"); userState == organisationsBootstrapFieldValue {
+				legacyUserIDs[userID] = struct{}{}
+			}
+		}
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
+
+	users, err := findOrganisationsBackfillUsers(ctx, database.Collection("users"), legacyUserIDs)
+	if err != nil {
+		return report, err
+	}
+	for _, user := range users {
+		resolved := resolveOrganisationsBackfillUser(user)
+		if resolved.code == "" {
+			organisationIDs[resolved.organisationID] = struct{}{}
+		}
+	}
+	if !scopeID.IsZero() {
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := organisationsBackfillResolution{
+		ObservedFieldTypes: make(map[string]map[string]int64),
+		ObservedShapes:     make(map[string]int64),
+	}
+	if config.OrganisationID != "" {
+		resetOrganisationsBackfillScopedInventory(&report)
+	}
+	if !scopeID.IsZero() && !organisations[scopeID] {
+		resolution.OrphanOrganisations++
+		resolution.Conflicts++
+		resolution.ConflictEntries = append(resolution.ConflictEntries, organisationsBackfillConflict{
+			Code:                  "scope-organisation-not-found",
+			CanonicalOrganisation: scopeID.Hex(),
+			ResolvedOrganisations: []string{scopeID.Hex()},
+			Message:               "requested organisation does not exist",
+		})
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillHeatmap(document, users, organisations, projects)
+		if !organisationsBackfillHeatmapInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome.organisationsBackfillProjectResourceOutcome)
+		if outcome.orphanUser {
+			resolution.OrphanUsers++
+		}
+		if config.OrganisationID != "" {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome.organisationsBackfillProjectResourceOutcome)
+		}
+	}
+	sort.Slice(resolution.ConflictEntries, func(left, right int) bool {
+		first := resolution.ConflictEntries[left]
+		second := resolution.ConflictEntries[right]
+		if first.DocumentID != second.DocumentID {
+			return first.DocumentID < second.DocumentID
+		}
+		return first.Code < second.Code
+	})
+	if len(resolution.ConflictEntries) > organisationsBackfillConflictLimit {
+		resolution.ConflictEntries = resolution.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillHeatmapIndexes(ctx, database.Collection(adapter.Collection))
+	return report, err
+}
+
+func resolveOrganisationsBackfillHeatmap(
+	document bson.Raw,
+	users map[primitive.ObjectID]bson.Raw,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillHeatmapOutcome) {
+	resource := &outcome.organisationsBackfillProjectResourceOutcome
+	resource.documentID = organisationsBackfillDocumentID(document)
+	defer resource.enrichConflicts()
+	defer resource.resolveProject(projects)
+
+	legacyID, legacyState := organisationsBackfillStringObjectIDField(document, "user_id")
+	if legacyState != organisationsBootstrapFieldEmpty {
+		resource.legacyPresent = true
+	}
+	if legacyState == organisationsBootstrapFieldValue {
+		resource.legacyUserID = legacyID
+	}
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		resource.projectPresent = true
+		resource.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		resource.projectMissing = true
+	default:
+		resource.projectWrong = true
+		resource.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		resource.canonicalID = canonicalID
+		resource.canonicalValid = true
+		if !organisations[canonicalID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+		return outcome
+	case organisationsBootstrapFieldWrong:
+		resource.canonicalWrong = true
+		resource.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		resource.canonicalMissing = true
+	}
+
+	switch legacyState {
+	case organisationsBootstrapFieldEmpty:
+		resource.zeroCandidate = true
+		resource.addConflict("zero-candidate", "heatmap has neither canonical organisationId nor legacy user_id")
+	case organisationsBootstrapFieldWrong:
+		resource.invalidLegacy = true
+		resource.addConflict("invalid-legacy-user-id", "user_id must contain an ObjectID hex string")
+	case organisationsBootstrapFieldValue:
+		user, exists := users[legacyID]
+		if !exists {
+			outcome.orphanUser = true
+			resource.addConflict("orphan-user", "legacy user_id does not resolve to a user")
+			return outcome
+		}
+		userResolution := resolveOrganisationsBackfillUser(user)
+		if userResolution.code != "" {
+			resource.addConflict(userResolution.code, userResolution.message)
+			return outcome
+		}
+		resource.resolvedID = userResolution.organisationID
+		if !organisations[resource.resolvedID] {
+			resource.orphanOrganisation = true
+			resource.addConflict("orphan-organisation", "organisation resolved from legacy user_id does not exist")
+			return outcome
+		}
+		resource.resolved = true
+		resource.proposedWrite = true
+	}
+	return outcome
+}
+
+func organisationsBackfillHeatmapInScope(outcome organisationsBackfillHeatmapOutcome, scopeID primitive.ObjectID) bool {
+	if scopeID.IsZero() {
+		return true
+	}
+	if outcome.canonicalValid {
+		return outcome.canonicalID == scopeID
+	}
+	return outcome.resolvedID == scopeID
+}
+
+func inspectOrganisationsBackfillHeatmapIndexes(ctx context.Context, collection *mongo.Collection) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("current-legacy-retention", bson.D{{Key: "user_id", Value: int32(1)}, {Key: "timestamp", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("cleanup-canonical-retention", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "timestamp", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("cleanup-global-retention", bson.D{{Key: "timestamp", Value: int32(1)}}),
+	}
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	return contracts, nil
+}

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -27,6 +27,7 @@ const (
 	organisationsBackfillResolverSite         = "site-tenant"
 	organisationsBackfillResolverGroup        = "group-tenant"
 	organisationsBackfillResolverIO           = "io-actor"
+	organisationsBackfillResolverHeatmap      = "heatmap-tenant"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -65,6 +66,8 @@ type organisationsBackfillAdapter struct {
 	LegacyCandidates      []string
 	PreservedFields       []string
 	ResolverKind          string
+	LifecycleStatus       string
+	OperationalUse        string
 	MinimumWriterVersions []string
 	MinimumReaderVersions []string
 }
@@ -95,6 +98,8 @@ type organisationsBackfillCollection struct {
 	LegacyCandidates      []string                             `json:"legacyCandidates"`
 	PreservedFields       []string                             `json:"preservedFields"`
 	ResolverKind          string                               `json:"resolverKind,omitempty"`
+	LifecycleStatus       string                               `json:"lifecycleStatus,omitempty"`
+	OperationalUse        string                               `json:"operationalUse,omitempty"`
 	MinimumWriterVersions []string                             `json:"minimumWriterVersions,omitempty"`
 	MinimumReaderVersions []string                             `json:"minimumReaderVersions,omitempty"`
 	Total                 int64                                `json:"total"`
@@ -245,6 +250,9 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverIO {
 		return inspectOrganisationsBackfillIO(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverHeatmap {
+		return inspectOrganisationsBackfillHeatmap(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -393,6 +401,19 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:v1.9.56"},
 			MinimumReaderVersions: []string{"hub-api:v1.9.56", "hub-pipeline-notification:v1.3.19"},
 		},
+		"heatmap": {
+			Collection:       "heatmap",
+			OwnershipScope:   "project-scoped",
+			TargetField:      "organisationId",
+			TargetBSONType:   "string",
+			ProjectField:     "projectId",
+			ProjectBSONType:  "objectId",
+			LegacyCandidates: []string{"user_id"},
+			PreservedFields:  []string{"user_id"},
+			ResolverKind:     organisationsBackfillResolverHeatmap,
+			LifecycleStatus:  "inactive",
+			OperationalUse:   "retention-only",
+		},
 		"io": {
 			Collection:            "io",
 			OwnershipScope:        "project-scoped",
@@ -438,7 +459,6 @@ func organisationsBackfillBlockedAdapters() map[string]string {
 		"analysis":      "shared model and canonical BSON type are not declared",
 		"channels":      "persistence and ownership contracts are unverified",
 		"counting":      "persisted shapes require a production audit",
-		"heatmap":       "persisted shapes require a production audit",
 		"labels":        "shared model does not declare organisationId",
 		"notifications": "shape-specific canonical models and writers are missing",
 		"sequences":     "shared model and canonical BSON type are not declared",
@@ -470,6 +490,8 @@ func inspectOrganisationsBackfillCollection(
 		LegacyCandidates:      append([]string(nil), adapter.LegacyCandidates...),
 		PreservedFields:       append([]string(nil), adapter.PreservedFields...),
 		ResolverKind:          adapter.ResolverKind,
+		LifecycleStatus:       adapter.LifecycleStatus,
+		OperationalUse:        adapter.OperationalUse,
 		MinimumWriterVersions: append([]string(nil), adapter.MinimumWriterVersions...),
 		MinimumReaderVersions: append([]string(nil), adapter.MinimumReaderVersions...),
 		LegacyCandidateCount:  make(map[string]int64, len(adapter.LegacyCandidates)),

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,7 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "devices", "groups", "io", "sites", "subscriptions"}
+	want := []string{"alerts", "devices", "groups", "heatmap", "io", "sites", "subscriptions"}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}


### PR DESCRIPTION
## Description

Adds audit and inspection support for the inactive `heatmap` collection to the organisations backfill tooling.

This change removes `heatmap` from the blocked adapters list and introduces a dedicated resolver that validates ownership, organisation resolution, legacy user references, project mappings, and index coverage. It also classifies the collection as `inactive` and `retention-only`, making its operational role explicit in audit output.

By bringing `heatmap` into the backfill inspection flow, we gain visibility into orphaned records, invalid organisation references, unresolved legacy users, and missing retention indexes before any migration or cleanup work happens. This improves confidence in organisation backfills, reduces the risk of silent data integrity issues, and ensures even dormant collections remain observable and governed by the same tenancy rules as active datasets.