### PR TITLE
feat(organisations): audit marker resources

### DIFF
--- a/actions/check-indexes.go
+++ b/actions/check-indexes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -181,7 +182,7 @@ func CheckIndexes(
 			continue
 		}
 
-		existing, err := listIndexKeys(ctx, db.Collection(collName))
+		existing, err := listIndexes(ctx, db.Collection(collName))
 		if err != nil {
 			fmt.Printf("[error] list indexes for %s: %v\n", collName, err)
 			continue
@@ -190,8 +191,14 @@ func CheckIndexes(
 		// Compare
 		var missing []IndexSpec
 		for _, s := range specs {
-			normalized := normalizeKey(s.Key)
-			if _, found := existing[normalized]; !found {
+			found := false
+			for _, candidate := range existing {
+				if indexSpecMatches(s, candidate) {
+					found = true
+					break
+				}
+			}
+			if !found {
 				missing = append(missing, s)
 				allMissing = append(allMissing, missEntry{coll: collName, spec: s})
 			}
@@ -303,25 +310,35 @@ func parseCSV(s string) []string {
 	return out
 }
 
-// listIndexKeys returns a set keyed by ordered key spec like "name:1.user_id:1".
-func listIndexKeys(ctx context.Context, coll *mongo.Collection) (map[string]struct{}, error) {
+// listIndexes returns the full contracts needed to distinguish an ordinary
+// index from a unique or partial index with the same ordered keys.
+func listIndexes(ctx context.Context, coll *mongo.Collection) ([]IndexSpec, error) {
 	cur, err := coll.Indexes().List(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cur.Close(ctx)
 
-	out := make(map[string]struct{})
+	var out []IndexSpec
 	for cur.Next(ctx) {
 		var doc struct {
-			Key bson.D `bson:"key"`
+			Name                    string `bson:"name"`
+			Key                     bson.D `bson:"key"`
+			Unique                  bool   `bson:"unique"`
+			PartialFilterExpression bson.M `bson:"partialFilterExpression"`
 		}
 		if err := cur.Decode(&doc); err != nil || len(doc.Key) == 0 {
 			continue
 		}
-		out[normalizeKey(doc.Key)] = struct{}{}
+		out = append(out, IndexSpec{Name: doc.Name, Key: doc.Key, Unique: doc.Unique, PartialFilterExpression: doc.PartialFilterExpression})
 	}
 	return out, cur.Err()
+}
+
+func indexSpecMatches(required, actual IndexSpec) bool {
+	return normalizeKey(required.Key) == normalizeKey(actual.Key) &&
+		required.Unique == actual.Unique &&
+		reflect.DeepEqual(required.PartialFilterExpression, actual.PartialFilterExpression)
 }
 
 // normalizeKey builds an order-preserving string like "field1:1.field2:-1".

--- a/actions/check-indexes_test.go
+++ b/actions/check-indexes_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -78,6 +79,21 @@ func TestExtractUnique(t *testing.T) {
 	}
 	if extractUnique("{ v: 2, key: { slug: 1 }, name: 'slug_1' }") != false {
 		t.Fatal("absent unique reported as true")
+	}
+}
+
+func TestIndexSpecMatchesOptions(t *testing.T) {
+	keys := bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}}
+	partial := bson.M{"projectId": bson.M{"$type": "objectId"}}
+	required := IndexSpec{Key: keys, Unique: true, PartialFilterExpression: partial}
+	if !indexSpecMatches(required, IndexSpec{Key: keys, Unique: true, PartialFilterExpression: partial}) {
+		t.Fatal("exact index contract did not match")
+	}
+	if indexSpecMatches(required, IndexSpec{Key: keys, PartialFilterExpression: partial}) {
+		t.Fatal("non-unique index satisfied unique contract")
+	}
+	if indexSpecMatches(required, IndexSpec{Key: keys, Unique: true}) {
+		t.Fatal("full index satisfied partial contract")
 	}
 }
 
@@ -334,6 +350,42 @@ func TestDeviceScopeIndexFileDeclaresCanonicalAndLegacyContracts(t *testing.T) {
 	}}
 	if got := canonical["users"]; !reflect.DeepEqual(got, wantUsers) {
 		t.Fatalf("cloud-key user indexes = %#v, want %#v", got, wantUsers)
+	}
+}
+
+func TestMarkerOwnershipIndexFileDeclaresOrderedContracts(t *testing.T) {
+	path := filepath.Join("..", "indexes", "migration-hub-marker-ownership-27-08-2026.txt")
+	canonical, err := loadCanonicalIndexSpecsFromFile(path)
+	if err != nil {
+		t.Fatalf("loadCanonicalIndexSpecsFromFile: %v", err)
+	}
+
+	wantCollections := []string{
+		"marker_category_options", "marker_event_option_ranges", "marker_event_options",
+		"marker_option_ranges", "marker_options", "marker_tag_option_ranges",
+		"marker_tag_options", "markers",
+	}
+	gotCollections := make([]string, 0, len(canonical))
+	for collection := range canonical {
+		gotCollections = append(gotCollections, collection)
+	}
+	sort.Strings(gotCollections)
+	if !reflect.DeepEqual(gotCollections, wantCollections) {
+		t.Fatalf("marker index collections = %#v, want %#v", gotCollections, wantCollections)
+	}
+
+	markerSpecs := canonical["markers"]
+	if len(markerSpecs) != 4 || normalizeKey(markerSpecs[0].Key) != "organisationId:1.projectId:1.startTimestamp:-1._id:-1" || normalizeKey(markerSpecs[3].Key) != "organisationId:1.projectId:1.deviceId:1.startTimestamp:1" {
+		t.Fatalf("marker index specs = %#v", markerSpecs)
+	}
+	for _, collection := range []string{"marker_options", "marker_tag_options", "marker_event_options", "marker_category_options"} {
+		specs := canonical[collection]
+		if len(specs) != 2 || !specs[0].Unique || normalizeKey(specs[0].Key) != "organisationId:1.projectId:1.value:1" || normalizeKey(specs[1].Key) != "organisationId:1.projectId:1.updatedAt:-1._id:-1" {
+			t.Fatalf("%s index specs = %#v", collection, specs)
+		}
+	}
+	if specs := canonical["marker_option_ranges"]; len(specs) != 4 || normalizeKey(specs[2].Key) != "organisationId:1.projectId:1.value:1.deviceKey:1.start:1.end:1" {
+		t.Fatalf("marker range index specs = %#v", specs)
 	}
 }
 

--- a/actions/organisations-backfill-markers.go
+++ b/actions/organisations-backfill-markers.go
@@ -1,0 +1,908 @@
+package actions
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type organisationsBackfillMarkerParent struct {
+	organisationID primitive.ObjectID
+	projectID      primitive.ObjectID
+	valid          bool
+}
+
+type organisationsBackfillMarkerParents struct {
+	byKey map[string][]organisationsBackfillMarkerParent
+}
+
+type organisationsBackfillMarkerLinks struct {
+	keys       []string
+	legacyKeys []string
+	usesKeys   bool
+	malformed  bool
+}
+
+type organisationsBackfillMarkerResolvedDocument struct {
+	document bson.Raw
+	outcome  organisationsBackfillProjectResourceOutcome
+}
+
+func inspectOrganisationsBackfillMarkers(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	mediaKeys := make(map[string]struct{})
+	deviceKeys := make(map[string]struct{})
+	for _, document := range documents {
+		links := organisationsBackfillMarkerLinksFromDocument(document)
+		organisationID, _ := organisationsBackfillStringObjectIDField(document, "organisationId")
+		for _, mediaKey := range organisationsBackfillMarkerLookupKeys(links.keys, organisationID) {
+			mediaKeys[mediaKey] = struct{}{}
+		}
+		for _, mediaKey := range organisationsBackfillMarkerLookupKeys(links.legacyKeys, organisationID) {
+			mediaKeys[mediaKey] = struct{}{}
+		}
+		if deviceKey := organisationsBackfillMarkerDeviceKey(document); deviceKey != "" {
+			deviceKeys[deviceKey] = struct{}{}
+		}
+	}
+	parents, err := findOrganisationsBackfillMarkerParents(ctx, database.Collection("media"), mediaKeys)
+	if err != nil {
+		return report, err
+	}
+	devices, err := findOrganisationsBackfillMarkerDevices(ctx, database.Collection("devices"), deviceKeys)
+	if err != nil {
+		return report, err
+	}
+
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if organisationID, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[organisationID] = struct{}{}
+		}
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
+	for _, matches := range parents.byKey {
+		for _, parent := range matches {
+			if parent.valid {
+				organisationIDs[parent.organisationID] = struct{}{}
+				projectIDs[parent.projectID] = struct{}{}
+			}
+		}
+	}
+	for _, matches := range devices.byKey {
+		for _, parent := range matches {
+			if parent.valid {
+				organisationIDs[parent.organisationID] = struct{}{}
+				projectIDs[parent.projectID] = struct{}{}
+			}
+		}
+	}
+	scopeID := primitive.NilObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := newOrganisationsBackfillResolution()
+	if !scopeID.IsZero() {
+		resetOrganisationsBackfillScopedInventory(&report)
+		addOrganisationsBackfillMissingScope(&resolution, scopeID, organisations)
+	}
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillMarker(document, parents, devices, organisations, projects)
+		if !organisationsBackfillSiteInScope(outcome, scopeID) {
+			continue
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome)
+		if !scopeID.IsZero() {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome, "")
+			if organisationsBackfillMarkerFieldPresent(document, "mediaKeys") {
+				report.LegacyCandidateCount["mediaKeys"]++
+			}
+			if organisationsBackfillMarkerFieldPresent(document, "mediaIds") {
+				report.LegacyCandidateCount["mediaIds"]++
+			}
+		}
+	}
+	finalizeOrganisationsBackfillResolution(&resolution)
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillOrderedIndexes(ctx, database.Collection(adapter.Collection), organisationsBackfillMarkerIndexContracts())
+	return report, err
+}
+
+func findOrganisationsBackfillMarkerParents(
+	ctx context.Context,
+	collection *mongo.Collection,
+	keys map[string]struct{},
+) (organisationsBackfillMarkerParents, error) {
+	parents := organisationsBackfillMarkerParents{
+		byKey: make(map[string][]organisationsBackfillMarkerParent, len(keys)),
+	}
+	if len(keys) == 0 {
+		return parents, nil
+	}
+	cursor, err := collection.Find(ctx, bson.M{"videoFile": bson.M{"$in": sortedOrganisationsBackfillStrings(keys)}}, options.Find().SetProjection(bson.M{
+		"_id": 1, "videoFile": 1, "organisationId": 1, "projectId": 1,
+	}))
+	if err != nil {
+		return parents, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return parents, err
+		}
+		organisationID, organisationState := organisationsBackfillStringObjectIDField(document, "organisationId")
+		parent := organisationsBackfillMarkerParent{}
+		projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+		if organisationState == organisationsBootstrapFieldValue {
+			if projectState == organisationsBootstrapFieldEmpty {
+				projectID = organisationID
+			}
+			if projectState == organisationsBootstrapFieldValue || projectID == organisationID {
+				parent = organisationsBackfillMarkerParent{organisationID: organisationID, projectID: projectID, valid: true}
+			}
+		}
+		videoFile := document.Lookup("videoFile")
+		if videoFile.Type == bsontype.String {
+			key := videoFile.StringValue()
+			if _, requested := keys[key]; requested {
+				parents.byKey[key] = append(parents.byKey[key], parent)
+			}
+		}
+	}
+	return parents, cursor.Err()
+}
+
+func findOrganisationsBackfillMarkerDevices(
+	ctx context.Context,
+	collection *mongo.Collection,
+	keys map[string]struct{},
+) (organisationsBackfillMarkerParents, error) {
+	devices := organisationsBackfillMarkerParents{byKey: make(map[string][]organisationsBackfillMarkerParent, len(keys))}
+	if len(keys) == 0 {
+		return devices, nil
+	}
+	cursor, err := collection.Find(ctx, bson.M{"key": bson.M{"$in": sortedOrganisationsBackfillStrings(keys)}}, options.Find().SetProjection(bson.M{
+		"key": 1, "organisationId": 1, "projectId": 1, "user_id": 1,
+	}))
+	if err != nil {
+		return devices, err
+	}
+	defer cursor.Close(ctx)
+	for cursor.Next(ctx) {
+		var document bson.Raw
+		if err := cursor.Decode(&document); err != nil {
+			return devices, err
+		}
+		key := document.Lookup("key")
+		if key.Type != bsontype.String {
+			continue
+		}
+		organisationID, organisationState := organisationsBackfillStringObjectIDField(document, "organisationId")
+		parent := organisationsBackfillMarkerParent{}
+		projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+		if organisationState == organisationsBootstrapFieldValue {
+			if projectState == organisationsBootstrapFieldEmpty {
+				projectID = organisationID
+			}
+			if projectState == organisationsBootstrapFieldValue || projectID == organisationID {
+				parent = organisationsBackfillMarkerParent{organisationID: organisationID, projectID: projectID, valid: true}
+			}
+		}
+		devices.byKey[key.StringValue()] = append(devices.byKey[key.StringValue()], parent)
+	}
+	return devices, cursor.Err()
+}
+
+func resolveOrganisationsBackfillMarker(
+	document bson.Raw,
+	parents organisationsBackfillMarkerParents,
+	devices organisationsBackfillMarkerParents,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillProjectResourceOutcome) {
+	outcome.documentID = organisationsBackfillDocumentID(document)
+	defer outcome.enrichConflicts()
+
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		outcome.projectPresent = true
+		outcome.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		outcome.projectMissing = true
+	default:
+		outcome.projectWrong = true
+		outcome.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+
+	canonicalID, canonicalState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch canonicalState {
+	case organisationsBootstrapFieldValue:
+		outcome.canonicalID = canonicalID
+		outcome.canonicalValid = true
+		if !organisations[canonicalID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+		}
+	case organisationsBootstrapFieldWrong:
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		outcome.canonicalMissing = true
+	}
+
+	links := organisationsBackfillMarkerLinksFromDocument(document)
+	links.keys = organisationsBackfillMarkerLookupKeys(links.keys, outcome.canonicalID)
+	links.legacyKeys = organisationsBackfillMarkerLookupKeys(links.legacyKeys, outcome.canonicalID)
+	if outcome.canonicalValid {
+		outcome.resolveMarkerProject(outcome.canonicalID, projects)
+		if len(links.keys) == 0 && len(links.legacyKeys) == 0 {
+			return outcome
+		}
+		parent, code := organisationsBackfillResolveMarkerParent(links, parents, projects, outcome.canonicalID, outcome.resolvedProjectID, outcome.projectPresent)
+		if code != "" {
+			parent, code = organisationsBackfillResolveMarkerParent(links, parents, projects, primitive.NilObjectID, primitive.NilObjectID, false)
+		}
+		if code == "" {
+			return outcome.resolveMarkerParent(parent, organisations, projects, "parent")
+		}
+		return outcome
+	}
+	if len(links.keys) == 0 && len(links.legacyKeys) == 0 {
+		device, code := organisationsBackfillResolveMarkerDevice(document, devices, projects)
+		if code != "" {
+			if outcome.canonicalMissing {
+				outcome.zeroCandidate = code == "zero-device"
+				outcome.multipleCandidates = code == "ambiguous-device"
+				outcome.addConflict(code, "marker has no unique stored device ownership source")
+			} else {
+				outcome.resolveProject(projects)
+			}
+			return outcome
+		}
+		return outcome.resolveMarkerParent(device, organisations, projects, "device")
+	}
+	parent, code := organisationsBackfillResolveMarkerParent(links, parents, projects, outcome.canonicalID, outcome.resolvedProjectID, outcome.projectPresent)
+	if code != "" {
+		if code == "ambiguous-parent" {
+			outcome.multipleCandidates = true
+		}
+		outcome.addConflict(code, "linked media does not provide one authoritative organisation and project")
+		return outcome
+	}
+
+	return outcome.resolveMarkerParent(parent, organisations, projects, "parent")
+}
+
+func (outcome organisationsBackfillProjectResourceOutcome) resolveMarkerParent(
+	parent organisationsBackfillMarkerParent,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+	source string,
+) organisationsBackfillProjectResourceOutcome {
+	if outcome.canonicalValid {
+		outcome.resolvedID = parent.organisationID
+		if outcome.canonicalID != parent.organisationID {
+			outcome.addConflict("canonical-"+source+"-organisation-mismatch", "canonical organisationId differs from stored "+source+" ownership")
+		}
+		outcome.resolveMarkerProject(outcome.canonicalID, projects)
+		if !outcome.projectWrong && outcome.resolvedProjectID != parent.projectID {
+			outcome.addConflict("canonical-"+source+"-project-mismatch", "marker projectId differs from stored "+source+" ownership")
+		}
+		return outcome
+	}
+	if !organisations[parent.organisationID] {
+		outcome.orphanOrganisation = true
+		outcome.addConflict("orphan-organisation", "linked media organisation does not exist")
+		return outcome
+	}
+	outcome.resolvedID = parent.organisationID
+	outcome.resolved = true
+	outcome.proposedWrite = true
+	if outcome.projectPresent && outcome.resolvedProjectID != parent.projectID {
+		outcome.addConflict("parent-project-mismatch", "marker projectId differs from linked media ownership")
+		return outcome
+	}
+	if outcome.projectMissing {
+		outcome.resolvedProjectID = parent.projectID
+		outcome.projectResolved = true
+		outcome.proposedProjectWrite = true
+		return outcome
+	}
+	outcome.resolveMarkerProject(parent.organisationID, projects)
+	return outcome
+}
+
+func organisationsBackfillResolveMarkerParent(
+	links organisationsBackfillMarkerLinks,
+	parents organisationsBackfillMarkerParents,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+	expectedOrganisation primitive.ObjectID,
+	expectedProject primitive.ObjectID,
+	hasExpectedProject bool,
+) (organisationsBackfillMarkerParent, string) {
+	if links.malformed {
+		return organisationsBackfillMarkerParent{}, "orphan-parent"
+	}
+	candidates := make([]organisationsBackfillMarkerParent, 0, len(links.keys)+len(links.legacyKeys))
+	if links.usesKeys {
+		for _, mediaKey := range links.keys {
+			matches := organisationsBackfillMarkerParentsInScope(parents.byKey[mediaKey], expectedOrganisation, expectedProject, hasExpectedProject)
+			if len(matches) == 0 {
+				return organisationsBackfillMarkerParent{}, "orphan-parent"
+			}
+			if len(matches) != 1 {
+				return organisationsBackfillMarkerParent{}, "ambiguous-parent"
+			}
+			candidates = append(candidates, matches[0])
+		}
+	} else {
+		for _, mediaKey := range links.legacyKeys {
+			matches := organisationsBackfillMarkerParentsInScope(parents.byKey[mediaKey], expectedOrganisation, expectedProject, hasExpectedProject)
+			if len(matches) == 0 {
+				return organisationsBackfillMarkerParent{}, "orphan-parent"
+			}
+			if len(matches) != 1 {
+				return organisationsBackfillMarkerParent{}, "ambiguous-parent"
+			}
+			candidates = append(candidates, matches[0])
+		}
+	}
+	var resolved organisationsBackfillMarkerParent
+	for _, parent := range candidates {
+		if !parent.valid {
+			return organisationsBackfillMarkerParent{}, "unresolved-parent-ownership"
+		}
+		if parent.projectID != parent.organisationID {
+			projectOrganisationID, exists := projects[parent.projectID]
+			if !exists || projectOrganisationID != parent.organisationID {
+				return organisationsBackfillMarkerParent{}, "orphan-parent"
+			}
+		}
+		if !resolved.valid {
+			resolved = parent
+			continue
+		}
+		if resolved.organisationID != parent.organisationID || resolved.projectID != parent.projectID {
+			return organisationsBackfillMarkerParent{}, "ambiguous-parent"
+		}
+	}
+	return resolved, ""
+}
+
+func organisationsBackfillMarkerParentsInScope(
+	parents []organisationsBackfillMarkerParent,
+	organisationID primitive.ObjectID,
+	projectID primitive.ObjectID,
+	hasProject bool,
+) []organisationsBackfillMarkerParent {
+	if organisationID.IsZero() {
+		return parents
+	}
+	filtered := make([]organisationsBackfillMarkerParent, 0, len(parents))
+	for _, parent := range parents {
+		if parent.organisationID != organisationID || (hasProject && parent.projectID != projectID) {
+			continue
+		}
+		filtered = append(filtered, parent)
+	}
+	return filtered
+}
+
+func organisationsBackfillResolveMarkerDevice(
+	document bson.Raw,
+	devices organisationsBackfillMarkerParents,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (organisationsBackfillMarkerParent, string) {
+	deviceKey := organisationsBackfillMarkerDeviceKey(document)
+	if deviceKey == "" {
+		return organisationsBackfillMarkerParent{}, "zero-device"
+	}
+	matches := devices.byKey[deviceKey]
+	if len(matches) == 0 {
+		return organisationsBackfillMarkerParent{}, "orphan-device"
+	}
+	if len(matches) != 1 {
+		return organisationsBackfillMarkerParent{}, "ambiguous-device"
+	}
+	device := matches[0]
+	if !device.valid {
+		return organisationsBackfillMarkerParent{}, "unresolved-device-ownership"
+	}
+	if device.projectID != device.organisationID {
+		organisationID, exists := projects[device.projectID]
+		if !exists || organisationID != device.organisationID {
+			return organisationsBackfillMarkerParent{}, "orphan-device-project"
+		}
+	}
+	return device, ""
+}
+
+func organisationsBackfillMarkerDeviceKey(document bson.Raw) string {
+	for _, field := range []string{"deviceId", "deviceKey"} {
+		value := document.Lookup(field)
+		if value.Type == bsontype.String && value.StringValue() != "" {
+			return value.StringValue()
+		}
+	}
+	return ""
+}
+
+func (outcome *organisationsBackfillProjectResourceOutcome) resolveMarkerProject(
+	organisationID primitive.ObjectID,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) {
+	if outcome.projectWrong || organisationID.IsZero() {
+		return
+	}
+	if outcome.projectMissing {
+		outcome.resolvedProjectID = organisationID
+		outcome.projectResolved = true
+		outcome.proposedProjectWrite = true
+		return
+	}
+	if outcome.resolvedProjectID == organisationID {
+		outcome.projectResolved = true
+		return
+	}
+	projectOrganisationID, exists := projects[outcome.resolvedProjectID]
+	if !exists {
+		outcome.addConflict("orphan-project", "projectId does not resolve to a project")
+		return
+	}
+	if projectOrganisationID != organisationID {
+		outcome.addConflict("project-organisation-mismatch", "projectId belongs to a different organisation")
+		return
+	}
+	outcome.projectResolved = true
+}
+
+func organisationsBackfillMarkerLinksFromDocument(document bson.Raw) organisationsBackfillMarkerLinks {
+	if keys, present, malformed := organisationsBackfillMarkerStringArray(document, "mediaKeys"); present {
+		if len(keys) > 0 || malformed {
+			return organisationsBackfillMarkerLinks{keys: keys, usesKeys: true, malformed: malformed}
+		}
+	}
+	values, present, malformed := organisationsBackfillMarkerStringArray(document, "mediaIds")
+	links := organisationsBackfillMarkerLinks{legacyKeys: values, malformed: malformed}
+	if !present {
+		return links
+	}
+	return links
+}
+
+func organisationsBackfillMarkerLookupKeys(keys []string, organisationID primitive.ObjectID) []string {
+	seen := make(map[string]struct{}, len(keys)*2)
+	result := make([]string, 0, len(keys)*2)
+	for _, key := range keys {
+		candidates := []string{key}
+		if !organisationID.IsZero() && !strings.Contains(key, "/") {
+			candidates = append(candidates, organisationID.Hex()+"/"+key)
+		}
+		for _, candidate := range candidates {
+			if _, exists := seen[candidate]; exists {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			result = append(result, candidate)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func organisationsBackfillMarkerStringArray(document bson.Raw, field string) ([]string, bool, bool) {
+	value := document.Lookup(field)
+	if value.Type == bsontype.Type(0) || value.Type == bsontype.Null || value.Type == bsontype.Undefined {
+		return nil, false, false
+	}
+	if value.Type != bsontype.Array {
+		return nil, true, true
+	}
+	values, err := value.Array().Values()
+	if err != nil {
+		return nil, true, true
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	malformed := false
+	for _, item := range values {
+		if item.Type != bsontype.String || item.StringValue() == "" {
+			malformed = true
+			continue
+		}
+		text := item.StringValue()
+		if _, exists := seen[text]; !exists {
+			seen[text] = struct{}{}
+			result = append(result, text)
+		}
+	}
+	sort.Strings(result)
+	return result, true, malformed
+}
+
+func organisationsBackfillMarkerFieldPresent(document bson.Raw, field string) bool {
+	_, present, _ := organisationsBackfillMarkerStringArray(document, field)
+	return present
+}
+
+func sortedOrganisationsBackfillStrings(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func organisationsBackfillMarkerIndexContracts() []organisationsBackfillIndexContract {
+	return []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("project-time-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "startTimestamp", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("project-device-name-time", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "deviceId", Value: int32(1)}, {Key: "name", Value: int32(1)}, {Key: "startTimestamp", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("project-media-keys", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "mediaKeys", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("project-device-time", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "deviceId", Value: int32(1)}, {Key: "startTimestamp", Value: int32(1)}}),
+	}
+}
+
+func inspectOrganisationsBackfillMarkerCanonical(
+	ctx context.Context,
+	database *mongo.Database,
+	adapter organisationsBackfillAdapter,
+	config OrganisationsBackfillConfig,
+	report organisationsBackfillCollection,
+) (organisationsBackfillCollection, error) {
+	documents, err := findOrganisationsBackfillDocuments(ctx, database.Collection(adapter.Collection), config)
+	if err != nil {
+		return report, err
+	}
+	organisationIDs := make(map[primitive.ObjectID]struct{})
+	projectIDs := make(map[primitive.ObjectID]struct{})
+	for _, document := range documents {
+		if organisationID, state := organisationsBackfillStringObjectIDField(document, "organisationId"); state == organisationsBootstrapFieldValue {
+			organisationIDs[organisationID] = struct{}{}
+		}
+		if projectID, state := organisationsBootstrapObjectID(document, "projectId"); state == organisationsBootstrapFieldValue {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
+	scopeID := primitive.NilObjectID
+	if config.OrganisationID != "" {
+		scopeID, _ = primitive.ObjectIDFromHex(config.OrganisationID)
+		organisationIDs[scopeID] = struct{}{}
+	}
+	organisations, err := findOrganisationsBackfillOrganisations(ctx, database.Collection("organisation"), organisationIDs)
+	if err != nil {
+		return report, err
+	}
+	projects, err := findOrganisationsBackfillProjects(ctx, database.Collection("project"), projectIDs)
+	if err != nil {
+		return report, err
+	}
+
+	resolution := newOrganisationsBackfillResolution()
+	if !scopeID.IsZero() {
+		resetOrganisationsBackfillScopedInventory(&report)
+		addOrganisationsBackfillMissingScope(&resolution, scopeID, organisations)
+	}
+	resolvedDocuments := make([]organisationsBackfillMarkerResolvedDocument, 0, len(documents))
+	for _, document := range documents {
+		outcome := resolveOrganisationsBackfillCanonicalOnly(document, adapter.Collection, organisations, projects)
+		if organisationsBackfillMarkerOptionCollection(adapter.Collection) {
+			value := document.Lookup("value")
+			if value.Type != bsontype.String || value.StringValue() == "" {
+				outcome.addConflict("invalid-option-value", "option value must be a non-empty string before a unique index can be created")
+			}
+		}
+		if organisationsBackfillMarkerRangeCollection(adapter.Collection) && !organisationsBackfillValidMarkerRangeIdentity(document) {
+			outcome.addConflict("invalid-range-identity", "range value, deviceId, and start must be valid before a unique index can be created")
+		}
+		if !organisationsBackfillSiteInScope(outcome, scopeID) {
+			continue
+		}
+		if adapter.LifecycleStatus == "inactive" || adapter.OperationalUse == "retention-only" {
+			outcome.proposedProjectWrite = false
+		}
+		observeOrganisationsBackfillDocument(&resolution, document)
+		addOrganisationsBackfillSiteOutcome(&resolution, outcome)
+		if !scopeID.IsZero() {
+			addOrganisationsBackfillSiteScopedInventory(&report, outcome, "")
+		}
+		resolvedDocuments = append(resolvedDocuments, organisationsBackfillMarkerResolvedDocument{document: document, outcome: outcome})
+	}
+	if organisationsBackfillMarkerOptionCollection(adapter.Collection) && config.DocumentID == "" {
+		addOrganisationsBackfillMarkerOptionDuplicates(&resolution, resolvedDocuments)
+	}
+	if organisationsBackfillMarkerRangeCollection(adapter.Collection) && config.DocumentID == "" {
+		addOrganisationsBackfillMarkerRangeDuplicates(&resolution, resolvedDocuments)
+	}
+	finalizeOrganisationsBackfillResolution(&resolution)
+	report.Resolution = &resolution
+	report.IndexContracts, err = inspectOrganisationsBackfillMarkerCanonicalIndexes(ctx, database.Collection(adapter.Collection), adapter.Collection)
+	return report, err
+}
+
+func resolveOrganisationsBackfillCanonicalOnly(
+	document bson.Raw,
+	resourceName string,
+	organisations map[primitive.ObjectID]bool,
+	projects map[primitive.ObjectID]primitive.ObjectID,
+) (outcome organisationsBackfillProjectResourceOutcome) {
+	outcome.documentID = organisationsBackfillDocumentID(document)
+	defer outcome.enrichConflicts()
+	projectID, projectState := organisationsBootstrapObjectID(document, "projectId")
+	switch projectState {
+	case organisationsBootstrapFieldValue:
+		outcome.projectPresent = true
+		outcome.resolvedProjectID = projectID
+	case organisationsBootstrapFieldEmpty:
+		outcome.projectMissing = true
+	default:
+		outcome.projectWrong = true
+		outcome.addConflict("invalid-project-id", "projectId must be a non-zero BSON ObjectID or null")
+	}
+	organisationID, organisationState := organisationsBackfillStringObjectIDField(document, "organisationId")
+	switch organisationState {
+	case organisationsBootstrapFieldValue:
+		outcome.canonicalID = organisationID
+		outcome.canonicalValid = true
+		if !organisations[organisationID] {
+			outcome.orphanOrganisation = true
+			outcome.addConflict("orphan-organisation", "canonical organisation does not exist")
+			return outcome
+		}
+	case organisationsBootstrapFieldWrong:
+		outcome.canonicalWrong = true
+		outcome.addConflict("invalid-canonical-organisation", "organisationId must contain an ObjectID hex string")
+		return outcome
+	default:
+		outcome.canonicalMissing = true
+		outcome.zeroCandidate = true
+		outcome.addConflict("missing-canonical-organisation", resourceName+" has no trustworthy ownership fallback")
+		return outcome
+	}
+	outcome.resolveMarkerProject(organisationID, projects)
+	return outcome
+}
+
+func addOrganisationsBackfillMarkerOptionDuplicates(report *organisationsBackfillResolution, documents []organisationsBackfillMarkerResolvedDocument) {
+	counts := make(map[string]int64)
+	for _, resolved := range documents {
+		if !resolved.outcome.canonicalValid || !resolved.outcome.projectResolved || len(resolved.outcome.conflicts) > 0 {
+			continue
+		}
+		value := resolved.document.Lookup("value")
+		if value.Type != bsontype.String || value.StringValue() == "" {
+			continue
+		}
+		key := resolved.outcome.canonicalID.Hex() + "\x00" + resolved.outcome.resolvedProjectID.Hex() + "\x00" + value.StringValue()
+		counts[key]++
+	}
+	for _, count := range counts {
+		if count < 2 {
+			continue
+		}
+		report.MultipleCandidates += count
+		report.Conflicts++
+		report.ConflictEntries = append(report.ConflictEntries, organisationsBackfillConflict{
+			Code:    "duplicate-option-value",
+			Message: "a redacted option value is duplicated within one organisation and project",
+		})
+	}
+}
+
+func organisationsBackfillMarkerOptionCollection(collection string) bool {
+	switch collection {
+	case "marker_options", "marker_tag_options", "marker_event_options", "marker_category_options":
+		return true
+	default:
+		return false
+	}
+}
+
+func organisationsBackfillMarkerRangeCollection(collection string) bool {
+	switch collection {
+	case "marker_option_ranges", "marker_tag_option_ranges", "marker_event_option_ranges":
+		return true
+	default:
+		return false
+	}
+}
+
+func organisationsBackfillValidMarkerRangeIdentity(document bson.Raw) bool {
+	value := document.Lookup("value")
+	deviceID := document.Lookup("deviceId")
+	start := document.Lookup("start")
+	if value.Type != bsontype.String || value.StringValue() == "" || deviceID.Type != bsontype.String || deviceID.StringValue() == "" {
+		return false
+	}
+	return start.Type == bsontype.Int32 || start.Type == bsontype.Int64 || start.Type == bsontype.Double
+}
+
+func addOrganisationsBackfillMarkerRangeDuplicates(report *organisationsBackfillResolution, documents []organisationsBackfillMarkerResolvedDocument) {
+	counts := make(map[string]int64)
+	for _, resolved := range documents {
+		if !resolved.outcome.canonicalValid || !resolved.outcome.projectResolved || len(resolved.outcome.conflicts) > 0 || !organisationsBackfillValidMarkerRangeIdentity(resolved.document) {
+			continue
+		}
+		value := resolved.document.Lookup("value").StringValue()
+		deviceID := resolved.document.Lookup("deviceId").StringValue()
+		start, ok := organisationsBackfillMarkerNumericIdentity(resolved.document.Lookup("start"))
+		if !ok {
+			continue
+		}
+		key := resolved.outcome.canonicalID.Hex() + "\x00" + resolved.outcome.resolvedProjectID.Hex() + "\x00" + value + "\x00" + deviceID + "\x00" + start
+		counts[key]++
+	}
+	for _, count := range counts {
+		if count < 2 {
+			continue
+		}
+		report.MultipleCandidates += count
+		report.Conflicts++
+		report.ConflictEntries = append(report.ConflictEntries, organisationsBackfillConflict{
+			Code:    "duplicate-range-identity",
+			Message: "a redacted range identity is duplicated within one organisation and project",
+		})
+	}
+}
+
+func organisationsBackfillMarkerNumericIdentity(value bson.RawValue) (string, bool) {
+	switch value.Type {
+	case bsontype.Int32:
+		return strconv.FormatInt(int64(value.Int32()), 10), true
+	case bsontype.Int64:
+		return strconv.FormatInt(value.Int64(), 10), true
+	case bsontype.Double:
+		return strconv.FormatFloat(value.Double(), 'g', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+func organisationsBackfillMarkerCanonicalIndexContracts(collection string) []organisationsBackfillIndexContract {
+	if organisationsBackfillMarkerOptionCollection(collection) {
+		contracts := []organisationsBackfillIndexContract{
+			organisationsBackfillNewIndexContract("project-value-unique", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "value", Value: int32(1)}}),
+			organisationsBackfillNewIndexContract("project-updated-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "updatedAt", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),
+		}
+		contracts[0].Unique = true
+		return contracts
+	}
+	contracts := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("project-text-range", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "text", Value: int32(1)}, {Key: "start", Value: int32(1)}, {Key: "end", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("project-value-device-start-unique", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "value", Value: int32(1)}, {Key: "deviceId", Value: int32(1)}, {Key: "start", Value: int32(1)}}),
+	}
+	if collection == "marker_option_ranges" {
+		contracts = append(contracts,
+			organisationsBackfillNewIndexContract("project-value-device-key-range", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "value", Value: int32(1)}, {Key: "deviceKey", Value: int32(1)}, {Key: "start", Value: int32(1)}, {Key: "end", Value: int32(1)}}),
+			organisationsBackfillNewIndexContract("project-range", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "start", Value: int32(1)}, {Key: "end", Value: int32(1)}}),
+		)
+	}
+	contracts[1].Unique = true
+	contracts[1].PartialFilterExpression = markerRangePartialFilter()
+	return contracts
+}
+
+func markerRangePartialFilter() bson.M {
+	return bson.M{
+		"organisationId": bson.M{"$type": "string"},
+		"projectId":      bson.M{"$type": "objectId"},
+		"value":          bson.M{"$type": "string"},
+		"deviceId":       bson.M{"$type": "string"},
+		"start":          bson.M{"$type": "number"},
+	}
+}
+
+func inspectOrganisationsBackfillMarkerCanonicalIndexes(
+	ctx context.Context,
+	collection *mongo.Collection,
+	collectionName string,
+) ([]organisationsBackfillIndexContract, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var indexes []struct {
+		Name                    string `bson:"name"`
+		Key                     bson.D `bson:"key"`
+		Unique                  bool   `bson:"unique"`
+		PartialFilterExpression bson.M `bson:"partialFilterExpression"`
+	}
+	if err := cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	contracts := organisationsBackfillMarkerCanonicalIndexContracts(collectionName)
+	for index := range contracts {
+		contracts[index].Status = "missing"
+		for _, candidate := range indexes {
+			status := organisationsBackfillOrderedIndexCoverage(candidate.Key, contracts[index].Keys)
+			if contracts[index].Unique != candidate.Unique || !reflect.DeepEqual(contracts[index].PartialFilterExpression, candidate.PartialFilterExpression) {
+				continue
+			}
+			if status == "exact" || (status == "prefix" && contracts[index].Status == "missing") {
+				contracts[index].Status = status
+				contracts[index].IndexName = candidate.Name
+			}
+			if status == "exact" {
+				break
+			}
+		}
+	}
+	if organisationsBackfillMarkerOptionCollection(collectionName) {
+		obsoleteKeys := []organisationsBackfillIndexKey{{Field: "organisationId", Direction: 1}, {Field: "value", Direction: 1}}
+		for _, candidate := range indexes {
+			if candidate.Unique && organisationsBackfillOrderedIndexCoverage(candidate.Key, obsoleteKeys) == "exact" {
+				obsolete := organisationsBackfillIndexContract{Name: "obsolete-organisation-value-unique", Keys: obsoleteKeys, Status: "obsolete", IndexName: candidate.Name}
+				contracts = append(contracts, obsolete)
+				break
+			}
+		}
+	}
+	return contracts, nil
+}
+
+func newOrganisationsBackfillResolution() organisationsBackfillResolution {
+	return organisationsBackfillResolution{ObservedFieldTypes: make(map[string]map[string]int64), ObservedShapes: make(map[string]int64)}
+}
+
+func addOrganisationsBackfillMissingScope(report *organisationsBackfillResolution, scopeID primitive.ObjectID, organisations map[primitive.ObjectID]bool) {
+	if scopeID.IsZero() || organisations[scopeID] {
+		return
+	}
+	report.OrphanOrganisations++
+	report.Conflicts++
+	report.ConflictEntries = append(report.ConflictEntries, organisationsBackfillConflict{
+		Code:                  "scope-organisation-not-found",
+		CanonicalOrganisation: scopeID.Hex(),
+		ResolvedOrganisations: []string{scopeID.Hex()},
+		Message:               "requested organisation does not exist",
+	})
+}
+
+func finalizeOrganisationsBackfillResolution(report *organisationsBackfillResolution) {
+	sort.Slice(report.ConflictEntries, func(left, right int) bool {
+		first := report.ConflictEntries[left]
+		second := report.ConflictEntries[right]
+		if first.DocumentID != second.DocumentID {
+			return first.DocumentID < second.DocumentID
+		}
+		return first.Code < second.Code
+	})
+	if len(report.ConflictEntries) > organisationsBackfillConflictLimit {
+		report.ConflictEntries = report.ConflictEntries[:organisationsBackfillConflictLimit]
+	}
+}

--- a/actions/organisations-backfill-markers_test.go
+++ b/actions/organisations-backfill-markers_test.go
@@ -1,0 +1,305 @@
+package actions
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResolveOrganisationsBackfillMarkerOwnership(t *testing.T) {
+	organisationA := primitive.NewObjectID()
+	organisationB := primitive.NewObjectID()
+	projectA := primitive.NewObjectID()
+	documentID := primitive.NewObjectID()
+	parents := organisationsBackfillMarkerParents{
+		byKey: map[string][]organisationsBackfillMarkerParent{
+			"media-a.mp4": {{organisationID: organisationA, projectID: projectA, valid: true}},
+			"media-b.mp4": {{organisationID: organisationB, projectID: organisationB, valid: true}},
+		},
+	}
+	devices := organisationsBackfillMarkerParents{byKey: map[string][]organisationsBackfillMarkerParent{
+		"device-a": {{organisationID: organisationA, projectID: projectA, valid: true}},
+		"duplicate-device": {
+			{organisationID: organisationA, projectID: projectA, valid: true},
+			{organisationID: organisationB, projectID: organisationB, valid: true},
+		},
+	}}
+	organisations := map[primitive.ObjectID]bool{organisationA: true, organisationB: true}
+	projects := map[primitive.ObjectID]primitive.ObjectID{projectA: organisationA}
+
+	tests := []struct {
+		name     string
+		document bson.D
+		check    func(*testing.T, organisationsBackfillProjectResourceOutcome)
+	}{
+		{
+			name: "canonical wins over conflicting linked parent",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "organisationId", Value: organisationA.Hex()},
+				{Key: "projectId", Value: projectA},
+				{Key: "mediaKeys", Value: bson.A{"media-b.mp4"}},
+			},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.canonicalValid || outcome.resolved || !outcome.projectResolved || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name: "mediaKeys resolve ownership before legacy mediaIds",
+			document: bson.D{
+				{Key: "_id", Value: documentID},
+				{Key: "mediaKeys", Value: bson.A{"media-a.mp4"}},
+				{Key: "mediaIds", Value: bson.A{"media-b.mp4"}},
+			},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || !outcome.projectResolved || outcome.resolvedProjectID != projectA || !outcome.proposedWrite || !outcome.proposedProjectWrite || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "legacy mediaIds resolve by recording key",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "mediaIds", Value: bson.A{"media-a.mp4"}}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || outcome.resolvedProjectID != projectA || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "empty mediaKeys fall back to legacy mediaIds",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "mediaKeys", Value: bson.A{}}, {Key: "mediaIds", Value: bson.A{"media-a.mp4"}}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || outcome.resolvedProjectID != projectA || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "unlinked marker resolves through one stored device",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "deviceId", Value: "device-a"}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.resolved || outcome.resolvedID != organisationA || !outcome.projectResolved || outcome.resolvedProjectID != projectA || len(outcome.conflicts) != 0 {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "unlinked marker rejects ambiguous stored devices",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "deviceId", Value: "duplicate-device"}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.multipleCandidates || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "ambiguous-device" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "orphan linked media conflicts",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "mediaKeys", Value: bson.A{"missing.mp4"}}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "orphan-parent" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "different linked owners are ambiguous",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "mediaKeys", Value: bson.A{"media-a.mp4", "media-b.mp4"}}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.multipleCandidates || outcome.zeroCandidate || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "ambiguous-parent" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+		{
+			name:     "non-unique media key is ambiguous even within one project",
+			document: bson.D{{Key: "_id", Value: documentID}, {Key: "mediaKeys", Value: bson.A{"duplicate.mp4"}}},
+			check: func(t *testing.T, outcome organisationsBackfillProjectResourceOutcome) {
+				if !outcome.multipleCandidates || len(outcome.conflicts) != 1 || outcome.conflicts[0].Code != "ambiguous-parent" {
+					t.Fatalf("outcome = %+v", outcome)
+				}
+			},
+		},
+	}
+	parents.byKey["duplicate.mp4"] = []organisationsBackfillMarkerParent{
+		{organisationID: organisationA, projectID: projectA, valid: true},
+		{organisationID: organisationA, projectID: projectA, valid: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outcome := resolveOrganisationsBackfillMarker(organisationsBackfillTestRaw(t, test.document), parents, devices, organisations, projects)
+			test.check(t, outcome)
+			for _, conflict := range outcome.conflicts {
+				if conflict.LegacyUser != "" || len(conflict.ResolvedOrganisations) > 2 {
+					t.Fatalf("conflict exposed media links: %+v", conflict)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkerParentResolutionUsesCanonicalScope(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	links := organisationsBackfillMarkerLinks{keys: []string{"recording.mp4"}, usesKeys: true}
+	parents := organisationsBackfillMarkerParents{byKey: map[string][]organisationsBackfillMarkerParent{
+		"recording.mp4": {
+			{organisationID: primitive.NewObjectID(), projectID: primitive.NewObjectID(), valid: true},
+			{organisationID: organisationID, projectID: projectID, valid: true},
+		},
+	}}
+	parent, code := organisationsBackfillResolveMarkerParent(links, parents, map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID}, organisationID, projectID, true)
+	if code != "" || parent.organisationID != organisationID || parent.projectID != projectID {
+		t.Fatalf("parent = %+v code=%q", parent, code)
+	}
+}
+
+func TestMarkerLookupKeysAddsCanonicalPrefix(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	got := organisationsBackfillMarkerLookupKeys([]string{"recording.mp4"}, organisationID)
+	want := []string{organisationID.Hex() + "/recording.mp4", "recording.mp4"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("lookup keys = %#v, want %#v", got, want)
+	}
+}
+
+func TestMarkerNumericIdentityNormalizesEquivalentIntegers(t *testing.T) {
+	values := []bson.RawValue{
+		organisationsBackfillTestRaw(t, bson.D{{Key: "start", Value: int32(42)}}).Lookup("start"),
+		organisationsBackfillTestRaw(t, bson.D{{Key: "start", Value: int64(42)}}).Lookup("start"),
+		organisationsBackfillTestRaw(t, bson.D{{Key: "start", Value: float64(42)}}).Lookup("start"),
+	}
+	for _, value := range values {
+		if got, ok := organisationsBackfillMarkerNumericIdentity(value); !ok || got != "42" {
+			t.Fatalf("numeric identity = %q ok=%v", got, ok)
+		}
+	}
+}
+
+func TestResolveOrganisationsBackfillCanonicalOnly(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	organisations := map[primitive.ObjectID]bool{organisationID: true}
+	projects := map[primitive.ObjectID]primitive.ObjectID{projectID: organisationID}
+
+	missing := resolveOrganisationsBackfillCanonicalOnly(
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "value", Value: "secret"}}),
+		"marker option",
+		organisations,
+		projects,
+	)
+	if !missing.canonicalMissing || !missing.zeroCandidate || missing.proposedWrite || len(missing.conflicts) != 1 || missing.conflicts[0].Code != "missing-canonical-organisation" {
+		t.Fatalf("missing outcome = %+v", missing)
+	}
+
+	resolved := resolveOrganisationsBackfillCanonicalOnly(
+		organisationsBackfillTestRaw(t, bson.D{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "organisationId", Value: organisationID.Hex()}, {Key: "projectId", Value: projectID}}),
+		"marker option",
+		organisations,
+		projects,
+	)
+	if !resolved.canonicalValid || !resolved.projectResolved || resolved.resolvedProjectID != projectID || len(resolved.conflicts) != 0 {
+		t.Fatalf("resolved outcome = %+v", resolved)
+	}
+}
+
+func TestMarkerDeviceFallbackRequiresCanonicalOwnership(t *testing.T) {
+	document := organisationsBackfillTestRaw(t, bson.D{
+		{Key: "key", Value: "device-a"},
+		{Key: "user_id", Value: primitive.NewObjectID().Hex()},
+	})
+	devices := organisationsBackfillMarkerParents{byKey: map[string][]organisationsBackfillMarkerParent{}}
+	organisationID, state := organisationsBackfillStringObjectIDField(document, "organisationId")
+	if state != organisationsBootstrapFieldEmpty || !organisationID.IsZero() {
+		t.Fatalf("canonical organisation = %s state=%v", organisationID.Hex(), state)
+	}
+	devices.byKey["device-a"] = []organisationsBackfillMarkerParent{{valid: false}}
+	marker := organisationsBackfillTestRaw(t, bson.D{{Key: "deviceId", Value: "device-a"}})
+	if _, code := organisationsBackfillResolveMarkerDevice(marker, devices, nil); code != "unresolved-device-ownership" {
+		t.Fatalf("device fallback code = %q, want unresolved-device-ownership", code)
+	}
+}
+
+func TestMarkerAdaptersAndIndexContracts(t *testing.T) {
+	registry := organisationsBackfillAdapters()
+	optionCollections := []string{"marker_options", "marker_tag_options", "marker_event_options", "marker_category_options"}
+	for _, collection := range optionCollections {
+		adapter := registry[collection]
+		if adapter.ResolverKind != organisationsBackfillResolverMarkerCanonical || adapter.OwnershipScope != "project-scoped" || len(adapter.LegacyCandidates) != 0 {
+			t.Fatalf("option adapter %q = %+v", collection, adapter)
+		}
+	}
+	rangeCollections := []string{"marker_option_ranges", "marker_tag_option_ranges", "marker_event_option_ranges"}
+	for _, collection := range rangeCollections {
+		adapter := registry[collection]
+		if adapter.ResolverKind != organisationsBackfillResolverMarkerCanonical || adapter.LifecycleStatus != "active" || adapter.OperationalUse != "derived-query-projection" {
+			t.Fatalf("range adapter %q = %+v", collection, adapter)
+		}
+	}
+
+	wantMarker := []organisationsBackfillIndexContract{
+		organisationsBackfillNewIndexContract("project-time-list", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "startTimestamp", Value: int32(-1)}, {Key: "_id", Value: int32(-1)}}),
+		organisationsBackfillNewIndexContract("project-device-name-time", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "deviceId", Value: int32(1)}, {Key: "name", Value: int32(1)}, {Key: "startTimestamp", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("project-media-keys", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "mediaKeys", Value: int32(1)}}),
+		organisationsBackfillNewIndexContract("project-device-time", bson.D{{Key: "organisationId", Value: int32(1)}, {Key: "projectId", Value: int32(1)}, {Key: "deviceId", Value: int32(1)}, {Key: "startTimestamp", Value: int32(1)}}),
+	}
+	if got := organisationsBackfillMarkerIndexContracts(); !reflect.DeepEqual(got, wantMarker) {
+		t.Fatalf("marker contracts = %#v, want %#v", got, wantMarker)
+	}
+	optionContracts := organisationsBackfillMarkerCanonicalIndexContracts("marker_options")
+	if len(optionContracts) != 2 || optionContracts[0].Name != "project-value-unique" || optionContracts[1].Name != "project-updated-list" {
+		t.Fatalf("option contracts = %#v", optionContracts)
+	}
+	rangeContracts := organisationsBackfillMarkerCanonicalIndexContracts("marker_option_ranges")
+	if len(rangeContracts) != 4 || rangeContracts[0].Keys[2].Field != "text" || rangeContracts[1].Name != "project-value-device-start-unique" || !rangeContracts[1].Unique || !reflect.DeepEqual(rangeContracts[1].PartialFilterExpression, markerRangePartialFilter()) || rangeContracts[2].Keys[2].Field != "value" || rangeContracts[2].Keys[3].Field != "deviceKey" {
+		t.Fatalf("range contracts = %#v", rangeContracts)
+	}
+}
+
+func TestMarkerOptionDuplicateReportRedactsValues(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	documents := []organisationsBackfillMarkerResolvedDocument{
+		{
+			document: organisationsBackfillTestRaw(t, bson.D{{Key: "value", Value: "sensitive-value"}}),
+			outcome:  organisationsBackfillProjectResourceOutcome{canonicalID: organisationID, canonicalValid: true, resolvedProjectID: organisationID, projectResolved: true},
+		},
+		{
+			document: organisationsBackfillTestRaw(t, bson.D{{Key: "value", Value: "sensitive-value"}}),
+			outcome:  organisationsBackfillProjectResourceOutcome{canonicalID: organisationID, canonicalValid: true, resolvedProjectID: organisationID, projectResolved: true},
+		},
+	}
+	report := newOrganisationsBackfillResolution()
+	addOrganisationsBackfillMarkerOptionDuplicates(&report, documents)
+	if report.Conflicts != 1 || report.MultipleCandidates != 2 || len(report.ConflictEntries) != 1 {
+		t.Fatalf("duplicate report = %+v", report)
+	}
+	conflict := report.ConflictEntries[0]
+	if conflict.DocumentID != "" || conflict.CanonicalOrganisation != "" || len(conflict.ResolvedOrganisations) != 0 || strings.Contains(conflict.Message, "sensitive-value") {
+		t.Fatalf("duplicate conflict exposed value or identity: %+v", conflict)
+	}
+}
+
+func TestMarkerRangeDuplicateReportRedactsIdentity(t *testing.T) {
+	organisationID := primitive.NewObjectID()
+	projectID := primitive.NewObjectID()
+	document := bson.D{{Key: "value", Value: "sensitive-value"}, {Key: "deviceId", Value: "sensitive-device"}, {Key: "start", Value: int64(42)}}
+	documents := []organisationsBackfillMarkerResolvedDocument{
+		{document: organisationsBackfillTestRaw(t, document), outcome: organisationsBackfillProjectResourceOutcome{canonicalID: organisationID, canonicalValid: true, resolvedProjectID: projectID, projectResolved: true}},
+		{document: organisationsBackfillTestRaw(t, document), outcome: organisationsBackfillProjectResourceOutcome{canonicalID: organisationID, canonicalValid: true, resolvedProjectID: projectID, projectResolved: true}},
+	}
+	report := newOrganisationsBackfillResolution()
+	addOrganisationsBackfillMarkerRangeDuplicates(&report, documents)
+	if report.Conflicts != 1 || report.MultipleCandidates != 2 || len(report.ConflictEntries) != 1 {
+		t.Fatalf("duplicate report = %+v", report)
+	}
+	conflict := report.ConflictEntries[0]
+	if strings.Contains(conflict.Message, "sensitive-value") || strings.Contains(conflict.Message, "sensitive-device") {
+		t.Fatalf("duplicate conflict exposed range identity: %+v", conflict)
+	}
+}

--- a/actions/organisations-backfill-sites.go
+++ b/actions/organisations-backfill-sites.go
@@ -27,6 +27,7 @@ type organisationsBackfillProjectResourceOutcome struct {
 	resolvedID           primitive.ObjectID
 	resolved             bool
 	zeroCandidate        bool
+	multipleCandidates   bool
 	orphanOrganisation   bool
 	proposedWrite        bool
 	conflicts            []organisationsBackfillConflict
@@ -303,6 +304,9 @@ func addOrganisationsBackfillSiteOutcome(report *organisationsBackfillResolution
 	if outcome.zeroCandidate {
 		report.ZeroCandidate++
 	}
+	if outcome.multipleCandidates {
+		report.MultipleCandidates++
+	}
 	if outcome.invalidLegacy {
 		report.InvalidLegacy++
 	}
@@ -342,7 +346,7 @@ func addOrganisationsBackfillSiteScopedInventory(report *organisationsBackfillCo
 	if outcome.projectWrong {
 		report.ProjectWrongType++
 	}
-	if outcome.legacyPresent {
+	if outcome.legacyPresent && legacyField != "" {
 		report.LegacyCandidateCount[legacyField]++
 	}
 }

--- a/actions/organisations-backfill-subscriptions.go
+++ b/actions/organisations-backfill-subscriptions.go
@@ -45,10 +45,12 @@ type organisationsBackfillConflict struct {
 }
 
 type organisationsBackfillIndexContract struct {
-	Name      string                          `json:"name"`
-	Keys      []organisationsBackfillIndexKey `json:"keys"`
-	Status    string                          `json:"status"`
-	IndexName string                          `json:"indexName,omitempty"`
+	Name                    string                          `json:"name"`
+	Keys                    []organisationsBackfillIndexKey `json:"keys"`
+	Unique                  bool                            `json:"unique,omitempty"`
+	PartialFilterExpression bson.M                          `json:"partialFilterExpression,omitempty"`
+	Status                  string                          `json:"status"`
+	IndexName               string                          `json:"indexName,omitempty"`
 }
 
 type organisationsBackfillIndexKey struct {

--- a/actions/organisations-backfill.go
+++ b/actions/organisations-backfill.go
@@ -18,19 +18,21 @@ import (
 )
 
 const (
-	organisationsBackfillAdapterVersion       = "v1"
-	organisationsBackfillExitOperational      = 1
-	organisationsBackfillExitData             = 2
-	organisationsBackfillExitUsage            = 64
-	organisationsBackfillResolverSubscription = "subscription-user"
-	organisationsBackfillResolverAlert        = "alert-tenant"
-	organisationsBackfillResolverSite         = "site-tenant"
-	organisationsBackfillResolverGroup        = "group-tenant"
-	organisationsBackfillResolverIO           = "io-actor"
-	organisationsBackfillResolverHeatmap      = "heatmap-tenant"
-	organisationsBackfillResolverLabel        = "label-owner"
-	organisationsBackfillResolverCounting     = "counting-source"
-	organisationsBackfillResolverVideowall    = "videowall-tenant"
+	organisationsBackfillAdapterVersion          = "v1"
+	organisationsBackfillExitOperational         = 1
+	organisationsBackfillExitData                = 2
+	organisationsBackfillExitUsage               = 64
+	organisationsBackfillResolverSubscription    = "subscription-user"
+	organisationsBackfillResolverAlert           = "alert-tenant"
+	organisationsBackfillResolverSite            = "site-tenant"
+	organisationsBackfillResolverGroup           = "group-tenant"
+	organisationsBackfillResolverIO              = "io-actor"
+	organisationsBackfillResolverHeatmap         = "heatmap-tenant"
+	organisationsBackfillResolverLabel           = "label-owner"
+	organisationsBackfillResolverCounting        = "counting-source"
+	organisationsBackfillResolverVideowall       = "videowall-tenant"
+	organisationsBackfillResolverMarker          = "marker-media-parent"
+	organisationsBackfillResolverMarkerCanonical = "marker-canonical-only"
 )
 
 type OrganisationsBackfillConfig struct {
@@ -265,6 +267,12 @@ func inspectOrganisationsBackfillAdapter(
 	if adapter.ResolverKind == organisationsBackfillResolverVideowall {
 		return inspectOrganisationsBackfillVideowalls(ctx, database, adapter, config, report)
 	}
+	if adapter.ResolverKind == organisationsBackfillResolverMarker {
+		return inspectOrganisationsBackfillMarkers(ctx, database, adapter, config, report)
+	}
+	if adapter.ResolverKind == organisationsBackfillResolverMarkerCanonical {
+		return inspectOrganisationsBackfillMarkerCanonical(ctx, database, adapter, config, report)
+	}
 	return report, nil
 }
 
@@ -465,6 +473,26 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumWriterVersions: []string{"hub-api:unreleased"},
 			MinimumReaderVersions: []string{"hub-api:unreleased"},
 		},
+		"markers": {
+			Collection:            "markers",
+			OwnershipScope:        "project-scoped",
+			TargetField:           "organisationId",
+			TargetBSONType:        "string",
+			ProjectField:          "projectId",
+			ProjectBSONType:       "objectId",
+			LegacyCandidates:      []string{"mediaKeys", "mediaIds", "deviceId"},
+			PreservedFields:       []string{"deviceId", "siteId", "groupId", "audit", "metadata"},
+			ResolverKind:          organisationsBackfillResolverMarker,
+			MinimumWriterVersions: []string{"hub-api:unreleased", "ingest:unreleased", "hub-workflows:unreleased"},
+			MinimumReaderVersions: []string{"hub-api:unreleased", "hub-pipeline-sequence:unreleased", "hub-cleanup:unreleased"},
+		},
+		"marker_options":             markerCanonicalAdapter("marker_options", false),
+		"marker_tag_options":         markerCanonicalAdapter("marker_tag_options", false),
+		"marker_event_options":       markerCanonicalAdapter("marker_event_options", false),
+		"marker_category_options":    markerCanonicalAdapter("marker_category_options", false),
+		"marker_option_ranges":       markerCanonicalAdapter("marker_option_ranges", true),
+		"marker_tag_option_ranges":   markerCanonicalAdapter("marker_tag_option_ranges", true),
+		"marker_event_option_ranges": markerCanonicalAdapter("marker_event_option_ranges", true),
 		"sites": {
 			Collection:            "sites",
 			OwnershipScope:        "project-scoped",
@@ -503,6 +531,27 @@ func organisationsBackfillAdapters() map[string]organisationsBackfillAdapter {
 			MinimumReaderVersions: []string{"hub-api:unreleased"},
 		},
 	}
+}
+
+func markerCanonicalAdapter(collection string, lifecycleDerived bool) organisationsBackfillAdapter {
+	adapter := organisationsBackfillAdapter{
+		Collection:            collection,
+		OwnershipScope:        "project-scoped",
+		TargetField:           "organisationId",
+		TargetBSONType:        "string",
+		ProjectField:          "projectId",
+		ProjectBSONType:       "objectId",
+		LegacyCandidates:      []string{},
+		PreservedFields:       []string{"value", "text"},
+		ResolverKind:          organisationsBackfillResolverMarkerCanonical,
+		MinimumWriterVersions: []string{"ingest:unreleased"},
+		MinimumReaderVersions: []string{"hub-api:unreleased", "hub-cleanup:unreleased"},
+	}
+	if lifecycleDerived {
+		adapter.LifecycleStatus = "active"
+		adapter.OperationalUse = "derived-query-projection"
+	}
+	return adapter
 }
 
 func organisationsBackfillBlockedAdapters() map[string]string {

--- a/actions/organisations-backfill_test.go
+++ b/actions/organisations-backfill_test.go
@@ -129,7 +129,12 @@ func TestSelectOrganisationsBackfillAdaptersAllIsDeterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectOrganisationsBackfillAdapters() error = %v", err)
 	}
-	want := []string{"alerts", "counting", "devices", "groups", "heatmap", "io", "labels", "sites", "subscriptions", "videowalls"}
+	want := []string{
+		"alerts", "counting", "devices", "groups", "heatmap", "io", "labels",
+		"marker_category_options", "marker_event_option_ranges", "marker_event_options",
+		"marker_option_ranges", "marker_options", "marker_tag_option_ranges",
+		"marker_tag_options", "markers", "sites", "subscriptions", "videowalls",
+	}
 	if len(adapters) != len(want) {
 		t.Fatalf("len(adapters) = %d, want %d", len(adapters), len(want))
 	}

--- a/indexes/migration-hub-marker-ownership-27-08-2026.txt
+++ b/indexes/migration-hub-marker-ownership-27-08-2026.txt
@@ -1,0 +1,44 @@
+markers
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, startTimestamp: -1, _id: -1 }, name: 'organisationId_1_projectId_1_startTimestamp_-1__id_-1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, deviceId: 1, name: 1, startTimestamp: 1 }, name: 'organisationId_1_projectId_1_deviceId_1_name_1_startTimestamp_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, mediaKeys: 1 }, name: 'organisationId_1_projectId_1_mediaKeys_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, deviceId: 1, startTimestamp: 1 }, name: 'organisationId_1_projectId_1_deviceId_1_startTimestamp_1' }
+]
+marker_options
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1 }, name: 'organisationId_1_projectId_1_value_1', unique: true },
+  { v: 2, key: { organisationId: 1, projectId: 1, updatedAt: -1, _id: -1 }, name: 'organisationId_1_projectId_1_updatedAt_-1__id_-1' }
+]
+marker_tag_options
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1 }, name: 'organisationId_1_projectId_1_value_1', unique: true },
+  { v: 2, key: { organisationId: 1, projectId: 1, updatedAt: -1, _id: -1 }, name: 'organisationId_1_projectId_1_updatedAt_-1__id_-1' }
+]
+marker_event_options
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1 }, name: 'organisationId_1_projectId_1_value_1', unique: true },
+  { v: 2, key: { organisationId: 1, projectId: 1, updatedAt: -1, _id: -1 }, name: 'organisationId_1_projectId_1_updatedAt_-1__id_-1' }
+]
+marker_category_options
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1 }, name: 'organisationId_1_projectId_1_value_1', unique: true },
+  { v: 2, key: { organisationId: 1, projectId: 1, updatedAt: -1, _id: -1 }, name: 'organisationId_1_projectId_1_updatedAt_-1__id_-1' }
+]
+marker_option_ranges
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, text: 1, start: 1, end: 1 }, name: 'organisationId_1_projectId_1_text_1_start_1_end_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1, deviceId: 1, start: 1 }, name: 'organisationId_1_projectId_1_value_1_deviceId_1_start_1', unique: true, partialFilterExpression: { organisationId: { $type: 'string' }, projectId: { $type: 'objectId' }, value: { $type: 'string' }, deviceId: { $type: 'string' }, start: { $type: 'number' } } },
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1, deviceKey: 1, start: 1, end: 1 }, name: 'organisationId_1_projectId_1_value_1_deviceKey_1_start_1_end_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, start: 1, end: 1 }, name: 'organisationId_1_projectId_1_start_1_end_1' }
+]
+marker_tag_option_ranges
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, text: 1, start: 1, end: 1 }, name: 'organisationId_1_projectId_1_text_1_start_1_end_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1, deviceId: 1, start: 1 }, name: 'organisationId_1_projectId_1_value_1_deviceId_1_start_1', unique: true, partialFilterExpression: { organisationId: { $type: 'string' }, projectId: { $type: 'objectId' }, value: { $type: 'string' }, deviceId: { $type: 'string' }, start: { $type: 'number' } } }
+]
+marker_event_option_ranges
+[
+  { v: 2, key: { organisationId: 1, projectId: 1, text: 1, start: 1, end: 1 }, name: 'organisationId_1_projectId_1_text_1_start_1_end_1' },
+  { v: 2, key: { organisationId: 1, projectId: 1, value: 1, deviceId: 1, start: 1 }, name: 'organisationId_1_projectId_1_value_1_deviceId_1_start_1', unique: true, partialFilterExpression: { organisationId: { $type: 'string' }, projectId: { $type: 'objectId' }, value: { $type: 'string' }, deviceId: { $type: 'string' }, start: { $type: 'number' } } }
+]


### PR DESCRIPTION
## Description

This PR adds auditing and validation support for marker-related organisation resources, with a strong focus on ownership resolution and index contract verification.

The change improves the reliability of organisation backfills by ensuring marker documents can be consistently mapped to valid organisation and project ownership through media and device relationships. It also introduces conflict detection for ambiguous, orphaned, malformed, or inconsistent ownership states, making migration and remediation workflows safer and easier to reason about.

Index validation was strengthened to compare full index contracts instead of only key order. CI checks now distinguish between indexes that share the same fields but differ in uniqueness or partial filter behaviour, preventing false positives and ensuring database guarantees are accurately enforced.

Additional coverage was added for marker ownership index definitions and index option matching, helping prevent regressions as marker resources evolve.

Overall, this improves data integrity, migration safety, and operational confidence for organisation-scoped marker resources.